### PR TITLE
fix: let the test fail if there are errors

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -37,6 +37,7 @@ class Test(unittest.TestCase):
         #    driver = webdriver.Chrome(options=options,service_log_path='/dev/null')
         self.driver = driver
         self.driver.get(url)
+        self.errors = []
 
     def tearDown(self):
         self.driver.close()
@@ -51,6 +52,7 @@ class Test(unittest.TestCase):
                 WebDriverWait(self.driver, 5).until(
                     EC.element_to_be_clickable((By.XPATH, "(//div[text()='" + i + "'])[last()]"))).click()
             except:
+                self.errors.append(i)
                 print("ERROR Cound not locate click element \t'" + i + "'")
         print()
         print("----------------------------------------------------------------------")
@@ -64,7 +66,9 @@ class Test(unittest.TestCase):
                 else:
                     print("Element\t-\t'" + i + "'\t-\tIs Not Visible")
             except:
+                self.errors.append(i)
                 print("ERROR Cound not locate Visibility element \t'" + i + "'")
+        self.assertEqual(len(self.errors),0)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## What does this PR do?
It makes sure the test actually fails by adding an assertion.

### Background
currently the there are errors, but the test passes since there are no assertions.
I added an errors array for a quick fix but would likely be better to create separate test cases to make the output more readable.

I assume as well that the `TestCaseClick` and  are not actually real elements and should be removed to make this pass again

### Proposal
I would propose the following to make this even better:

Use GitHub Actions and the Deploy Preview from Netlify to test against the deploy preview instead of production.

```
name: test against netlify deploy review

 on:
   pull_request:
     branches: [ master ]

 jobs:
    build:
      runs-on: ubuntu-latest
      steps:
        - name: Set up Python 3.7
          uses: actions/setup-python@v1
          with:
            python-version: 3.7
        - name: install dependencies
          run: |
            python -m pip install --upgrade pip
            pip install selenium urllib3
        - name: Set url
          run: echo '::set-env name=PR_REVIEW_APP_URL::https://deploy-preview-${{github.event.pull_request.number}}--wazimap-staging.netlify.app'
        - name: wait for netlify review app
          uses: nev7n/wait_for_response@v1
          with:
           url: 'https://deploy-preview-${{github.event.pull_request.number}}--wazimap-staging.netlify.app'
        - name: Test against PR
          run: python tests/main.py
```