### PR TITLE
feat: use env variable to define hostname

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -12,7 +12,7 @@ const mainUrl = 'https://staging.wazimap-ng.openup.org.za';
 const productionUrl = 'https://production.wazimap-ng.openup.org.za';
 let config = new SAConfig();
 
-let hostname = window.location.hostname;
+let hostname = process.env.HOSTNAME || window.location.hostname;
 const defaultProfile = 8;
 const defaultUrl = productionUrl;
 const defaultConfig = new SAConfig();


### PR DESCRIPTION
## Description

We want the hostname to be dynamic by default but on certain instances and especially on deploy previews with netlify we want to set the hostname explicitly
using parcel environment replacement option we can set an env var `HOSTNAME` to whatever we want and it will be used, otherwise it will use the default `window.location.hostname` this can and will be extended for the baseUrl as well

## Related Issue
_no issue created_

## How to test it locally
Create an `.env` file and add `HOSTNAME=yourhostname`
The app should now use the defined hostname to get the config from the baseUrl api. 

## Screenshots
_not applicable_

## Changelog

### Added
* added `.env` via parcel

### Updated
* the way hostname is looked up. 

### Removed

## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing