### PR TITLE
fix: Please ensure that capitalisation of profile categories and subcategories are honoured

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -3462,7 +3462,6 @@ label {
   font-size: 0.85em;
   font-weight: 500;
   text-decoration: none;
-  text-transform: capitalize;
   cursor: pointer;
 }
 
@@ -6379,7 +6378,6 @@ label {
   border-radius: 4px;
   background-color: #fff;
   box-shadow: 0 0 0 -1px rgba(0, 0, 0, 0.2), 0 1px 6px -2px rgba(0, 0, 0, 0.3);
-  z-index: 999;
 }
 
 .mag-geo__dropdown_wrap {


### PR DESCRIPTION
## Description

> Please ensure that capitalisation of profile categories and subcategories are honoured.

this will change the capitalization for the categories and subcategories

## Related Issue
https://trello.com/c/B9tiEZpI/420-please-ensure-that-capitalisation-of-profile-categories-and-subcategories-are-honoured

## How to test it locally
Go to "Data Mapper" panel; Select "Demographics" and look at "Region of Birth". 
It should now be "Region of Birth" instead of "Region Of Birth". 

## Screenshots
Before:
<img width="288" alt="Bildschirmfoto 2020-09-18 um 11 55 13" src="https://user-images.githubusercontent.com/688980/93584687-f09d9280-f9a5-11ea-96be-e233b20b9e90.png">

After:
<img width="279" alt="Bildschirmfoto 2020-09-18 um 11 55 05" src="https://user-images.githubusercontent.com/688980/93584705-f5624680-f9a5-11ea-9cc0-af14ec64c9c0.png">

## Changelog

### Added

### Updated
* capitalization in css

### Removed

## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing