### PR TITLE
Applying per indicator configuration to charts

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -20,6 +20,7 @@ export class Chart extends Observable {
         this.graphValueType = graphValueType;
         this.title = title;
         this.formattingConfig = formattingConfig;
+        this.chartConfiguration = this.getChartConfiguration(detail, title);
 
         tooltipClone = $(tooltipClass)[0].cloneNode(true);
         this.subCategoryNode = _subCategoryNode;
@@ -29,6 +30,16 @@ export class Chart extends Observable {
 
         this.handleChartFilter(detail, groups, title);
         this.addChart();
+    }
+
+    getChartConfiguration = (detail, title) => {
+        let chartConfiguration = [{"label": "Value", "formatting": ",.3d"}];
+
+        if (typeof detail.indicators[title].chart_configuration !== 'undefined') {
+            chartConfiguration = detail.indicators[title].chart_configuration;
+        }
+
+        return chartConfiguration;
     }
 
     addChart = () => {
@@ -78,7 +89,7 @@ export class Chart extends Observable {
             })
         } else {
             chart.xAxisFormatter((d) => {
-                return numFmtAlt(d);
+                return d3format(this.chartConfiguration[0].formatting)(d);
             })
         }
     }
@@ -92,8 +103,7 @@ export class Chart extends Observable {
                 label: subindicator.keys,
                 value: val,
                 valueText: this.graphValueType === graphValueTypes[0] ?
-                    formatNumericalValue(val / 100, this.formattingConfig, 'percentage') :
-                    formatNumericalValue(val, this.formattingConfig, 'absolute_value')
+                    formatNumericalValue(val / 100, this.formattingConfig, 'percentage') : d3format(this.chartConfiguration[0].formatting)(val)
             })
         }
 

--- a/src/js/setup/map.js
+++ b/src/js/setup/map.js
@@ -11,7 +11,7 @@ export function configureMapEvents(controller, objs = {mapcontrol: null}) {
     controller.on('profile.loaded', payload => {
         const geography = payload.payload.profile.geography;
         const geometries = payload.payload.geometries;
-        mapcontrol.overlayBoundaries(geography, geometries)
+        mapcontrol.overlayBoundaries(geography, geometries);
     });
 
     controller.on('redraw', payload => {


### PR DESCRIPTION
## Description
Using `chart_configuration` key while creating the charts so the numerical values of each chart can be configured separately using the admin panel.

Assigned a default configuration so if the `chart_configuration` key is not available, the numerical values would be formatted using the default configuration. Here is the default if the key is not available :
`[{"label": "Value", "type": "absolute_value"}]`

## Related Issue
https://trello.com/c/sduyMyPI/441-bug-x-axis-not-being-correctly-calculated-and-rendered


## How to test it locally
* If the `chart_configuration` key is available through all_details API, update it from the admin panel.
* If the `chart_configuration` key is not available through all_details API, update the hardcoded default array.
* For most profiles the available numerical format types are :
     * percentage
     * absolute_value
     * decimal
* From the Rich Data panel, using the settings dropdown on top right side of any chart click 'Value'
* Check if the numbers are formatted correctly.


## Screenshots
![image](https://user-images.githubusercontent.com/53019884/94199478-8dd65a80-fec1-11ea-802d-34fea3bf2a20.png)
![image](https://user-images.githubusercontent.com/53019884/94199629-caa25180-fec1-11ea-8ca5-d70a8b2dab41.png)
![image](https://user-images.githubusercontent.com/53019884/94199736-edcd0100-fec1-11ea-8eae-f3a76ad608f3.png)


## Changelog

### Added
* `getChartConfiguration()` function in chart.js. This function returns 'chart_configuration' key if available. Otherwise returns a default configuration

### Updated
* `getValuesFromSubindicators()` function in chart.js so formatting method is taken from the `chart_configuration` instead of a hardcoded value

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
