### PR TITLE
increasing the size of markers on mouse over

### DIFF
--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -154,8 +154,11 @@ export class PointData extends Observable {
                 this.showMarkerPopup(e, point, true);
                 stopPropagation(e); //prevent map click event
             }).on('mouseover', (e) => {
+                e.target.setRadius(self.markerRadius() * 2);
+                e.target.bringToFront();
                 this.showMarkerPopup(e, point);
-            }).on('mouseout', () => {
+            }).on('mouseout', (e) => {
+                e.target.setRadius(self.markerRadius());
                 this.hideMarkerPopup();
             });
             layer.addLayer(marker);


### PR DESCRIPTION
## Description
When a user hovers over a marker, the marker's radius is doubled

## Related Issue
https://trello.com/c/s0MWhWeE/423-level-of-precision-required-to-click-a-point-is-really-tricky-to-click-is-there-a-better-solution


## How to test it locally
* Select an option from the Point Mapper
* Hover over a marker 


## Screenshots
![image](https://user-images.githubusercontent.com/53019884/94440870-c8364500-01aa-11eb-8046-2c7fd586d40f.png)


## Changelog

### Added

### Updated
* Updated the mouseover and mouseout events of markers in `point_data.js` 

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
