### PR TITLE
fix: Charting Indicators using custom configuration from the Admin interface

### DIFF
--- a/src/js/dataobjects.js
+++ b/src/js/dataobjects.js
@@ -37,7 +37,7 @@ export class Profile {
                 subcategory = self._fixSubcategory(subcategory)
                 Object.values(subcategory.indicators).forEach(indicator => {
                     self._fixMetadata(indicator)
-                    indicator.chartConfiguration = defaultIfMissing(indicator.chartConfiguration, defaultValues.chartConfiguration)
+                    indicator.chartConfiguration = defaultIfMissing(indicator.chart_configuration, defaultValues.chartConfiguration)
 
                     indicator.subindicators = Object
                         .entries(indicator.subindicators)


### PR DESCRIPTION
## Description
this slipped through the cracks. the api returns snake_case and not camelCase it should be `chart_configuration`
this cries for more API related testing :)

## Related Issue


## How to test it locally


## Screenshots


## Changelog

### Added

### Updated
* changed the BE API response usage from `chartConfiguration` to the actual `chart_configuration` key

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
