### PR TITLE
Reversing the order in which subindicators are added to the graph.

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -16,7 +16,7 @@ export class Chart extends Observable {
         //we need the subindicators and groups too even though we have detail parameter. they are used for the default chart data
         super();
 
-        this.subindicators = subindicators;
+        this.subindicators = subindicators.reverse();
         this.graphValueType = graphValueType;
         this.title = title;
         this.formattingConfig = formattingConfig;


### PR DESCRIPTION

## Description

The bar chart adds bars from the bottom up whereas it is more natural to read values from the top down.

## Related Issue
None

## How to test it locally
Note the order of subindicators that are sent from the API. Then compare with the order in the bar chart. The order in the bar chart should match that sent from the API starting at the top of the chart.

## Screenshots


## Changelog

### Added

### Updated
chart.js - reversed the subindicator array

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
