### PR TITLE
fixed highlighted areas offset issue

### DIFF
--- a/src/js/setup/map.js
+++ b/src/js/setup/map.js
@@ -11,13 +11,17 @@ export function configureMapEvents(controller, objs = {mapcontrol: null}) {
     controller.on('profile.loaded', payload => {
         const geography = payload.payload.profile.geography;
         const geometries = payload.payload.geometries;
-        mapcontrol.overlayBoundaries(geography, geometries);
+        setTimeout(() => {
+            mapcontrol.overlayBoundaries(geography, geometries);
+        }, 0)
     });
 
     controller.on('redraw', payload => {
         const geography = payload.payload.profile.geography;
         const geometries = payload.payload.geometries;
-        mapcontrol.overlayBoundaries(geography, geometries)
+        setTimeout(() => {
+            mapcontrol.overlayBoundaries(geography, geometries);
+        }, 0)
     });
 
 


### PR DESCRIPTION
## Description
Map highlighted areas were sometimes offset to the base map. This is temporarily fixed by adding setTimeout encapsulation with 0 delay to `mapcontrol.overlayBoundaries()` function

## Related Issue
https://trello.com/c/T78OApmY/488-bug-map-highlight-areas-are-sometimes-offset-to-the-base-map

## How to test it locally
Test if a problem like the screenshot below occurs

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/94857522-49573b80-043a-11eb-92e7-f8093523c7ab.png)


## Changelog

### Added

### Updated
* `setup > map.js` to add `setTimeout` encapsulation

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
