### PR TITLE
rendering points above geography names

### DIFF
--- a/src/js/map/maps.js
+++ b/src/js/map/maps.js
@@ -97,12 +97,26 @@ export class MapControl extends Observable {
             L.tileLayer(layer.url, {pane: pane}).addTo(map).addTo(map);
         })
 
+        this.createCustomMarkersPane(map);
+
         L.control.zoom({position: this.zoomPosition}).addTo(map);
         this.boundaryLayers = L.layerGroup().addTo(map);
         this.configureForwarder(map);
 
         return map;
     };
+
+    createCustomMarkersPane(map) {
+        /**
+         * z-index for markerPane is 600
+         * z-index for tooltipPane is 650
+         * z-index for popupPane is 700
+         * z-index for custom pane must be between tooltipPane and popupPane
+         * */
+
+        map.createPane('customMarkersPane');
+        map.getPane('customMarkersPane').style.zIndex = 680;
+    }
 
     configureForwarder(map) {
         this.myEventForwarder = new L.eventForwarder({

--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -148,7 +148,7 @@ export class PointData extends Observable {
                 fill: true,
                 fillColor: col,
                 fillOpacity: 1,
-                pane: 'markerPane'
+                pane: 'customMarkersPane'
             })
             marker.on('click', (e) => {
                 this.showMarkerPopup(e, point, true);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6870,9 +6870,10 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-svelte-dev-tools@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/svelte-dev-tools/-/svelte-dev-tools-0.0.1.tgz#91ad146b8001de9748aec592be8e644a28214b04"
+svelte-dev-tools@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/svelte-dev-tools/-/svelte-dev-tools-0.0.2.tgz#794b0c5cad5a9d94774150713892f8d6765f2be5"
+  integrity sha512-z/hevP/jQ7r+zvDGYGJiI+CpmiOMdWGYGUziTefcMoqHvzjZKfGkvaty7unrYpl+BS/Bijg960K5YHmLPaoHpw==
 
 svgo@^1.0.0, svgo@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
## Description
Creating a custom pane on the map to render the markers in, so they are above the geography names but below the popups.

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/105

## How to test it locally
* Run the project
* Select a category from the point mapper
* Check if the point markers are created above the geography names but below the popups

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/96368518-de597480-115c-11eb-9ff7-ce99d4841638.png)
![image](https://user-images.githubusercontent.com/53019884/96368539-f0d3ae00-115c-11eb-8042-07d645f45de9.png)


## Changelog

### Added

### Updated
* Added createCustomMarkersPane() function to maps.js. This function creates a custom pane that is above the geography names but below the popups.
* Updated point_data.js so the markers are created into the newly added custom pane.

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
