### PR TITLE
disabling choropleth at the lowest geography level

### DIFF
--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -68,14 +68,6 @@ export default class Analytics {
     }
 
     logEvent(profile, category, action, label = '', value = 0) {
-        console.log(`
-profile: ${profile}
-category: ${category}
-action: ${action}
-label: ${label}
-value: ${value}
-        `)
-
         this.gtag('event', action, {
             'event_category': category,
             'event_action': action,

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -184,7 +184,6 @@ export default class Controller extends Observable {
             // Shouldn't be here
             setTimeout(() => {
                 if (callRegisterFunction) {
-                    console.log("initialising webflow")
                     Webflow.require('ix2').init()
                     // self.registerWebflowEvents();
                 }

--- a/src/js/elements/menu.js
+++ b/src/js/elements/menu.js
@@ -7,7 +7,7 @@ const categoryTemplate = $(".data-category")[0].cloneNode(true);
 const subCategoryTemplate = $(".data-category__h2", categoryTemplate)[0].cloneNode(true);
 const indicatorTemplate = $(".data-category__h2_content", subCategoryTemplate)[0].cloneNode(true);
 const indicatorItemTemplate = $(".data-category__h4", subCategoryTemplate)[0].cloneNode(true);
-const noDataWrapperClsName = 'data-menu__no-data';
+const noDataWrapperClsName = 'data-mapper-content__no-data';
 const loadingClsName = 'data-mapper-content__loading';
 
 function subindicatorsInCategory(category) {
@@ -121,6 +121,7 @@ export function loadMenu(data, subindicatorCallback) {
         $(newCategory).removeClass(hideondeployClsName);
         $(".data-category__h1_title div", newCategory).text(category);
         $('.' + loadingClsName).addClass('hidden');
+        $('.' + noDataWrapperClsName).addClass('hidden');
         parentContainer.append(newCategory);
         var h2Wrapper = $(".data-category__h1_wrapper", newCategory);
         $(".data-category__h2", h2Wrapper).remove();
@@ -165,4 +166,10 @@ export function loadMenu(data, subindicatorCallback) {
             $('.' + noDataWrapperClsName).removeClass(hideondeployClsName);
         }
     }
+}
+
+export function showNoData(){
+    $(parentContainer).empty();
+    $('.' + loadingClsName).addClass('hidden');
+    $('.' + noDataWrapperClsName).removeClass('hidden');
 }

--- a/src/js/setup/dataexplorer.js
+++ b/src/js/setup/dataexplorer.js
@@ -1,7 +1,14 @@
-import {loadMenu} from '../elements/menu';
+import {loadMenu, showNoData} from '../elements/menu';
 
 export function configureDataExplorerEvents(controller) {
-    controller.on('profile.loaded', payload => loadMenu(payload.payload.profile.profileData, payload => {
-        controller.onSubIndicatorClick(payload)
-    }))
+    controller.on('profile.loaded', payload => {
+        if ($.isEmptyObject(payload.payload.geometries.children)) {
+            //no children -- show no-data chip
+            showNoData();
+        } else {
+            loadMenu(payload.payload.profile.profileData, payload => {
+                controller.onSubIndicatorClick(payload)
+            })
+        }
+    })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6870,9 +6870,10 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-svelte-dev-tools@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/svelte-dev-tools/-/svelte-dev-tools-0.0.1.tgz#91ad146b8001de9748aec592be8e644a28214b04"
+svelte-dev-tools@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/svelte-dev-tools/-/svelte-dev-tools-0.0.2.tgz#794b0c5cad5a9d94774150713892f8d6765f2be5"
+  integrity sha512-z/hevP/jQ7r+zvDGYGJiI+CpmiOMdWGYGUziTefcMoqHvzjZKfGkvaty7unrYpl+BS/Bijg960K5YHmLPaoHpw==
 
 svgo@^1.0.0, svgo@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
## Description
If a geography doesn't have any children geographies, we show no-data chip in data mapper instead of indicators & subindicators

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/106

## How to test it locally
* Start the project
* Navigate to a geography that has no children, for example `/#geo:364002`
* Check if no-data chip is shown as it should

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/96453783-a49f7100-1223-11eb-827a-77a81600ed43.png)


## Changelog

### Added

### Updated
* Updated `setup > dataexplorer.js` to trigger `showNoData()` function when there are no children geographies.
* Added showNoData() function to elements > menu.js. 

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
