### PR TITLE
Removing sources section in the facility overview

### DIFF
--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -62,6 +62,7 @@ export class Profile_header extends Observable {
 
     addFacilities = () => {
         $('.location-facility', facilityWrapper).remove();
+        $('.location__facilities_sources', facilityWrapper).remove();
         let self = this;
 
         let categoryArr = [];

--- a/yarn.lock
+++ b/yarn.lock
@@ -6870,9 +6870,10 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-svelte-dev-tools@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/svelte-dev-tools/-/svelte-dev-tools-0.0.1.tgz#91ad146b8001de9748aec592be8e644a28214b04"
+svelte-dev-tools@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/svelte-dev-tools/-/svelte-dev-tools-0.0.2.tgz#794b0c5cad5a9d94774150713892f8d6765f2be5"
+  integrity sha512-z/hevP/jQ7r+zvDGYGJiI+CpmiOMdWGYGUziTefcMoqHvzjZKfGkvaty7unrYpl+BS/Bijg960K5YHmLPaoHpw==
 
 svgo@^1.0.0, svgo@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
## Description
On the rich data panel in facility overview we used to have `sources` section. That section is removed with this PR

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/107

## How to test it locally
* Run the project
* Test if the facilities overview has `sources` section

## Screenshots
* Before 
![image](https://user-images.githubusercontent.com/53019884/96449248-3ce62780-121d-11eb-8242-008856caaf2f.png)

* After
![image](https://user-images.githubusercontent.com/53019884/96448932-c517fd00-121c-11eb-9363-d3ef20c94783.png)


## Changelog

### Added

### Updated
* Updated profile > profile_header.js to remove the sources section

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
