### PR TITLE
Chart last number value not showing issue

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -64,7 +64,7 @@ export class Chart extends Observable {
             .barPadding(6)
             .margin({
                 top: 15,
-                right: 0,
+                right: 5,
                 bottom: 15,
                 left: 120,
             })

--- a/yarn.lock
+++ b/yarn.lock
@@ -6870,9 +6870,10 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
-svelte-dev-tools@^0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/svelte-dev-tools/-/svelte-dev-tools-0.0.1.tgz#91ad146b8001de9748aec592be8e644a28214b04"
+svelte-dev-tools@^0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/svelte-dev-tools/-/svelte-dev-tools-0.0.2.tgz#794b0c5cad5a9d94774150713892f8d6765f2be5"
+  integrity sha512-z/hevP/jQ7r+zvDGYGJiI+CpmiOMdWGYGUziTefcMoqHvzjZKfGkvaty7unrYpl+BS/Bijg960K5YHmLPaoHpw==
 
 svgo@^1.0.0, svgo@^1.3.2:
   version "1.3.2"


### PR DESCRIPTION
## Description
Adding a small right margin to the charts, using the `margin` property we implemented before, fixes this issue

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/112

## How to test it locally
* Run the project
* Hardcode the hostname as `gcro.openup.org.za`
* Check if the numbers are visible

## Screenshots
Before : 
![image](https://user-images.githubusercontent.com/53019884/97005797-9dd86d00-1547-11eb-89c9-2dae7629359b.png)

After : 
![image](https://user-images.githubusercontent.com/53019884/97005837-aa5cc580-1547-11eb-8193-64ae9651d1b1.png)


## Changelog

### Added

### Updated
* Updated `profile > chart.js` to modify the margin property

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
