### PR TITLE
Removing embed from chart options

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -105,9 +105,15 @@ export class Chart extends Observable {
     }
 
     setChartMenu = (barChart) => {
-        const self = this;
         const containerParent = $(this.container).closest('.profile-indicator');
 
+        this.setSaveImageButton(containerParent, barChart);
+        this.setEmbedButton(containerParent);
+        this.setDisplayTypeButtons(containerParent);
+        this.setExportButtons(containerParent, barChart);
+    }
+
+    setSaveImageButton = (containerParent, barChart) => {
         //save as image button
         const saveImgButton = $(containerParent).find('.hover-menu__content a.hover-menu__content_item:nth-child(1)');
 
@@ -116,16 +122,29 @@ export class Chart extends Observable {
             barChart.saveAsPng(this.container);
             this.triggerEvent('profile.chart.saveAsPng', this);
         })
+    }
 
+    setEmbedButton = (containerParent) => {
+        //remove embed option
+        const embedButton = $(containerParent).find('.hover-menu__content a.hover-menu__content_item:nth-child(2)');
+        $(embedButton).remove();
+    }
+
+    setDisplayTypeButtons = (containerParent) => {
         //show as percentage / value
         //todo:don't use index, specific class names should be used here when the classes are ready
+        let self = this;
+
         $(containerParent).find('.hover-menu__content_list a').each(function (index) {
             $(this).off('click');
             $(this).on('click', () => {
                 self.selectedGraphValueTypeChanged(containerParent, index);
             })
         });
+    }
 
+    setExportButtons = (containerParent, barChart) => {
+        let self = this;
         $(containerParent).find('.hover-menu__content_list--last a').each(function (index) {
             $(this).off('click');
             $(this).on('click', () => {


### PR DESCRIPTION
## Description
Removed `embed` from chart options

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/113

## How to test it locally
* Run the project
* Confirm that charts do not have `embed` option anymore

## Screenshots
* Before
![image](https://user-images.githubusercontent.com/53019884/97308645-2752ac80-1872-11eb-9496-4c2b121964cc.png)
* After
![image](https://user-images.githubusercontent.com/53019884/97308657-2b7eca00-1872-11eb-8b11-c20f2c05c23d.png)


## Changelog

### Added

### Updated
* profile > chart.js to remove the `embed` option. While I'm at it, I refactored the function `setChartMenu()` quickly because it looked overcomplex

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
