### PR TITLE
chore: remove embed button from chart menu

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2379,12 +2379,6 @@
                           <div>Save as image</div>
                         </div>
                       </a>
-                      <a href="#" class="hover-menu__content_item w-inline-block">
-                        <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c39771e9e09f11_code-24px.svg" alt=""></div>
-                        <div class="content__item_title">
-                          <div>Embed chart</div>
-                        </div>
-                      </a>
                       <div class="hover-menu__content_item--no-link">
                         <div class="icon--small">
                           <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">


### PR DESCRIPTION
## Description
remove the embed option from the chart menu for now since it did not work as expected


## Related Issue
#113 

## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
