### PR TITLE
chart filtering bug is fixed

### DIFF
--- a/src/js/profile/subindicator_filter.js
+++ b/src/js/profile/subindicator_filter.js
@@ -136,8 +136,12 @@ export class SubindicatorFilter extends Observable {
     }
 
     getFilteredData = (selectedFilter, selectedGroup, title) => {
-        this.triggerEvent('point_tray.subindicator_filter.filter', {indicator: title, group: selectedGroup, subindicator: selectedFilter});
-                          
+        this.triggerEvent('point_tray.subindicator_filter.filter', {
+            indicator: title,
+            group: selectedGroup,
+            subindicator: selectedFilter
+        });
+
         let chartData = [];
 
         if (selectedFilter !== allValues) {
@@ -155,7 +159,9 @@ export class SubindicatorFilter extends Observable {
             }
         } else {
             for (const [indicatorTitle, subindicator] of Object.entries(this.indicators)) {
-                chartData = subindicator.subindicators;
+                if (indicatorTitle === title) {
+                    chartData = subindicator.subindicators;
+                }
             }
         }
 


### PR DESCRIPTION
## Description
Fixed the issue that was causing the charts displaying different results for the same grouping

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/122

## How to test it locally
* Navigate to `beta.youthexplorer.org.za`
* In the rich data view, scroll to population by age group
* Select race in the group dropdown
* Select Black African from the subindicator dropdown
* Select All Values from the subindicator dropdown
* Check if barchart still displaying the correct data
* _Note : This change affects choropleth filtering too, so it should be tested also_


## Screenshots
![image](https://user-images.githubusercontent.com/53019884/98815718-a16d5e80-2438-11eb-8e8f-fb9686beea40.png)
![image](https://user-images.githubusercontent.com/53019884/98815737-a7633f80-2438-11eb-96e3-d7317c23f01c.png)

## Changelog

### Added

### Updated
* `getFilteredData()` function is updated to make sure the subindicators are set correctly after filtering

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
