### PR TITLE
removing no facilities chip from rich data panel

### DIFF
--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -128,7 +128,7 @@ export class Profile_header extends Observable {
             $('.location__facilities_categories-value strong').text(categoryArr.length);
             $('.location__facilities_facilities-value strong').text(totalCount);
         } else {
-            $('.location__facilities_no-data').removeClass('hidden');
+            $('.location__facilities').addClass('hidden');
         }
 
         $('.location__facilities_loading').addClass('hidden');


### PR DESCRIPTION
## Description
Removed no-facilities chip that we show in case there are no facilities

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/124

## How to test it locally
* Navigate to an instance that has no facilities, like `gcro.openup.org.za` by hardcoding `hostname` parameter in `index.js`
* Confirm that there are no no-facilities chip

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/98819149-90731c00-243d-11eb-8c83-dd4989785fb6.png)


## Changelog

### Added

### Updated
* Replaced the code that showed no-facilities chip in `addFacilities()` function with the code that hides `.location__facilities`

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
