### PR TITLE
Fixed bug where the chart dropdowns reverse the subindicator order

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -16,7 +16,7 @@ export class Chart extends Observable {
         //we need the subindicators and groups too even though we have detail parameter. they are used for the default chart data
         super();
 
-        this.subindicators = subindicators.reverse();
+        this.subindicators = subindicators;
         this.graphValueType = graphValueType;
         this.title = title;
         this.formattingConfig = formattingConfig;
@@ -46,7 +46,7 @@ export class Chart extends Observable {
         this.setChartOptions(barChart);
 
         this.setChartMenu(barChart);
-        d3select(this.container).call(barChart.data(data));
+        d3select(this.container).call(barChart.data(data).reverse(true));
     }
 
     setChartOptions = (chart) => {

--- a/src/js/reusable-charts/horizontal-bar-chart.js
+++ b/src/js/reusable-charts/horizontal-bar-chart.js
@@ -26,6 +26,7 @@ export function horizontalBarChart() {
             bottom: 15,
             left: 100,
         },
+        reverse: false,
         tooltipFormatter: (d) => {
             return `${d.data.label}: ${d.data.value}`;
         },
@@ -54,6 +55,7 @@ export function horizontalBarChart() {
     let barPadding = initialConfiguration.barPadding;
     let xLabel = initialConfiguration.xLabel;
     let barLabelLength = initialConfiguration.barLabelLength;
+    let reverse = initialConfiguration.reverse;
 
     function chart(selection) {
         selection.each(() => {
@@ -412,6 +414,15 @@ export function horizontalBarChart() {
 
             return chart;
         }
+    };
+
+    chart.reverse = function (value) {
+        if (!arguments.length) return reverse;
+
+        reverse = value;
+        if (value)
+            data = data.reverse()
+        return chart;
     };
 
     chart.data = function (value) {


### PR DESCRIPTION
## Description

Fixed sub-indicators changing order when filtering 

## Related Issue

https://trello.com/c/1scTsuMh/520-chart-subindicators-change-order-when-filtering-ye-and-bps

## How to test it locally
1. Open rich data view
2. Select a group and subindicator from a chart dropdown
3. Now select All values in the subindicator dropdown
4. The order should remain consistent

## Screenshots


## Changelog

### Added
Added a `reverse` method to the chart object to indicate the order in which bars should be displayed

### Updated

### Removed

## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x ]  📰 good title
- [x ]  📝good description
- [ x]  🔖 issue linked
- [x ]  📖 changelog filled out

### Commits

- [x ]  commits are clean
- [x ]  commit messages are clean

### Code Quality

- [x ]  🚧 no commented out code
- [x ]  🖨 no unnecessary logging
- [x ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
