### PR TITLE
Feature/missing chart config keys added

### DIFF
--- a/__tests__/dataobjects.test.js
+++ b/__tests__/dataobjects.test.js
@@ -1,0 +1,46 @@
+import {IndicatorHelper} from '../src/js/dataobjects';
+import {defaultValues} from '../src/js/defaultValues';
+
+describe('Test IndicatorHelper static methods', () => {
+    test('missing data is correctly fixed', () => {
+        let indicator = {}
+        indicator = IndicatorHelper.fixMetadata(indicator)
+
+        expect(indicator.metadata.source).toBe('')
+        expect(indicator.metadata.description).toBe('')
+        expect(indicator.metadata.licence.name).toBe('')
+        expect(indicator.metadata.licence.url).toBe('')
+    })
+
+    test('missing configuration values inserted', () => {
+        const original = defaultValues.chartConfiguration
+        defaultValues.chartConfiguration = {test1: 1, test2: 2}
+
+        let indicator = {test1: 3}
+
+        indicator = IndicatorHelper.addDefaultConfiguration(indicator)
+        expect(indicator.chartConfiguration).toBeDefined()
+        expect(indicator.chartConfiguration.test1).toBe(1)
+        expect(indicator.chartConfiguration.test2).toBe(2)
+
+        defaultValues.chartConfiguration = original;
+    })
+
+    test('fix indicator applies all manipulations to indicator', () => {
+        const original = defaultValues.chartConfiguration
+        defaultValues.chartConfiguration = {test1: 1, test2: 2}
+        
+        let indicator = {}
+        indicator = IndicatorHelper.fixIndicator(indicator)
+
+        expect(indicator.metadata.source).toBe('')
+        expect(indicator.metadata.description).toBe('')
+        expect(indicator.metadata.licence.name).toBe('')
+        expect(indicator.metadata.licence.url).toBe('')
+        expect(indicator.chartConfiguration).toBeDefined()
+        expect(indicator.chartConfiguration.test1).toBe(1)
+        expect(indicator.chartConfiguration.test2).toBe(2)
+
+        defaultValues.chartConfiguration = original;
+    })
+})

--- a/__tests__/utils.test.js
+++ b/__tests__/utils.test.js
@@ -1,4 +1,4 @@
-import {validation, defaultIfMissing} from '../src/js/utils';
+import {validation, defaultIfMissing, fillMissingKeys} from '../src/js/utils';
 
 describe('Testing validation functions', () => {
 
@@ -43,5 +43,44 @@ describe('Testing defaults', () => {
     expect(defaultIfMissing({}, 5)).toBe(5);
     expect(defaultIfMissing('', 5)).toBe(5);
   }) 
+})
+
+describe('Test missing keys', () => {
+  test('check that missing keys are filled from defaults', () => {
+    const myObject = {first: 1, second: 2, fourth: 4}
+    const defaultObject = {first: 3, second: 4, third: 5}
+    const filledObject = fillMissingKeys(myObject, defaultObject)
+
+    expect(filledObject.first).toBe(1)
+    expect(filledObject.second).toBe(2)
+    expect(filledObject.third).toBe(5)
+    expect(filledObject.fourth).toBe(4)
+  })
+
+  test('check that fillMissingKeys works with empty objects', () => {
+    const myObject = {}
+    const defaultObject = {first: 1, second: 2}
+    const filledObject = fillMissingKeys(myObject, defaultObject)
+
+    expect(filledObject.first).toBe(1)
+    expect(filledObject.second).toBe(2)
+
+    const myObject2 = {first: 1, second: 2}
+    const defaultObject2 = {}
+    const filledObject2 = fillMissingKeys(myObject2, defaultObject2)
+
+    expect(filledObject2.first).toBe(1)
+    expect(filledObject2.second).toBe(2)
+
+  })
+
+  test('check that fillMissingKeys works on a copy', () => {
+    const myObject = {}
+    const defaultObject = {first: 1, second: 2}
+    const filledObject = fillMissingKeys(myObject, defaultObject)
+
+    expect(myObject.first).toBe(undefined)
+    expect(myObject.second).toBe(undefined)
+  })
 })
 

--- a/src/js/dataobjects.js
+++ b/src/js/dataobjects.js
@@ -1,5 +1,5 @@
 import {defaultValues} from './defaultValues';
-import {defaultIfMissing} from './utils';
+import {fillMissingKeys} from './utils';
 
 export class Geography {
     constructor(js) {
@@ -21,6 +21,37 @@ export class Geography {
     }
 }
 
+export class IndicatorHelper {
+    static fixMetadata(indicator) {
+        if (indicator.metadata == undefined)
+            indicator.metadata = {
+                source: "",
+                description: "",
+                licence: {
+                    name: "",
+                    url: ""
+                }
+
+            }
+
+        return indicator
+    }
+
+    static addDefaultConfiguration(indicator) {
+        if (indicator.chartConfiguration == undefined)
+            indicator.chartConfiguration = {}
+
+        indicator.chartConfiguration = fillMissingKeys(defaultValues.chartConfiguration, indicator.chartConfiguration)
+        return indicator
+    }
+
+    static fixIndicator(indicator) {
+        indicator = this.fixMetadata(indicator)
+        indicator = this.addDefaultConfiguration(indicator)
+        return indicator
+    }
+}
+
 export class Profile {
 
     constructor(js) {
@@ -36,8 +67,7 @@ export class Profile {
             Object.values(category.subcategories).forEach(subcategory => {
                 subcategory = self._fixSubcategory(subcategory)
                 Object.values(subcategory.indicators).forEach(indicator => {
-                    self._fixMetadata(indicator)
-                    indicator.chartConfiguration = defaultIfMissing(indicator.chart_configuration, defaultValues.chartConfiguration)
+                    indicator = IndicatorHelper.fixIndicator(indicator)
 
                     indicator.subindicators = Object
                         .entries(indicator.subindicators)
@@ -47,18 +77,6 @@ export class Profile {
         })
     }
 
-    _fixMetadata(indicator) {
-        if (indicator.metadata == undefined)
-            indicator.metadata = {
-                source: "",
-                description: "",
-                licence: {
-                    name: "",
-                    url: ""
-                }
-
-            }
-    }
 
     _fixProfile(profile) {
         if (profile.highlights == undefined)

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -288,3 +288,7 @@ export function saveAs(uri, filename) {
         window.open(uri);
     }
 }
+
+export function fillMissingKeys(obj, defaultObj) {
+    return {...defaultObj, ...obj}
+}


### PR DESCRIPTION
## Description

Dataobjects now fills in missing config keys in the chart configuration

## Related Issue
N/A

## How to test it locally
Look at the unit tests

## Screenshots


## Changelog

### Added
Created a separate function in dataobjects to normalise indicators received through the api

### Updated


### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- []  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
