### PR TITLE
Adding missing keys to chartConfiguration

### DIFF
--- a/__tests__/dataobjects.test.js
+++ b/__tests__/dataobjects.test.js
@@ -4,7 +4,7 @@ import {defaultValues} from '../src/js/defaultValues';
 describe('Test IndicatorHelper static methods', () => {
     test('missing data is correctly fixed', () => {
         let indicator = {}
-        indicator = IndicatorHelper.fixMetadata(indicator)
+        indicator.metadata = IndicatorHelper.getMetadata(indicator)
 
         expect(indicator.metadata.source).toBe('')
         expect(indicator.metadata.description).toBe('')
@@ -18,7 +18,7 @@ describe('Test IndicatorHelper static methods', () => {
 
         let indicator = {test1: 3}
 
-        indicator = IndicatorHelper.addDefaultConfiguration(indicator)
+        indicator.chartConfiguration = IndicatorHelper.getChartConfiguration(indicator)
         expect(indicator.chartConfiguration).toBeDefined()
         expect(indicator.chartConfiguration.test1).toBe(1)
         expect(indicator.chartConfiguration.test2).toBe(2)

--- a/__tests__/dataobjects.test.js
+++ b/__tests__/dataobjects.test.js
@@ -8,6 +8,7 @@ describe('Test IndicatorHelper static methods', () => {
 
         expect(indicator.metadata.source).toBe('')
         expect(indicator.metadata.description).toBe('')
+        expect(indicator.metadata.url).toBe('')
         expect(indicator.metadata.licence.name).toBe('')
         expect(indicator.metadata.licence.url).toBe('')
     })
@@ -43,4 +44,5 @@ describe('Test IndicatorHelper static methods', () => {
 
         defaultValues.chartConfiguration = original;
     })
+
 })

--- a/__tests__/dataobjects.test.js
+++ b/__tests__/dataobjects.test.js
@@ -1,0 +1,46 @@
+import {IndicatorHelper} from '../src/js/dataobjects';
+import {defaultValues} from '../src/js/defaultValues';
+
+describe('Test IndicatorHelper static methods', () => {
+    test('missing data is correctly fixed', () => {
+        let indicator = {}
+        indicator = IndicatorHelper.fixMetadata(indicator)
+
+        expect(indicator.metadata.source).toBe('')
+        expect(indicator.metadata.description).toBe('')
+        expect(indicator.metadata.licence.name).toBe('')
+        expect(indicator.metadata.licence.url).toBe('')
+    })
+
+    test('missing configuration values inserted', () => {
+        const original = defaultValues.chartConfiguration
+        defaultValues.chartConfiguration = {test1: 1, test2: 2}
+
+        let indicator = {test1: 3}
+
+        indicator = IndicatorHelper.addDefaultConfiguration(indicator)
+        expect(indicator.chartConfiguration).toBeDefined()
+        expect(indicator.chartConfiguration.test1).toBe(1)
+        expect(indicator.chartConfiguration.test2).toBe(2)
+
+        defaultValues.chartConfiguration = original;
+    })
+
+    test('fix indicator applies all manipulations to indicator', () => {
+        const original = defaultValues.chartConfiguration
+        defaultValues.chartConfiguration = {test1: 1, test2: 2}
+        
+        let indicator = {}
+        indicator = IndicatorHelper.fixIndicator(indicator)
+
+        expect(indicator.metadata.source).toBe('')
+        expect(indicator.metadata.description).toBe('')
+        expect(indicator.metadata.licence.name).toBe('')
+        expect(indicator.metadata.licence.url).toBe('')
+        expect(indicator.chartConfiguration).toBeDefined()
+        expect(indicator.chartConfiguration.test1).toBe(1)
+        expect(indicator.chartConfiguration.test2).toBe(2)
+
+        defaultValues.chartConfiguration = original;
+    })
+})

--- a/src/js/dataobjects.js
+++ b/src/js/dataobjects.js
@@ -24,11 +24,12 @@ export class Geography {
 export class IndicatorHelper {
     static getMetadata(indicator) {
         return indicator.metadata || {
-            source: "",
-            description: "",
+            source: '',
+            description: '',
+            url: '',
             licence: {
-                name: "",
-                url: ""
+                name: '',
+                url: ''
             }
         }
     }

--- a/src/js/dataobjects.js
+++ b/src/js/dataobjects.js
@@ -22,32 +22,24 @@ export class Geography {
 }
 
 export class IndicatorHelper {
-    static fixMetadata(indicator) {
-        if (indicator.metadata == undefined)
-            indicator.metadata = {
-                source: "",
-                description: "",
-                licence: {
-                    name: "",
-                    url: ""
-                }
-
+    static getMetadata(indicator) {
+        return indicator.metadata || {
+            source: "",
+            description: "",
+            licence: {
+                name: "",
+                url: ""
             }
-
-        return indicator
+        }
     }
 
-    static addDefaultConfiguration(indicator) {
-        if (indicator.chartConfiguration == undefined)
-            indicator.chartConfiguration = {}
-
-        indicator.chartConfiguration = fillMissingKeys(defaultValues.chartConfiguration, indicator.chartConfiguration)
-        return indicator
+    static getChartConfiguration(indicator) {
+        return fillMissingKeys(defaultValues.chartConfiguration, indicator.chartConfiguration || {})
     }
 
     static fixIndicator(indicator) {
-        indicator = this.fixMetadata(indicator)
-        indicator = this.addDefaultConfiguration(indicator)
+        indicator.metadata = this.getMetadata(indicator)
+        indicator.chartConfiguration = this.getChartConfiguration(indicator)
         return indicator
     }
 }

--- a/src/js/dataobjects.js
+++ b/src/js/dataobjects.js
@@ -1,5 +1,5 @@
 import {defaultValues} from './defaultValues';
-import {defaultIfMissing} from './utils';
+import {fillMissingKeys} from './utils';
 
 export class Geography {
     constructor(js) {
@@ -21,6 +21,37 @@ export class Geography {
     }
 }
 
+export class IndicatorHelper {
+    static fixMetadata(indicator) {
+        if (indicator.metadata == undefined)
+            indicator.metadata = {
+                source: "",
+                description: "",
+                licence: {
+                    name: "",
+                    url: ""
+                }
+
+            }
+
+        return indicator
+    }
+
+    static addDefaultConfiguration(indicator) {
+        if (indicator.chartConfiguration == undefined)
+            indicator.chartConfiguration = {}
+
+        indicator.chartConfiguration = fillMissingKeys(defaultValues.chartConfiguration, indicator.chartConfiguration)
+        return indicator
+    }
+
+    static fixIndicator(indicator) {
+        indicator = this.fixMetadata(indicator)
+        indicator = this.addDefaultConfiguration(indicator)
+        return indicator
+    }
+}
+
 export class Profile {
 
     constructor(js) {
@@ -36,8 +67,7 @@ export class Profile {
             Object.values(category.subcategories).forEach(subcategory => {
                 subcategory = self._fixSubcategory(subcategory)
                 Object.values(subcategory.indicators).forEach(indicator => {
-                    self._fixMetadata(indicator)
-                    indicator.chartConfiguration = defaultIfMissing(indicator.chart_configuration, defaultValues.chartConfiguration)
+                    indicator = IndicatorHelper.fixIndicator(indicator)
 
                     indicator.subindicators = Object
                         .entries(indicator.subindicators)
@@ -47,18 +77,6 @@ export class Profile {
         })
     }
 
-    _fixMetadata(indicator) {
-        if (indicator.metadata == undefined)
-            indicator.metadata = {
-                source: "",
-                description: "",
-                licence: {
-                    name: "",
-                    url: ""
-                }
-
-            }
-    }
 
     _fixProfile(profile) {
         if (profile.highlights == undefined)


### PR DESCRIPTION
## Description
previously the expectation was that all keys were present if a custom config was provided via the api
Dataobjects now fills in missing config keys in the chart configuration

## Related Issue
N/A

## How to test it locally
Look at the unit tests

## Screenshots


## Changelog

### Added

### Updated
Extracted a function to normalise indicators received through the api

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
