### PR TITLE
Added an additional margin to the barchart so that ticks are hidden

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -64,7 +64,7 @@ export class Chart extends Observable {
             .barPadding(6)
             .margin({
                 top: 15,
-                right: 5,
+                right: 15,
                 bottom: 15,
                 left: 120,
             })


### PR DESCRIPTION
## Description

Added a margin to the right of the barcharts to prevent the last tick from being cut off

## Related Issue
https://trello.com/c/gHBdFxJT/531-when-switching-the-graphs-to-numbers-some-are-cut-off-see-for-example-households-with-solar-or-wind-generators-where-the-24k-is

## How to test it locally
Using the beta.youthexplorer.org.za backend. Have a look at the Employment barchart - the '%' of the last tick should be fully visible.


## Screenshots


## Changelog

### Added

### Updated
Increased barchart margin 

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
