### PR TITLE
Better mechanism to detect the width of the dom element to prevent it…

### DIFF
--- a/src/js/reusable-charts/horizontal-bar-chart.js
+++ b/src/js/reusable-charts/horizontal-bar-chart.js
@@ -211,19 +211,22 @@ export function horizontalBarChart() {
     }
 
     chart.saveAsPng = function (container) {
+
         let element = $(container).closest('.profile-indicator')[0];
+
         $(element).find('.profile-indicator__options').attr('data-html2canvas-ignore', true);
         $(element).find('.profile-indicator__filters').attr('data-html2canvas-ignore', true);
+        const rightMargin = 60;
 
         let options = {
             x: $(element).offset().left - 30,
             y: $(element).offset().top - 5,
-            width: $(element).width() + 60,
-            height: $(element).height(),
+            width: element.getBoundingClientRect().width + rightMargin,
+            height: element.getBoundingClientRect().height,
             //fix the size of the chart so it doesn't get affected by the client's resolution
             windowWidth: 1920,
             windowHeight: 1080,
-            scale: 0.9
+            scale: 0.9  
         }
 
         html2canvas(element, options).then(function (canvas) {


### PR DESCRIPTION
## Description

Previously the downloaded image would cut off the bottom text in the image. Now using the client bounding box to detect the actual height of the image

## Related Issue
N/A

## How to test it locally
Use the gcro backend. Download the age of respondents chart. The bottom text should be full displayed

## Screenshots


## Changelog

### Added

### Updated
Using `getBoundingClientRect` instead of `.width()` to detect the height and height of the element being downloaded 

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
