### PR TITLE
removing survey popup

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2986,8 +2986,6 @@
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5ecb7ed6bb713f2f4b48319b" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="js/webflow.js" type="text/javascript"></script>
   <!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
-  <!--  User feedback form  -->
-  <script type="text/javascript" async="" src="https://l.getsitecontrol.com/5wv1eggw.js">
 </script>
   <!--  Used for the autocomplete search box  -->
   <link href="https://code.jquery.com/ui/1.12.0/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css">


### PR DESCRIPTION
## Description
Removed the survey popup we show on the first visit of a new user 

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/142

## How to test it locally
* Run the project using a new browser or incognito mode
* Move the cursor out of the page and check if a survey pops up

## Screenshots


## Changelog

### Added

### Updated
* Removed the javascript reference that used to call the plugin from `index.html`

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
