### PR TITLE
Fix: Unit Tests on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
-on: push
+on: [push, pull_request]
 jobs:
-  tests:
+  unit_tests:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-name: CI
-on: [push, pull_request]
+name: Unit tests
+on: push
 jobs:
   unit_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e_pr.yml
+++ b/.github/workflows/e2e_pr.yml
@@ -1,7 +1,7 @@
 name: E2E
 on: pull_request
 jobs:
-  tests:
+  e2e_tests:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -18,6 +18,7 @@ jobs:
         uses: nev7n/wait_for_response@v1
         with:
           url: ${{env.CYPRESS_BASE_URL}}
+          timeout: 120000
 
       - name: Cypress run
         uses: cypress-io/github-action@v2.6.1


### PR DESCRIPTION
## Description

Update CI Pipeline. 
Changing the names of the CI pipeline did have the effect that they now run (which is weird, but let's see how this goes moving forward). 
Added waiting to E2E for netlify build to up to two minutes to make sure netlify is available before attempting to run E2E on it. 

## Related Issue

## How to test it locally


## Screenshots

## Changelog

### Added

### Updated
* Unit test workfloe
* E2E workflow

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
