### PR TITLE
removing kml feature

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2512,9 +2512,6 @@
                         <a href="#" class="hover-menu__content_list-item w-inline-block">
                           <div>JSON</div>
                         </a>
-                        <a href="#" class="hover-menu__content_list-item--last w-inline-block">
-                          <div>KML</div>
-                        </a>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Description
removing KML from chart export options

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/147

## How to test it locally
* run the project
* expand rich data panel
* check export options of any chart and confirm that KLM is not one of the options

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/100450057-0c1fca80-30c6-11eb-92f4-b9d511f609c7.png)


## Changelog

### Added

### Updated
* modified index.html to remove KML option

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
