### PR TITLE
Don't enable event forwarder when using svg layers

### DIFF
--- a/src/js/map/maps.js
+++ b/src/js/map/maps.js
@@ -100,7 +100,9 @@ export class MapControl extends Observable {
 
         L.control.zoom({position: this.zoomPosition}).addTo(map);
         this.boundaryLayers = L.layerGroup().addTo(map);
-        this.configureForwarder(map);
+
+        if (mapOptions.leafletOptions.preferCanvas)
+            this.configureForwarder(map);
 
         return map;
     };


### PR DESCRIPTION

## Description

When using canvas on leaflet, mouse events are forwarded to the relevant handlers - ensure this is not enabled with svg. SVG renders much smoother but the forwarder make popups flicker

## Related Issue
N/A

## How to test it locally
Disable preferCanvas in the profile config - hovering over labels and points should result in smooth rendering rather than flickering

{
    ...
    leaflet_options: {
        preferCanvas: false
    }
}

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
