### PR TITLE
[Feature] Title need on the map download

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -6619,6 +6619,17 @@ label {
   cursor: pointer;
 }
 
+#map-download-title {
+  position: fixed;
+  top: 80px;
+  z-index: 998;
+  width: 100%;
+  text-align: center;
+  font-size: 30px;
+  font-weight: bold;
+  color: white;
+}
+
 .map-download:hover {
   color: #39ad84;
 }

--- a/src/js/elements/mapchip.js
+++ b/src/js/elements/mapchip.js
@@ -6,6 +6,7 @@ const wrapperClsName = 'content__map_current-display';
 const mapOptionsClass = '.map-options';
 const lightStart = 3;
 
+let title = '';
 let subindicatorKey = '';
 
 /**
@@ -131,7 +132,14 @@ export class MapChip extends Observable {
         if (args.indicatorTitle === args.subindicatorKey) {
             label = args.indicatorTitle;
         }
+
+        title = `${args.parents.category} by ${label}`;
+
         this.updateMapChipText(label);
         this.showMapChip(args);
+    }
+
+    get title() {
+        return title;
     }
 }

--- a/src/js/elements/mapchip.js
+++ b/src/js/elements/mapchip.js
@@ -6,7 +6,6 @@ const wrapperClsName = 'content__map_current-display';
 const mapOptionsClass = '.map-options';
 const lightStart = 3;
 
-let title = '';
 let subindicatorKey = '';
 
 /**
@@ -17,6 +16,7 @@ export class MapChip extends Observable {
         super();
         this.legendColors = legendColors;
         this.prepareDomElements();
+        this.title = '';
     }
 
     prepareDomElements() {
@@ -133,13 +133,9 @@ export class MapChip extends Observable {
             label = args.indicatorTitle;
         }
 
-        title = `${args.parents.category} by ${label}`;
+        this.title = `${args.category} by ${label}`;
 
         this.updateMapChipText(label);
         this.showMapChip(args);
-    }
-
-    get title() {
-        return title;
     }
 }

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -60,7 +60,7 @@ export default function configureApplication(profileId, config) {
     const zoomToggle = new ZoomToggle();
     const preferredChildToggle = new PreferredChildToggle();
     const boundaryTypeBox = new BoundaryTypeBox(config.config.preferred_children);
-    const mapDownload = new MapDownload();
+    const mapDownload = new MapDownload(mapchip);
 
     // TODO not certain if it is need to register both here and in the controller in loadedGeography
     // controller.registerWebflowEvents();

--- a/src/js/map/map_download.js
+++ b/src/js/map/map_download.js
@@ -1,12 +1,11 @@
 import html2canvas from 'html2canvas';
 
 import {Observable, saveAs} from "../utils";
-import {MapChip} from "../elements/mapchip";
 
 export class MapDownload extends Observable {
-    constructor() {
+    constructor(mapChip) {
         super();
-        this.mapChip = new MapChip();
+        this.mapChip = mapChip;
         this.prepareDomElements();
     }
 

--- a/src/js/map/map_download.js
+++ b/src/js/map/map_download.js
@@ -1,13 +1,12 @@
 import html2canvas from 'html2canvas';
 
 import {Observable, saveAs} from "../utils";
-import { MapChip } from "../elements/mapchip";
+import {MapChip} from "../elements/mapchip";
 
 export class MapDownload extends Observable {
     constructor() {
         super();
         this.mapChip = new MapChip();
-
         this.prepareDomElements();
     }
 

--- a/src/js/map/map_download.js
+++ b/src/js/map/map_download.js
@@ -1,5 +1,6 @@
-import {Observable, saveAs} from "../utils";
 import html2canvas from 'html2canvas';
+
+import {Observable, saveAs} from "../utils";
 import { MapChip } from "../elements/mapchip";
 
 export class MapDownload extends Observable {

--- a/src/js/map/map_download.js
+++ b/src/js/map/map_download.js
@@ -1,9 +1,11 @@
 import {Observable, saveAs} from "../utils";
 import html2canvas from 'html2canvas';
+import { MapChip } from "../elements/mapchip";
 
 export class MapDownload extends Observable {
     constructor() {
         super();
+        this.mapChip = new MapChip();
 
         this.prepareDomElements();
     }
@@ -15,15 +17,16 @@ export class MapDownload extends Observable {
     }
 
     downloadMap = () => {
-        let options = {
+        const options = {
             useCORS: true
         };
-        let element = document.getElementById("main-map");
+        const title = $(`<div id="map-download-title">${this.mapChip.title}</div>`);
+        const element = document.getElementById("main-map");
+        $(element).append(title);
 
         html2canvas(element, options).then(function (canvas) {
+            $(title).remove();
             saveAs(canvas.toDataURL(), 'map.png');
         });
     }
-
-
 }

--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -57,7 +57,7 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
             indicators: pp.indicators,
             subindicatorKey: pp.obj.keys,
             indicatorTitle: pp.indicatorTitle,
-            parents: pp.parents
+            category: pp.parents.category
         }
 
         mapchip.onSubIndicatorChange(args);

--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -56,7 +56,8 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
         const args = {
             indicators: pp.indicators,
             subindicatorKey: pp.obj.keys,
-            indicatorTitle: pp.indicatorTitle
+            indicatorTitle: pp.indicatorTitle,
+            parents: pp.parents
         }
 
         mapchip.onSubIndicatorChange(args);


### PR DESCRIPTION
## Description

Title was added to downloaded map image(.png)

## How to test it locally
1. Open the data mapper
2. Select Population -> Households -> Age Group -> 15-24 on the menu
Download the map image on the bottom right of the screen.
You will get a png of the map with title - Population by Age Group (15-24). This will be the same for all other indicators

## Screenshots
![map-title-download](https://user-images.githubusercontent.com/75182798/100849395-9172f880-3493-11eb-8ba2-dbf0ac1d0d76.png)


## Changelog

### Added
Download map title

## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
