### PR TITLE
Point data now receives an array from the api rather than a dictionary

### DIFF
--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -210,19 +210,12 @@ export class PointData extends Observable {
 
         $('.' + tooltipItemsClsName, item).html('');
 
-        let arr = [];
-        for (let key in point.data) {
-            if (point.data.hasOwnProperty(key)) {
-                arr.push({key: key, value: point.data[key]});
-            }
-        }
-
-        arr.forEach((a, i) => {
+        point.data.forEach((a, i) => {
             if (Object.prototype.toString.call(a.value) == '[object String]') {
                 let itemRow = tooltipRowItem.cloneNode(true);
                 $('.tooltip__facility-item_label div', itemRow).text(a.key);
                 $('.tooltip__facility-item_value div', itemRow).text(a.value);
-                if (i === arr.length - 1) {
+                if (i === point.data.length - 1) {
                     $(itemRow).addClass('last')
                 }
 


### PR DESCRIPTION
## Description

In order to ensure a consistent order for point data attributes - the api will now send an array of attributes rather than a dictionary. This commit will be paired with a backend commit.

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/176

## How to test it locally
1. Ensure that the backend sends point data as an array rather than dictionary (see related issue - https://github.com/OpenUpSA/wazimap-ng-ui/issues/176)
2. Click on a popup - ensure that the tooltips are displayed in the order sent from the API

Did not write tests since Jest and Leaflet aren't playing nicely together

## Screenshots


## Changelog

### Added

### Updated
Minor change - using the api data verbatim rather than massaging it into the right format
### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
