### PR TITLE
added checks to prevent breaking when subindicator lacks children key

### DIFF
--- a/src/js/elements/mapchip.js
+++ b/src/js/elements/mapchip.js
@@ -127,6 +127,10 @@ export class MapChip extends Observable {
     }
 
     onSubIndicatorChange(args) {
+        if (typeof args.children === 'undefined') {
+            return;
+        }
+
         let label = `${args.indicatorTitle} (${args.subindicatorKey})`;
         if (args.indicatorTitle === args.subindicatorKey) {
             label = args.indicatorTitle;

--- a/src/js/map/popup.js
+++ b/src/js/map/popup.js
@@ -73,7 +73,7 @@ export class Popup extends Observable {
 
     setTooltipSubindicators = (payload, state, item, areaCode) => {
         let formattingConfig = this.formattingConfig;
-        if (state.subindicator != null) {
+        if (state.subindicator !== null && typeof state.subindicator.children !== 'undefined' && state.subindicator.children !== null) {
             //if any subindicator selected
             let isChild = false;
             for (const [geographyCode, count] of Object.entries(state.subindicator.children)) {

--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -36,7 +36,8 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
                     indicators: pp.indicators,
                     subindicatorKey: ps.selectedSubindicator,
                     indicatorTitle: ps.subindicator.indicatorTitle,
-                    filter: ps.subindicator.filter
+                    filter: ps.subindicator.filter,
+                    children: ps.subindicator.children
                 }
 
                 mapchip.onSubIndicatorChange(args);
@@ -56,7 +57,8 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
         const args = {
             indicators: pp.indicators,
             subindicatorKey: pp.obj.keys,
-            indicatorTitle: pp.indicatorTitle
+            indicatorTitle: pp.indicatorTitle,
+            children: payload.state.subindicator.children
         }
 
         mapchip.onSubIndicatorChange(args);


### PR DESCRIPTION
## Description
For some geographies(like `#geo:166008` on `beta.youthexplorer.org.za` instance) subindicators lack `children` key. This caused the map breaking. Added some checks to prevent that

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/150

## How to test it locally
* open: https://deploy-preview-178--wazimap-staging.netlify.app/?dev-tools=true
* open dev tools and change profile to YE
* Navigate to `#geo:166008`
* Select an indicator in the data mapper
* Check if the map is breaking

## Screenshots
This is the data that caused this issue
![image](https://user-images.githubusercontent.com/53019884/100891773-acad2a80-34ca-11eb-9ccc-85d695e4d477.png)

## Changelog

### Added

### Updated
* updated mapchip.js so the mapchip is not shown when data is missing
* popup.js so it doesn't break on hover, when data is missing

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
