### PR TITLE
fix: click show facilities should show the facilities

### DIFF
--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -29,7 +29,7 @@ export class Profile_header extends Observable {
         breadcrumbsContainer = $('.location__breadcrumbs');
         breadcrumbTemplate = $('.styles').find(breadcrumbClass)[0];
 
-        facilityWrapper = $('.location__facilities .location__facilities_content-wrapper');
+        facilityWrapper = $('.location__facilities .location__facilities_content');
         facilityTemplate = typeof $('.location-facility')[0] === 'undefined' ? null : $('.location-facility')[0].cloneNode(true);
         facilityRowClone = facilityTemplate === null ? null : $(facilityTemplate).find('.location-facility__list_item')[0].cloneNode(true);
 


### PR DESCRIPTION
## Description
Fix the showing of facilities

before this change the facilities were added to the wrong position. the previous css was in the `styles__wrapper` which was hidden. 
changing it to the correct location now shows the facilities the change was introduced here: https://github.com/OpenUpSA/wazimap-ng-ui/commit/341d2eb764a81d8806133dd443923a413c81097e#diff-420eda66ebdbd6b83d68e2e90f0a267f6d158cd3c31f1b5e58556039c5b8cb09R32


## Related Issue
#172 

## How to test it locally
* Go to rich data mapper (where there are facilities)
* Click Show Facilities
* Facilities should show up

## Screenshots
<img width="917" alt="Bildschirmfoto 2020-12-02 um 17 49 32" src="https://user-images.githubusercontent.com/688980/100903967-c9476380-34c6-11eb-842d-c6197ce86480.png">
<img width="896" alt="Bildschirmfoto 2020-12-02 um 17 49 26" src="https://user-images.githubusercontent.com/688980/100903975-cb112700-34c6-11eb-828d-2de21ec277dd.png">


## Changelog

### Added

### Updated
* selector for facility wrapper

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
