### PR TITLE
feat: add the choropleth legend onto the map download

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -6630,6 +6630,22 @@ label {
   color: white;
 }
 
+#map-download-legend {
+  position: absolute;
+  bottom: 50px;
+  z-index: 998;
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+#map-download-legend .map-options__legend_wrap {
+  background: white;
+  padding: 5px;
+  height: 29px;
+  max-width: 397px;
+}
+
 .map-download:hover {
   color: #39ad84;
 }

--- a/src/js/map/map_download.js
+++ b/src/js/map/map_download.js
@@ -21,10 +21,18 @@ export class MapDownload extends Observable {
         };
         const title = $(`<div id="map-download-title">${this.mapChip.title}</div>`);
         const element = document.getElementById("main-map");
+
+        const legend = document.querySelector('.map-options__legend');
+        let clonedLegend = legend.cloneNode(true);
+        $(clonedLegend).find('.map-options__legend_label').remove();
+        clonedLegend.id = 'map-download-legend';
+
         $(element).append(title);
+        $(element).append(clonedLegend);
 
         html2canvas(element, options).then(function (canvas) {
             $(title).remove();
+            $(clonedLegend).remove();
             saveAs(canvas.toDataURL(), 'map.png');
         });
     }


### PR DESCRIPTION
## Description

A legend was added to downloaded map image(.png)

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/180

## How to test it locally
1. Open the data mapper
2. Select Population -> Households -> Age Group -> 15-24 on the menu
Download the map image on the bottom right of the screen.
You will get a png of the map with legend

## Screenshots
![map-legend-download](https://user-images.githubusercontent.com/75182798/100930723-88694200-34fa-11eb-9866-96673f1007d0.png)

## Changelog

### Added
Legend on Download map image

## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
