### PR TITLE
fix: Show Facilities is now working again

### DIFF
--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -29,7 +29,7 @@ export class Profile_header extends Observable {
         breadcrumbsContainer = $('.location__breadcrumbs');
         breadcrumbTemplate = $('.styles').find(breadcrumbClass)[0];
 
-        facilityWrapper = $('.location__facilities .location__facilities_content');
+        facilityWrapper = $('.location__facilities .location__facilities_content-wrapper');
         facilityTemplate = typeof $('.location-facility')[0] === 'undefined' ? null : $('.location-facility')[0].cloneNode(true);
         facilityRowClone = facilityTemplate === null ? null : $(facilityTemplate).find('.location-facility__list_item')[0].cloneNode(true);
 
@@ -123,6 +123,7 @@ export class Profile_header extends Observable {
                 facilityWrapper.prepend(facilityItem);
             })
 
+            $('.location__facilities .location__facilities_content').append(facilityWrapper);
             $('.location__facilities_header').removeClass('hidden');
             $('.location__facilities_trigger').removeClass('hidden');
             $('.location__facilities_categories-value strong').text(categoryArr.length);


### PR DESCRIPTION
## Description
The "Show Facilities" button did not work as expected. 

The change I tried in #179 did not result in the correct styling being applied. 
This PR will change that.

**Reason**
we have a wrapper and a content, both are needed. so we need to add the wrapper to the content

## Related Issue
#172 

## How to test it locally
* open Rich data panel
* click show facilities
* the facilities should show but also next to each other as in the screenshot below. 

## Screenshots
<img width="924" alt="Bildschirmfoto 2020-12-03 um 08 17 54" src="https://user-images.githubusercontent.com/688980/100976942-8de97b00-3540-11eb-91f0-d025ca2ee97f.png">


## Changelog

### Added

### Updated
* add `facilitiesWrapper` to `.location__facilities .location__facilities_content`

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  ⚙️ ran jslint
- [ ]  🧰 ran codeclimate locally

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
