### PR TITLE
adding filtered values to title on downloaded image

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -123,7 +123,7 @@ export class Chart extends Observable {
 
         $(saveImgButton).off('click');
         $(saveImgButton).on('click', () => {
-            let chartTitle = self.selectedGroup === null ? `${self.title}` : `${self.title} by ${self.selectedGroup} : ${self.selectedFilter}`;
+            let chartTitle = self.getChartTitle(':');
             let fileName = 'chart.png';
             barChart.saveAsPng(this.container, fileName, chartTitle);
             this.triggerEvent('profile.chart.saveAsPng', this);
@@ -148,10 +148,14 @@ export class Chart extends Observable {
                 }[index];
                 self.triggerEvent(`profile.chart.download_${downloadFn['type']}`, self);
 
-                let fileName = self.selectedGroup === null ? `${self.title}` : `${self.title} - by ${self.selectedGroup} - ${self.selectedFilter}`;
+                let fileName = self.getChartTitle('-');
                 downloadFn.fn(fileName);
             })
         });
+    }
+
+    getChartTitle = (separator) => {
+        return this.selectedGroup === null ? `${this.title}` : `${this.title} by ${this.selectedGroup} ${separator} ${this.selectedFilter}`;
     }
 
     selectedGraphValueTypeChanged = (containerParent, index) => {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -123,8 +123,9 @@ export class Chart extends Observable {
 
         $(saveImgButton).off('click');
         $(saveImgButton).on('click', () => {
-            let fileName = self.selectedGroup === null ? `${self.title}` : `${self.title} by ${self.selectedGroup} : ${self.selectedFilter}`;
-            barChart.saveAsPng(this.container, `${fileName}.png`);
+            let chartTitle = self.selectedGroup === null ? `${self.title}` : `${self.title} by ${self.selectedGroup} : ${self.selectedFilter}`;
+            let fileName = 'chart.png';
+            barChart.saveAsPng(this.container, fileName, chartTitle);
             this.triggerEvent('profile.chart.saveAsPng', this);
         })
 

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -123,7 +123,8 @@ export class Chart extends Observable {
 
         $(saveImgButton).off('click');
         $(saveImgButton).on('click', () => {
-            barChart.saveAsPng(this.container);
+            let fileName = self.selectedGroup === null ? `${self.title}` : `${self.title} by ${self.selectedGroup} : ${self.selectedFilter}`;
+            barChart.saveAsPng(this.container, `${fileName}.png`);
             this.triggerEvent('profile.chart.saveAsPng', this);
         })
 

--- a/src/js/reusable-charts/horizontal-bar-chart.js
+++ b/src/js/reusable-charts/horizontal-bar-chart.js
@@ -235,12 +235,11 @@ export function horizontalBarChart() {
         });
     }
 
-    chart.saveAsPng = function (container, fileName) {
-
+    chart.saveAsPng = function (container, fileName, chartTitle) {
         let element = $(container).closest('.profile-indicator')[0];
 
-        $(element).find('.profile-indicator__options').attr('data-html2canvas-ignore', true);
-        $(element).find('.profile-indicator__filters').attr('data-html2canvas-ignore', true);
+        $('.profile-indicator__options', element).attr('data-html2canvas-ignore', true);
+        $('.profile-indicator__filters', element).attr('data-html2canvas-ignore', true);
         const rightMargin = 60;
 
         let options = {
@@ -251,7 +250,10 @@ export function horizontalBarChart() {
             //fix the size of the chart so it doesn't get affected by the client's resolution
             windowWidth: 1920,
             windowHeight: 1080,
-            scale: 0.9
+            scale: 0.9,
+            onclone: (clonedElement) => {
+                $('.profile-indicator__title h4', clonedElement).text(chartTitle);
+            }
         }
 
         html2canvas(element, options).then(function (canvas) {

--- a/src/js/reusable-charts/horizontal-bar-chart.js
+++ b/src/js/reusable-charts/horizontal-bar-chart.js
@@ -235,7 +235,7 @@ export function horizontalBarChart() {
         });
     }
 
-    chart.saveAsPng = function (container) {
+    chart.saveAsPng = function (container, fileName) {
 
         let element = $(container).closest('.profile-indicator')[0];
 
@@ -255,7 +255,7 @@ export function horizontalBarChart() {
         }
 
         html2canvas(element, options).then(function (canvas) {
-            saveAs(canvas.toDataURL(), 'chart.png');
+            saveAs(canvas.toDataURL(), fileName);
 
             $(element).find('.profile-indicator__options').removeAttr('data-html2canvas-ignore');
             $(element).find('.profile-indicator__filters').removeAttr('data-html2canvas-ignore');


### PR DESCRIPTION
## Description
modifying the chart title on the downloaded image as `${title} by ${filterGroup}: ${filterValue}`

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/201

## How to test it locally
* run the project
* on the rich data panel, filter a chart
* download it as an image using the top-right menu
* check if the chart title has the correct format

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/101769917-c23cd880-3af8-11eb-8647-48af00e809a7.png)



## Changelog

### Added

### Updated
* `horizontal-bar-chart.js` to get the chart title as a parameter and set it on `onClone` event of `html2canvas`
* `chart.js` to create the chart title string and send it as a parameter

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
