### PR TITLE
Changing order of values in chart download

### DIFF
--- a/src/js/reusable-charts/horizontal-bar-chart.js
+++ b/src/js/reusable-charts/horizontal-bar-chart.js
@@ -325,7 +325,9 @@ export function horizontalBarChart() {
     }
 
     function getExportData() {
-        const exportData = data.reverse().map((d) => {
+        let exportArr = [...data];
+
+        const exportData = exportArr.reverse().map((d) => {
             return {
                 'Sub-indicator': d.label.toString(),
                 'Value': d.valueText.toString()

--- a/src/js/reusable-charts/horizontal-bar-chart.js
+++ b/src/js/reusable-charts/horizontal-bar-chart.js
@@ -325,7 +325,7 @@ export function horizontalBarChart() {
     }
 
     function getExportData() {
-        const exportData = data.map((d) => {
+        const exportData = data.reverse().map((d) => {
             return {
                 'Sub-indicator': d.label.toString(),
                 'Value': d.valueText.toString()


### PR DESCRIPTION
## Description
Array that is showed on the charts was reverse of the array that is exported. So reversed the `data` variable that is sent to export functions.

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/157

## How to test it locally
* Run the project
* Export any chart using the top-right menu
* Compare the exported data with the chart

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/102215957-7e2c4800-3eeb-11eb-97a7-0b6a00cefff7.png)


## Changelog

### Added

### Updated
* `horizontal-bar-chart.js` to get `data` as a new array and `reverse()` it

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
