### PR TITLE
Changing the page title to use the profile name

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -197,6 +197,7 @@ export default class Controller extends Observable {
                     // self.registerWebflowEvents();
                 }
             }, 600)
+            document.title = dataBundle.overview.name;
         })
     }
 


### PR DESCRIPTION
## Description
Changing the page title to use the profile name on `profile.loaded`

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/190

## How to test it locally
* run the project
* check if the page title is set as correctly

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/103115322-3d62ca80-4673-11eb-98db-d9352a41dba3.png)


## Changelog

### Added

### Updated
* `controller.js` to set the title

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
