### PR TITLE
fixed facility spreadsheet bug

### DIFF
--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -158,8 +158,8 @@ export class Profile_header extends Observable {
                     Latitude: geometry.coordinates[1]
                 })
 
-                for (const [title, value] of Object.entries(prop.data)) {
-                    points[points.length - 1][title] = value;
+                for (const [index, obj] of Object.entries(prop.data)) {
+                    points[points.length - 1][obj.key] = obj.value;
                 }
             })
 


### PR DESCRIPTION
## Description
While exporting to excel we use this endpoint : 
`api/v1/profile/<profile_id>/points/category/<category_id>/geography/<geo_code>/points`

The data structure of this endpoint used to be something like : 
```
data:[{
   website: "www.example.com"
}]
```

But that is changed to 
```
data:[{
   0: {key: "website", value: "www.example.com"}
}]
```

This BE change was the reason we got `[object Object]` values when downloading a spreadsheet. Applied the BE changes to FE to fix this issue.

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/189

## How to test it locally
* Modify `hostname` as beta.youthexplorer.org.za
* Open the rich data view
* Click on show facilities
* Download the youth cafe file
* Check the values on the downloaded spreadsheet and confirm they are not `[object Object]`

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/103849724-84f74680-50b6-11eb-8503-3501e072e520.png)
![image](https://user-images.githubusercontent.com/53019884/103849742-8f194500-50b6-11eb-9da5-305f58c86273.png)


## Changelog

### Added

### Updated
* `getAddressPoints()` function in `profile_header.js` to apply the BE changes

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
