### PR TITLE
configuring tutorial text

### DIFF
--- a/src/js/elements/tutorial.js
+++ b/src/js/elements/tutorial.js
@@ -1,17 +1,17 @@
-let wrapperClass = '.w-slider-mask';
-let slideClass = '.w-slide';
-
 export class Tutorial {
-    createSlides = (tutorialArr) => {
-        if (tutorialArr === null || tutorialArr.length <= 0) {
-            return;
-        }
+    constructor() {
+        this.wrapperClass = '.w-slider-mask';
+        this.slideClass = '.w-slide';
+    }
 
-        tutorialArr.forEach((t, i) => {
-            let item = $(wrapperClass).find(slideClass)[i];
-            $('.slide-info__title', item).text(t.title);
-            $('.slide-info__introduction', item).text(t.body);
-            $('.tutorial__slide-image', item).css('background-image', `url(${t.image})`)
+    createSlides = (tutorialArr) => {
+        let tutorials = tutorialArr || [];
+
+        tutorials.forEach((slide, i) => {
+            let item = $(this.wrapperClass).find(this.slideClass)[i];
+            $('.slide-info__title', item).text(slide.title);
+            $('.slide-info__introduction', item).text(slide.body);
+            $('.tutorial__slide-image', item).css('background-image', `url(${slide.image})`);
         });
     }
 }

--- a/src/js/elements/tutorial.js
+++ b/src/js/elements/tutorial.js
@@ -1,0 +1,17 @@
+let wrapperClass = '.w-slider-mask';
+let slideClass = '.w-slide';
+
+export class Tutorial {
+    createSlides = (tutorialArr) => {
+        if (tutorialArr === null || tutorialArr.length <= 0) {
+            return;
+        }
+
+        tutorialArr.forEach((t, i) => {
+            let item = $(wrapperClass).find(slideClass)[i];
+            $('.slide-info__title', item).text(t.title);
+            $('.slide-info__introduction', item).text(t.body);
+            $('.tutorial__slide-image', item).css('background-image', `url(${t.image})`)
+        });
+    }
+}

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -15,6 +15,7 @@ import {API} from './api';
 import Analytics from './analytics';
 import {BoundaryTypeBox} from "./map/boundary_type_box";
 import {MapDownload} from "./map/map_download";
+import {Tutorial} from "./elements/tutorial";
 
 import "data-visualisations/src/charts/bar/reusable-bar-chart/stories.styles.css";
 import "../css/barchart.css";
@@ -32,6 +33,7 @@ import {configureDataExplorerEvents} from './setup/dataexplorer';
 import {configureProfileEvents} from './setup/profile';
 import {configureBoundaryEvents} from "./setup/boundaryevents";
 import {configureMapDownloadEvents} from "./setup/mapdownload";
+import {configureTutorialEvents} from "./setup/tutorial";
 
 
 export default function configureApplication(profileId, config) {
@@ -62,6 +64,7 @@ export default function configureApplication(profileId, config) {
     const preferredChildToggle = new PreferredChildToggle();
     const boundaryTypeBox = new BoundaryTypeBox(config.config.preferred_children);
     const mapDownload = new MapDownload(mapchip);
+    const tutorial = new Tutorial();
 
     // TODO not certain if it is need to register both here and in the controller in loadedGeography
     // controller.registerWebflowEvents();
@@ -79,6 +82,7 @@ export default function configureApplication(profileId, config) {
     configureRichDataView(controller);
     configureBoundaryEvents(controller, boundaryTypeBox);
     configureMapDownloadEvents(mapDownload);
+    configureTutorialEvents(controller, tutorial, config.config.tutorial);
 
     controller.on('profile.loaded', payload => {
         // there seems to be a bug where menu items close if this is not set

--- a/src/js/setup/tutorial.js
+++ b/src/js/setup/tutorial.js
@@ -1,0 +1,3 @@
+export function configureTutorialEvents(controller, tutorialObj, tutorialArr) {
+    controller.on('profile.loaded', () => tutorialObj.createSlides(tutorialArr))
+}


### PR DESCRIPTION
## Description
overwriting the tutorial content using the profile configuration

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/211

## How to test it locally
* run the project
* click `tutorial` button on the right side of the header
* confirm that the slides show the API data
* p.s : currently because of a problem with webflow elements, the slides are not cloned and multiplied, we just modify their content using API data

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/104188397-3d601a00-542a-11eb-812a-94a93a6dab1b.png)


## Changelog

### Added
* `elements/tutorial.js` file modifies the slides.
* `setup/tutorial.js` configures the events related with tutorials

### Updated
* `load.js` to reference the new class and the function

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
