### PR TITLE
fix: facilities appear twice, make sure we only show one

### DIFF
--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -123,7 +123,6 @@ export class Profile_header extends Observable {
                 facilityWrapper.prepend(facilityItem);
             })
 
-            $('.location__facilities .location__facilities_content').append(facilityWrapper);
             $('.location__facilities_header').removeClass('hidden');
             $('.location__facilities_trigger').removeClass('hidden');
             $('.location__facilities_categories-value strong').text(categoryArr.length);


### PR DESCRIPTION
## Description

this line was duplicating the content
I added it because a month ago this seemed to have fixed the appearance
of facilities. before they were not appearing.

## Related Issue
#218 


## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
