### PR TITLE
choropleth breaking issue on YE subplaces

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,13 +5,13 @@ import {Config as SAConfig} from './configurations/geography_sa';
 import Analytics from './analytics';
 import {API} from './api';
 import * as Sentry from '@sentry/browser';
-import {getHostname, loadDevTools} from './utils';
+import { getHostname, loadDevTools }from './utils';
 
 const mainUrl = 'https://staging.wazimap-ng.openup.org.za';
 const productionUrl = 'https://production.wazimap-ng.openup.org.za';
 let config = new SAConfig();
 
-let hostname = 'beta.youthexplorer.org.za'; //getHostname();
+let hostname = getHostname();
 const defaultProfile = 8;
 const defaultUrl = productionUrl;
 const defaultConfig = new SAConfig();
@@ -114,6 +114,6 @@ async function init() {
 
 window.init = init;
 loadDevTools(() => {
-    init();
+  init();
 })
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,13 +5,13 @@ import {Config as SAConfig} from './configurations/geography_sa';
 import Analytics from './analytics';
 import {API} from './api';
 import * as Sentry from '@sentry/browser';
-import { getHostname, loadDevTools }from './utils';
+import {getHostname, loadDevTools} from './utils';
 
 const mainUrl = 'https://staging.wazimap-ng.openup.org.za';
 const productionUrl = 'https://production.wazimap-ng.openup.org.za';
 let config = new SAConfig();
 
-let hostname = getHostname();
+let hostname = 'beta.youthexplorer.org.za'; //getHostname();
 const defaultProfile = 8;
 const defaultUrl = productionUrl;
 const defaultConfig = new SAConfig();
@@ -114,6 +114,6 @@ async function init() {
 
 window.init = init;
 loadDevTools(() => {
-  init();
+    init();
 })
 

--- a/src/js/map/choropleth/choropleth.js
+++ b/src/js/map/choropleth/choropleth.js
@@ -52,7 +52,7 @@ export class Choropleth extends Observable {
             //setLayerToSelected -> removemapchip
             //setLayerToHoverOnly -> display
             const layer = self.layers[code];
-            if (setLayerToSelected && layer !== null && typeof layer !== 'undefined') {
+            if (setLayerToSelected) {
                 self.layerStyler.setLayerToSelected(layer);
             }
         })
@@ -87,8 +87,8 @@ export class Choropleth extends Observable {
 
         childGeographyValues.forEach(el => {
             const layer = self.layers[el.code];
-            self.currentLayers.push(el.code);
             if (layer != undefined) {
+                self.currentLayers.push(el.code);
                 const color = scale(el.val);
                 self.layerStyler.setLayerStyle(layer, {
                     over: {fillColor: color, fillOpacity: self.options.opacity_over},

--- a/src/js/map/choropleth/choropleth.js
+++ b/src/js/map/choropleth/choropleth.js
@@ -52,7 +52,7 @@ export class Choropleth extends Observable {
             //setLayerToSelected -> removemapchip
             //setLayerToHoverOnly -> display
             const layer = self.layers[code];
-            if (setLayerToSelected) {
+            if (setLayerToSelected && layer !== null && typeof layer !== 'undefined') {
                 self.layerStyler.setLayerToSelected(layer);
             }
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,7 +1517,7 @@ adler-32@~1.2.0:
     printj "~1.1.0"
 
 ajv-keywords@^3.5.2:
-  version "3.5.2"
+  version "3.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.1.tgz#b83ca89c5d42d69031f424cad49aada0236c6957"
 
 ajv@^6.12.3, ajv@^6.12.4:
@@ -8845,9 +8845,10 @@ word@~0.3.0:
   resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
   integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
-wrap-ansi@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"


### PR DESCRIPTION
## Description
The reason of this error was when the choropleth is getting reset, the `reset()` function tried to reset the `ward` children too even though on the UI `mainplace` is the selected boundary type or vice versa. This caused breaking because the client does not have the data of the children of unselected boundary type.

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/223

## How to test it locally
* set `hostname` parameter as `'beta.youthexplorer.org.za'`
* Open Data Mapper
* Select Demographics -> Language -> Language most spoken at home -> English
* Click through to the geography #165005 (SA > Western Cape > Cape Winelands > Witzenberg > Prince Alfred Hamlet)
* On the developer console look for `Cannot read property '_layers' of undefined` error and confirm it is not happening

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/105457897-a8b2b300-5c98-11eb-833c-50273357a3bc.png)


## Changelog

### Added

### Updated
* `map/choropleth/choroplet.js` to add `null` check in `reset()` function. this eliminates the children geographies of unselected boundary type

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
