### PR TITLE
applying tooltip design changes, showing facility modal

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -989,10 +989,7 @@ label {
 }
 
 .location__facilities_sources {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: none;
   width: 100%;
   margin-top: 16px;
   margin-right: 6px;
@@ -1007,6 +1004,7 @@ label {
   align-items: center;
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
+  -ms-grid-row-align: stretch;
   align-self: stretch;
 }
 
@@ -4591,12 +4589,12 @@ label {
   -ms-flex-align: center;
   align-items: center;
   border-radius: 100px;
-  background-color: #39ad84;
   color: #fff;
   font-size: 0.65em;
   line-height: 100%;
   letter-spacing: 1.5px;
   text-transform: uppercase;
+  background-color: #39ad84;
 }
 
 .tooltip__value_detail {
@@ -4642,7 +4640,7 @@ label {
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  margin-right: 6px;
+  font-weight: 700;
   text-transform: capitalize;
 }
 
@@ -4654,10 +4652,11 @@ label {
   width: 100%;
   padding-top: 6px;
   padding-bottom: 4px;
-  -webkit-box-flex: 1;
-  -webkit-flex: 1;
-  -ms-flex: 1;
-  flex: 1;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
   border-bottom: 1px solid #ebebeb;
   line-height: 150%;
   font-weight: 500;
@@ -4709,7 +4708,6 @@ label {
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  margin-top: 6px;
   padding-top: 4px;
   padding-right: 4px;
   padding-left: 4px;
@@ -4718,10 +4716,10 @@ label {
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
-  -webkit-box-pack: justify;
-  -webkit-justify-content: space-between;
-  -ms-flex-pack: justify;
-  justify-content: space-between;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
   -webkit-box-align: start;
   -webkit-align-items: flex-start;
   -ms-flex-align: start;
@@ -4763,6 +4761,10 @@ label {
   -webkit-align-self: stretch;
   -ms-flex-item-align: stretch;
   align-self: stretch;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
 }
 
 .facility-tooltip {
@@ -4772,10 +4774,11 @@ label {
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
+  max-height: 60vh;
   max-width: 350px;
   min-height: 32px;
   min-width: 110px;
-  padding: 6px 8px;
+  padding: 8px;
   -webkit-box-orient: vertical;
   -webkit-box-direction: normal;
   -webkit-flex-direction: column;
@@ -4789,6 +4792,9 @@ label {
   -webkit-align-items: center;
   -ms-flex-align: center;
   align-items: center;
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
   border-style: solid;
   border-width: 1px;
   border-color: #ccc;
@@ -4798,15 +4804,21 @@ label {
   font-weight: 500;
 }
 
+.facility-tooltip.demo {
+  position: absolute;
+  left: 37%;
+  top: 15%;
+}
+
+.facility-tooltip.demo._2 {
+  left: 16%;
+}
+
 .tooltip__facility-item_value {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  -webkit-box-pack: end;
-  -webkit-justify-content: flex-end;
-  -ms-flex-pack: end;
-  justify-content: flex-end;
   font-weight: 400;
 }
 
@@ -4980,7 +4992,6 @@ label {
   -ms-flex-align: center;
   align-items: center;
   border-radius: 2px;
-  background-color: #39ad84;
   background-image: none;
   font-weight: 500;
   text-align: center;
@@ -6642,6 +6653,410 @@ label {
 
 .map-download:hover {
   color: #39ad84;
+}.plate {
+   position: absolute;
+   left: 0%;
+   top: 0%;
+   right: 0%;
+   bottom: 0%;
+ }
+
+.plate.bg-primary {
+  background-color: #39ad84;
+}
+
+.bg-primary {
+  background-color: #39ad84;
+}
+
+.bg-secondary {
+  background-color: #3950ad;
+}
+
+.text-primary {
+  color: #39ad84;
+}
+
+.hover-bg-primary-light:hover {
+  background-color: rgba(57, 173, 132, 0.2);
+}
+
+.bg-primary-light {
+  background-color: rgba(57, 173, 132, 0.2);
+}
+
+.hover-text-primary:hover {
+  color: #39ad84;
+}
+
+.tab-notice {
+  position: fixed;
+  left: auto;
+  top: auto;
+  right: 22px;
+  bottom: 0%;
+  z-index: 999;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-bottom: 150px;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-transform: rotate(-90deg);
+  -ms-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+  -webkit-transform-origin: 100% 100%;
+  -ms-transform-origin: 100% 100%;
+  transform-origin: 100% 100%;
+  color: #fff;
+  font-weight: 700;
+  text-align: right;
+  text-decoration: none;
+}
+
+.tab-notice.hidden {
+  display: none;
+}
+
+.tab-notice__text {
+  position: relative;
+  z-index: 1;
+  display: inline-block;
+  -webkit-align-self: center;
+  -ms-flex-item-align: center;
+  -ms-grid-row-align: center;
+  align-self: center;
+}
+
+.tab-notice__inner {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  overflow: hidden;
+  height: 44px;
+  border-top-left-radius: 2px;
+  border-top-right-radius: 2px;
+  -webkit-transition: all 200ms ease;
+  transition: all 200ms ease;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.tab-notice__inner:hover {
+  padding-bottom: 52px;
+}
+
+.tab-notice__content {
+  padding: 12px;
+  color: #fff;
+}
+
+.point-mapper-content__error {
+  margin-bottom: 16px;
+}
+
+.error {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  padding: 4px 6px;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  border-radius: 2px;
+  background-color: #f0f0f0;
+  color: #666;
+  font-size: 0.9em;
+}
+
+.error__icon {
+  padding-right: 6px;
+}
+
+.facility-tooltip__scroll-wrapper {
+  overflow: auto;
+  height: 100%;
+  margin-top: 6px;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  -ms-grid-row-align: stretch;
+  align-self: stretch;
+}
+
+.facility-tooltip__open-modal {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  height: 32px;
+  margin-top: 8px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  border-radius: 2px;
+  background-color: rgba(0, 0, 0, 0.06);
+  font-size: 0.85em;
+  text-align: center;
+  cursor: pointer;
+}
+
+.facility-tooltip__open-modal:hover {
+  background-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0, 0, 0, 0.1)), to(rgba(0, 0, 0, 0.1)));
+  background-image: linear-gradient(180deg, rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.1));
+}
+
+.facility-tooltip__showing {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  padding-top: 8px;
+  border-top: 1px solid #ebebeb;
+  font-size: 0.85em;
+}
+
+.facility-tooltip__showing_icon {
+  width: 24px;
+  height: 24px;
+}
+
+.facility-info {
+  position: fixed;
+  left: 20%;
+  top: auto;
+  right: 20%;
+  bottom: 10px;
+  z-index: 5;
+  display: none;
+  max-height: 40vh;
+  max-width: 840px;
+  margin-right: auto;
+  margin-left: auto;
+  padding: 16px 12px 16px 20px;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-radius: 4px;
+  background-color: #fff;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1);
+}
+
+.facility-info.webflow {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.facility-info__title {
+  margin-top: 0px;
+  margin-bottom: 0px;
+}
+
+.facility-info__close {
+  z-index: 1;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 36px;
+  height: 36px;
+  padding: 2px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  border-radius: 4px;
+  -webkit-transition: all 200ms ease;
+  transition: all 200ms ease;
+  color: rgba(0, 0, 0, 0.63);
+  cursor: pointer;
+}
+
+.facility-info__close:hover {
+  color: #000;
+}
+
+.facility-info__close.hidden {
+  display: none;
+}
+
+.facility-info__content {
+  overflow: auto;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
+.facility-info__items {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 6px;
+  padding-top: 4px;
+  padding-right: 4px;
+  padding-left: 4px;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-box-align: start;
+  -webkit-align-items: flex-start;
+  -ms-flex-align: start;
+  align-items: flex-start;
+  -webkit-align-self: stretch;
+  -ms-flex-item-align: stretch;
+  align-self: stretch;
+  border-top: 1px solid #e6e6e6;
+  font-size: 0.85em;
+}
+
+.facility-info__item {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  width: 100%;
+  padding-top: 6px;
+  padding-bottom: 4px;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  border-bottom: 1px solid #ebebeb;
+  line-height: 150%;
+  font-weight: 500;
+}
+
+.facility-info__item.last {
+  border-bottom-style: none;
+}
+
+.facility-info__item_label {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-weight: 700;
+  text-transform: capitalize;
+}
+
+.facility-info__item_value {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  font-weight: 400;
+}
+
+.facility-info__header {
+  display: -ms-grid;
+  display: grid;
+  margin-bottom: 10px;
+  grid-auto-flow: column;
+  grid-auto-columns: -webkit-max-content;
+  grid-auto-columns: max-content;
+  grid-column-gap: 8px;
+  -ms-grid-columns: 1fr;
+  grid-template-columns: 1fr;
+  -ms-grid-rows: auto;
+  grid-template-rows: auto;
+}
+
+.facility-info__download {
+  z-index: 1;
+  display: none;
+  width: 36px;
+  height: 36px;
+  padding: 2px;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  border-radius: 4px;
+  -webkit-transition: all 200ms ease;
+  transition: all 200ms ease;
+  color: rgba(0, 0, 0, 0.63);
+  cursor: pointer;
+}
+
+.facility-info__download:hover {
+  color: #000;
+}
+
+.facility-info__download.hidden {
+  display: none;
+}
+
+.map-title {
+  position: absolute;
+  left: auto;
+  top: 16px;
+  right: auto;
+  bottom: auto;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-right: 24px;
+  margin-left: 24px;
+  padding: 12px;
+  border-radius: 6px;
+  background-color: #fff;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1);
+  font-size: 1.2em;
+  font-weight: 700;
+}
+
+.map-title.webflow {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
 }
 
 @media screen and (max-width: 991px) {

--- a/src/index.html
+++ b/src/index.html
@@ -9,47 +9,22 @@
     <link href="css/normalize.css" rel="stylesheet" type="text/css">
     <link href="css/webflow.css" rel="stylesheet" type="text/css">
     <link href="css/wazimap-ng-v1.webflow.css" rel="stylesheet" type="text/css">
-    <style>@media (max-width: 479px) {
-        html.w-mod-js:not(.w-mod-ix) [data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825"] {
-            -webkit-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);
-            -moz-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);
-            -ms-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);
-            transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);
-        }
-
-        html.w-mod-js:not(.w-mod-ix) [data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50"] {
-            width: 44PX;
-        }
-
-        html.w-mod-js:not(.w-mod-ix) [data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7"] {
-            -webkit-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);
-            -moz-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);
-            -ms-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);
-            transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);
-        }
-    }</style>
+    <style>@media (max-width:479px) {html.w-mod-js:not(.w-mod-ix) [data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825"] {-webkit-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);}html.w-mod-js:not(.w-mod-ix) [data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50"] {width:44PX;}html.w-mod-js:not(.w-mod-ix) [data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7"] {-webkit-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);-moz-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);-ms-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);}}</style>
     <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
-    <script type="text/javascript">WebFont.load({google: {families: ["Roboto:300,regular,italic,500,500italic,700,900"]}});</script>
-    <!-- [if lt IE 9]>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"
-            type="text/javascript"></script><![endif] -->
-    <script type="text/javascript">!function (o, c) {
-        var n = c.documentElement, t = " w-mod-";
-        n.className += t + "js", ("ontouchstart" in o || o.DocumentTouch && c instanceof DocumentTouch) && (n.className += t + "touch")
-    }(window, document);</script>
+    <script type="text/javascript">WebFont.load({  google: {    families: ["Roboto:300,regular,italic,500,500italic,700,900"]  }});</script>
+    <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
+    <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
     <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon">
     <link href="images/webclip.png" rel="apple-touch-icon">
     <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-93649482-25"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-
         function gtag() {
             dataLayer.push(arguments);
         }
-
         const analyticsId = 'UA-93649482-25';
         gtag('js', new Date());
-        gtag('config', analyticsId, {'send_page_view': false});
+        gtag('config', analyticsId, { 'send_page_view': false });
         gtag('config', analyticsId, {
             'custom_map': {'dimension1': 'profile'}
         });
@@ -64,31 +39,20 @@
             <h1 class="clear">Login Required</h1>
         </div>
         <div id="w-node-31f6ef2aede4-e148319d" data-w-id="138f8096-55b2-2cf7-756a-31f6ef2aede4" class="login__close">
-            <div class="svg-icon w-embed">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor"
-                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                </svg>
-            </div>
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+            </svg></div>
         </div>
         <div id="w-node-09c3cf7a9fe2-e148319d" class="login__description">
             <div>This is private instance of Wazimap and requires you to be an authorized user to access it.</div>
         </div>
         <div id="w-node-222d0aaebade-e148319d" class="login__form">
             <div class="form-block w-form">
-                <form id="wf-form-Login-Form" name="wf-form-Login-Form" data-name="Login Form"><label for="Email">Username</label><input
-                        type="email" class="text-field w-input" maxlength="256" name="Email" data-name="Email"
-                        placeholder="" id="Email" required=""><label for="Password">Password</label><input
-                        type="password" class="text-field w-input" maxlength="256" name="Password" data-name="Password"
-                        id="Password" required="">
-                    <div class="login-form__actions"><label id="w-node-fefcf113a3cc-e148319d"
-                                                            class="w-checkbox login-form__checkbox">
-                        <div class="w-checkbox-input w-checkbox-input--inputType-custom custom-checkbox"></div>
-                        <input type="checkbox" id="checkbox-2" name="checkbox-2" data-name="Checkbox 2"
-                               style="opacity:0;position:absolute;z-index:-1"><span class="checkbox-label w-form-label">Remember me</span>
-                    </label><input type="submit" value="Login" data-wait="Please wait..."
-                                   id="w-node-fceb1157e41b-e148319d" class="button w-button">
+                <form id="wf-form-Login-Form" name="wf-form-Login-Form" data-name="Login Form"><label for="Email">Username</label><input type="email" class="text-field w-input" maxlength="256" name="Email" data-name="Email" placeholder="" id="Email" required=""><label for="Password">Password</label><input type="password" class="text-field w-input" maxlength="256" name="Password" data-name="Password" id="Password" required="">
+                    <div class="login-form__actions"><label id="w-node-fefcf113a3cc-e148319d" class="w-checkbox login-form__checkbox">
+                        <div class="w-checkbox-input w-checkbox-input--inputType-custom custom-checkbox"></div><input type="checkbox" id="checkbox-2" name="checkbox-2" data-name="Checkbox 2" style="opacity:0;position:absolute;z-index:-1"><span class="checkbox-label w-form-label">Remember me</span>
+                    </label><input type="submit" value="Login" data-wait="Please wait..." id="w-node-fceb1157e41b-e148319d" class="button w-button">
                         <a id="w-node-25fe1e234621-e148319d" href="#">Forgot your password?</a>
                     </div>
                 </form>
@@ -109,24 +73,18 @@
                 <h1 class="clear">How to use</h1>
             </div>
             <div data-w-id="6ca2d157-b860-d2c0-78da-11837bc90d1d" data-testid="tutorial-close" class="tutorial__close">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                </svg></div>
             </div>
         </div>
-        <div data-animation="cross" data-nav-spacing="4" data-duration="500" id="w-node-d1064d900402-e148319d"
-             class="tutorial__slider w-slider">
+        <div data-animation="cross" data-nav-spacing="4" data-duration="500" id="w-node-d1064d900402-e148319d" class="tutorial__slider w-slider">
             <div class="mask w-slider-mask">
                 <div class="slide w-slide">
                     <div class="tutorial__slide-content">
                         <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Introduction:</span> <span
-                                    class="slide-info__introduction">This website was developed to enable you to easily find spatial information related to geographic areas. By clicking on the map or using the search bar, you can navigate to an area of interest and find relevant information about it.</span>
-                            </div>
+                            <div><span class="slide-info__title">Introduction:</span> <span class="slide-info__introduction">This website was developed to enable you to easily find spatial information related to geographic areas. By clicking on the map or using the search bar, you can navigate to an area of interest and find relevant information about it.</span></div>
                         </div>
                         <div class="tutorial__slide-image _1">
                             <div class="tutorial__slide_gradient bottom"></div>
@@ -139,10 +97,7 @@
                 <div class="slide w-slide">
                     <div class="tutorial__slide-content">
                         <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Location Search:</span> To get started, first select a
-                                location on the map or use the search box to find the location you would like to
-                                analyse.
-                            </div>
+                            <div><span class="slide-info__title">Location Search:</span> To get started, first select a location on the map or use the search box to find the location you would like to analyse.</div>
                         </div>
                         <div class="tutorial__slide-image _2">
                             <div class="tutorial__slide-number">
@@ -154,10 +109,7 @@
                 <div class="slide w-slide">
                     <div class="tutorial__slide-content">
                         <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Location Panel:</span> Basic information for your
-                                selected location can be found in the Location Panel. Use the buttons to navigate to
-                                parent locations.
-                            </div>
+                            <div><span class="slide-info__title">Location Panel:</span> Basic information for your selected location can be found in the Location Panel. Use the buttons to navigate to parent locations.</div>
                         </div>
                         <div class="tutorial__slide-image _2b">
                             <div class="tutorial__slide-number">
@@ -169,9 +121,7 @@
                 <div class="slide w-slide">
                     <div class="tutorial__slide-content">
                         <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Rich Data:</span> To view rich data specific to the
-                                location you selected, open the Rich Data panel in the left toolbar.
-                            </div>
+                            <div><span class="slide-info__title">Rich Data:</span> To view rich data specific to the location you selected, open the Rich Data panel in the left toolbar.</div>
                         </div>
                         <div class="tutorial__slide-image _3">
                             <div class="tutorial__slide-number">
@@ -183,9 +133,7 @@
                 <div class="slide w-slide">
                     <div class="tutorial__slide-content">
                         <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Point Mapper:</span> To add point data to the map, use
-                                the Point Mapper to show different facilities in that area.
-                            </div>
+                            <div><span class="slide-info__title">Point Mapper:</span> To add point data to the map, use the Point Mapper to show different facilities in that area.</div>
                         </div>
                         <div class="tutorial__slide-image _4">
                             <div class="tutorial__slide-number">
@@ -197,9 +145,7 @@
                 <div class="slide w-slide">
                     <div class="tutorial__slide-content">
                         <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Data Mapper:</span> To overlay compatible datasets onto
-                                your location, open the Data Mapper and choose from the available indicators.
-                            </div>
+                            <div><span class="slide-info__title">Data Mapper:</span> To overlay compatible datasets onto your location, open the Data Mapper and choose from the available indicators.</div>
                         </div>
                         <div class="tutorial__slide-image _5">
                             <div class="tutorial__slide-number">
@@ -211,10 +157,7 @@
                 <div class="slide w-slide">
                     <div class="tutorial__slide-content">
                         <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Data Filtering:</span> Once you&#x27;ve mapped a
-                                data-set (eg. gender), use the Data Filter to select a sub-indicator for that data-set
-                                (eg. male)
-                            </div>
+                            <div><span class="slide-info__title">Data Filtering:</span> Once you&#x27;ve mapped a data-set (eg. gender), use the Data Filter to select a sub-indicator for that data-set (eg. male)</div>
                         </div>
                         <div class="tutorial__slide-image _7">
                             <div class="tutorial__slide-number">
@@ -226,11 +169,7 @@
                 <div class="slide w-slide">
                     <div class="tutorial__slide-content">
                         <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Learn more:</span> For more information on how to use
-                                specific features, look out for tutorial icons. For an in-depth guide on using this
-                                site, please see our <a href="https://openup.gitbook.io/wazimap-ng-user-guide/"
-                                                        target="_blank">user manual</a>.
-                            </div>
+                            <div><span class="slide-info__title">Learn more:</span> For more information on how to use specific features, look out for tutorial icons. For an in-depth guide on using this site, please see our <a href="https://openup.gitbook.io/wazimap-ng-user-guide/" target="_blank">user manual</a>.</div>
                         </div>
                         <div class="tutorial__slide-image _7">
                             <div class="tutorial__slide-number">
@@ -242,12 +181,10 @@
             </div>
             <div class="left-arrow w-slider-arrow-left">
                 <div class="tutorial__slide_button previous">
-                    <div class="svg-icon w-embed">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path>
-                        </svg>
-                    </div>
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path>
+                    </svg></div>
                 </div>
             </div>
             <div class="right-arrow w-slider-arrow-right">
@@ -288,22 +225,16 @@
 </div>
 <div class="main">
     <div class="nav">
-        <div data-w-id="66ee4f1f-99f3-8310-c69c-b5d00bdac74c" style="opacity:1;display:none"
-             class="nav__search-deselect"></div>
+        <div data-w-id="66ee4f1f-99f3-8310-c69c-b5d00bdac74c" style="opacity:1;display:none" class="nav__search-deselect"></div>
         <div class="nav__shadow"></div>
         <div class="nav__content">
             <a id="w-node-926b3e9c855a-e148319d" href="#" class="nav__content_title w-inline-block">
-                <div class="nav__profile-logo"><img
-                        src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg"
-                        alt="" class="profile-logo"></div>
+                <div class="nav__profile-logo"><img src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg" alt="" class="profile-logo"></div>
             </a>
             <div id="w-node-926b3e9c8568-e148319d" class="nav__content_search">
                 <div class="nav__search_input">
                     <div data-w-id="2331a044-806f-907c-13ce-926b3e9c8576" class="search__input w-form">
-                        <form id="email-form" name="email-form" data-name="Email Form" method="post" class="form"><input
-                                type="text" class="location__search_input w-input" autocomplete="off" maxlength="256"
-                                name="Location" data-name="Location" placeholder="Search for a location..."
-                                id="Location">
+                        <form id="email-form" name="email-form" data-name="Email Form" method="post" class="form"><input type="text" class="location__search_input w-input" autocomplete="off" maxlength="256" name="Location" data-name="Location" placeholder="Search for a location..." id="Location">
                             <div class="location__search_loading hidden"><img src="images/loading.gif" alt=""></div>
                         </form>
                         <div class="w-form-done">
@@ -314,13 +245,10 @@
                         </div>
                     </div>
                     <div class="nav__search_button">
-                        <div class="svg-icon w-embed">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor"
-                                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
-                            </svg>
-                        </div>
+                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
+                        </svg></div>
                     </div>
                 </div>
                 <div style="display:none;opacity:0" class="nav__search_dropdown">
@@ -334,14 +262,10 @@
                                     <div class="search__dropdown_no-data">
                                         <div class="no-data">
                                             <div class="no-data__icon">
-                                                <div class="svg-icon w-embed">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                         viewbox="0 0 24 24">
-                                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                                        <path fill="currentColor"
-                                                              d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"></path>
-                                                    </svg>
-                                                </div>
+                                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                    <path fill="currentColor" d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"></path>
+                                                </svg></div>
                                             </div>
                                             <div class="no-data__text">
                                                 <div>Start typing to begin...</div>
@@ -356,31 +280,23 @@
             </div>
             <div id="w-node-926b3e9c85a0-e148319d" class="nav__content_menu">
                 <div class="nav__link-wrap">
-                    <a data-w-id="2331a044-806f-907c-13ce-926b3e9c8565" href="#"
-                       class="nav__link tutorial__open w-inline-block">
+                    <a data-w-id="2331a044-806f-907c-13ce-926b3e9c8565" href="#" class="nav__link tutorial__open w-inline-block">
                         <div class="nav__link_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+                            </svg></div>
                         </div>
                         <div class="nav__link_text">
                             <div>Tutorial</div>
                         </div>
                     </a>
-                    <a data-w-id="9ed47308-e332-9825-644e-4ad6bb204fab" href="#"
-                       class="nav__link hidden w-inline-block">
+                    <a data-w-id="9ed47308-e332-9825-644e-4ad6bb204fab" href="#" class="nav__link hidden w-inline-block">
                         <div class="nav__link_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5c-1.11 0-2 .9-2 2v4h2V5h14v14H5v-4H3v4c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5c-1.11 0-2 .9-2 2v4h2V5h14v14H5v-4H3v4c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"></path>
+                            </svg></div>
                         </div>
                         <div class="nav__link_text">
                             <div>Login</div>
@@ -388,11 +304,9 @@
                     </a>
                 </div>
                 <div class="nav__menu-trigger hidden">
-                    <div class="svg-icon w-embed">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
-                        </svg>
-                    </div>
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
+                    </svg></div>
                 </div>
             </div>
         </div>
@@ -400,13 +314,10 @@
     <div class="map">
         <div class="map-about hidden">
             <div class="map-about__icon">
-                <div class="svg-icon small w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
+                </svg></div>
             </div>
             <div class="map-about__profile-name">
                 <div>Profile name</div>
@@ -419,7 +330,7 @@
             <div class="map-location__tags">
                 <div title="Click to make this your primary search" class="location-tag__loading">
                     <div class="location-tag__type">
-                        <div>LOCATION TYPE</div>
+                        <div>LOCATION TYPE</div>
                     </div>
                     <div class="location-tag__name">
                         <div class="truncate text-center">Loading...</div>
@@ -434,42 +345,30 @@
                 <div class="map-options__filters_header">
                     <div class="filter__header_sub-indicator">
                         <div class="filters__header_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                            </svg></div>
                         </div>
                         <div class="filters__header_name">
                             <div class="truncate">indicator name</div>
                         </div>
                     </div>
                     <div data-w-id="a0a0a80b-723d-9f06-08f8-22ecf4a4bddb" class="filters__header_toggle">
-                        <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)"
-                             class="toggle-icon-v--first w-embed">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
-                            </svg>
-                        </div>
-                        <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)"
-                             class="toggle-icon-v--last w-embed">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
-                            </svg>
-                        </div>
+                        <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="toggle-icon-v--first w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
+                        </svg></div>
+                        <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="toggle-icon-v--last w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
+                        </svg></div>
                     </div>
                     <div data-w-id="f7f05345-5dc5-101e-109a-a0291cc7b897" class="filters__header_close">
-                        <div class="svg-icon w-embed">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor"
-                                      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                            </svg>
-                        </div>
+                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                        </svg></div>
                     </div>
                 </div>
                 <div style="display:flex" class="map-options__filters_content">
@@ -483,14 +382,10 @@
                                     <div class="truncate">All values</div>
                                 </div>
                                 <div class="dropdown-menu__icon">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="dropdown-menu__content position-top scroll-element">
@@ -505,7 +400,7 @@
                     </div>
                     <div class="mapping-options__filter disabled">
                         <div class="mapping-options__filter_label">
-                            <div>FILTER BY:</div>
+                            <div>FILTER BY:</div>
                         </div>
                         <div data-w-id="fd26a4e0-f0f7-aaf0-9eee-32c6e9fb2e19" class="mapping-options__filter_menu">
                             <div class="dropdown-menu__trigger narrow">
@@ -513,14 +408,10 @@
                                     <div class="truncate">All filters</div>
                                 </div>
                                 <div class="dropdown-menu__icon">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="dropdown-menu__content position-top scroll-element">
@@ -559,13 +450,10 @@
                             <div class="tooltip-notch dark"></div>
                         </div>
                     </div>
-                    <div class="svg-icon small w-embed">
-                        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor"
-                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
-                        </svg>
-                    </div>
+                    <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
+                    </svg></div>
                 </div>
             </div>
         </div>
@@ -580,12 +468,10 @@
                             <div class="truncate">Loading...</div>
                         </div>
                         <div class="dropdown-menu__icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                            </svg></div>
                         </div>
                     </div>
                     <div class="dropdown-menu__content dropdown-menu__content--top scroll-element">
@@ -600,25 +486,20 @@
             </div>
         </div>
         <div title="Download map" class="map-download">
-            <div class="svg-icon w-embed">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-                </svg>
-            </div>
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+            </svg></div>
         </div>
         <div id="main-map" class="map-area"></div>
     </div>
     <div class="rich-data">
         <div data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825" class="rich-data-nav">
             <div data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7" class="rich-data-nav__toggle">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M3 18h13v-2H3v2zm0-5h10v-2H3v2zm0-7v2h13V6H3zm18 9.59L17.42 12 21 8.41 19.59 7l-5 5 5 5L21 15.59z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M3 18h13v-2H3v2zm0-5h10v-2H3v2zm0-7v2h13V6H3zm18 9.59L17.42 12 21 8.41 19.59 7l-5 5 5 5L21 15.59z"></path>
+                </svg></div>
             </div>
             <div class="rich-data-nav__list">
                 <a href="#top" class="rich-data-nav__item w-inline-block">
@@ -626,13 +507,10 @@
                         <div class="truncate">Summary</div>
                     </div>
                     <div class="rich-data-nav__item-icon">
-                        <div class="svg-icon w-embed">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor"
-                                      d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
-                            </svg>
-                        </div>
+                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
+                        </svg></div>
                     </div>
                 </a>
             </div>
@@ -640,22 +518,18 @@
         <div data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50" class="rich-data-bumper"></div>
         <div class="rich-data-content">
             <div class="rich-data__shadow"></div>
-            <div style="-webkit-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)"
-                 class="sticky-header">
+            <div style="-webkit-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="sticky-header">
                 <div title="Click to make this your primary search" class="sticky-header__current-location">
                     <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                     <div class="loading__text">
-                        <div class="truncate">Loading...</div>
+                        <div class="truncate">Loading... </div>
                     </div>
                 </div>
                 <div class="sticky-header__tutorial hidden">
-                    <div class="svg-icon w-embed">
-                        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor"
-                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-                        </svg>
-                    </div>
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+                    </svg></div>
                 </div>
             </div>
             <section class="section header">
@@ -668,19 +542,16 @@
                         <div class="breadcrumb">
                             <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                             <div class="loading__text">
-                                <div>Loading...</div>
+                                <div>Loading... </div>
                             </div>
                         </div>
                     </div>
                     <div class="location__tutorial hidden">
                         <div class="location__tutorial_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+                            </svg></div>
                         </div>
                         <div>Quick tutorial</div>
                     </div>
@@ -689,25 +560,21 @@
                     <div class="loading">
                         <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                         <div class="loading__text">
-                            <div>Loading...</div>
+                            <div>Loading... </div>
                         </div>
                     </div>
                 </div>
                 <div class="location__description hidden">
-                    <div>A <span class="location-type">Location type</span> in <span class="parent-geography">parent geography</span>
-                    </div>
+                    <div>A <span class="location-type">Location type</span> in <span class="parent-geography">parent geography</span></div>
                 </div>
                 <div class="location__facilities">
                     <div class="location__facilities_no-data hidden">
                         <div class="no-data">
                             <div class="no-data__icon">
-                                <div class="svg-icon w-embed">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor"
-                                              d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                                    </svg>
-                                </div>
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                                </svg></div>
                             </div>
                             <div class="no-data__text">
                                 <div>No facilities for this location</div>
@@ -718,38 +585,27 @@
                         <div class="loading">
                             <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                             <div class="loading__text">
-                                <div>Loading...</div>
+                                <div>Loading... </div>
                             </div>
                         </div>
                     </div>
                     <div class="location__facilities_header hidden">
                         <div class="location__facilities_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                                    <path fill="currentColor"
-                                          d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                                <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                            </svg></div>
                         </div>
                         <div class="location__facilities_title">
-                            <div>This <span class="location__facilities_geo-type">location</span> has <span
-                                    class="location__facilities_facilities-value"><strong>0000</strong></span><strong>
-                                facilities</strong> in <span
-                                    class="location__facilities_categories-value"><strong>0000</strong></span><strong>
-                                categories</strong>.
-                            </div>
+                            <div>This <span class="location__facilities_geo-type">location</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> facilities</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
                         </div>
                     </div>
                     <div class="location__facilities_trigger hidden">
-                        <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6ad" style="display:flex"
-                             class="location__facilities_expand">
+                        <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6ad" style="display:flex" class="location__facilities_expand">
                             <div>Show facilities</div>
                         </div>
-                        <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6b0" style="display:none"
-                             class="location__facilities_contract">
+                        <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6b0" style="display:none" class="location__facilities_contract">
                             <div>Hide facilities</div>
                         </div>
                     </div>
@@ -763,7 +619,7 @@
                                     <div class="loading">
                                         <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                                         <div class="loading__text">
-                                            <div>Loading...</div>
+                                            <div>Loading... </div>
                                         </div>
                                     </div>
                                 </div>
@@ -785,13 +641,10 @@
         </div>
         <div class="rich-data-toggles">
             <div data-w-id="1b738c3c-f509-9ebc-f15d-d66894a02164" class="panel-toggle rich-data-panel__close cc-active">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+                </svg></div>
                 <div class="panel-toggle__tooltip">
                     <div class="panel-toggle__tooltip_text">
                         <div>Rich Data</div>
@@ -799,14 +652,24 @@
                     <div class="panel-toggle__tooltip_notch"></div>
                 </div>
             </div>
-            <div data-w-id="ef6902f7-5288-a426-a2e6-ee2a693e86d7" class="panel-toggle data-mapper-panel__open">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                    </svg>
+            <div data-w-id="1260faa6-080e-87e0-2b01-fe2eba016dcb" class="panel-toggle point-mapper-panel__open">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                </svg></div>
+                <div class="panel-toggle__tooltip">
+                    <div class="panel-toggle__tooltip_text">
+                        <div>Point Mapper</div>
+                    </div>
+                    <div class="panel-toggle__tooltip_notch"></div>
                 </div>
+            </div>
+            <div data-w-id="ef6902f7-5288-a426-a2e6-ee2a693e86d7" class="panel-toggle data-mapper-panel__open">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                </svg></div>
                 <div class="panel-toggle__tooltip">
                     <div class="panel-toggle__tooltip_text">
                         <div>Data Mapper</div>
@@ -820,21 +683,16 @@
         <div class="facility-info__header">
             <h3 class="facility-info__title">Loading...</h3>
             <div title="Download information (.pdf)" class="facility-info__download">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                </svg></div>
             </div>
             <div title="Close" class="facility-info__close">
-                <div class="svg-icon svg-icon--no-size w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                </svg></div>
             </div>
         </div>
         <div class="facility-info__content">
@@ -850,42 +708,34 @@
         <div class="point-mapper-content narrow-scroll">
             <div class="point-mapper-content__header">
                 <div class="point-data__header_icon">
-                    <div class="svg-icon w-embed">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor"
-                                  d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                            <path fill="currentColor"
-                                  d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                        </svg>
-                    </div>
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                        <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                    </svg></div>
                 </div>
                 <div class="point-data__header_title">
-                    <div>Point Mapper</div>
+                    <div>Point Mapper </div>
                 </div>
             </div>
             <div class="point-mapper-content__description">
-                <div>Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong>
-                </div>
+                <div>Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong></div>
             </div>
             <div class="point-mapper-content__loading">
                 <div class="loading">
                     <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                     <div class="loading__text">
-                        <div>Loading...</div>
+                        <div>Loading... </div>
                     </div>
                 </div>
             </div>
             <div class="point-mapper-content__no-data hidden">
                 <div class="no-data">
                     <div class="no-data__icon">
-                        <div class="svg-icon w-embed">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor"
-                                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                            </svg>
-                        </div>
+                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                        </svg></div>
                     </div>
                     <div class="no-data__text">
                         <div>No points available for this location</div>
@@ -896,13 +746,10 @@
         </div>
         <div class="point-mapper-toggles">
             <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de47" class="panel-toggle rich-data-panel__open">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+                </svg></div>
                 <div class="panel-toggle__tooltip">
                     <div class="panel-toggle__tooltip_text">
                         <div>Rich Data</div>
@@ -910,17 +757,12 @@
                     <div class="panel-toggle__tooltip_notch"></div>
                 </div>
             </div>
-            <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de4a"
-                 class="panel-toggle point-mapper-panel__close cc-active">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                        <path fill="currentColor"
-                              d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                    </svg>
-                </div>
+            <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de4a" class="panel-toggle point-mapper-panel__close cc-active">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                </svg></div>
                 <div class="panel-toggle__tooltip">
                     <div class="panel-toggle__tooltip_text">
                         <div>Point Mapper</div>
@@ -929,13 +771,10 @@
                 </div>
             </div>
             <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de49" class="panel-toggle data-mapper-panel__open">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                </svg></div>
                 <div class="panel-toggle__tooltip">
                     <div class="panel-toggle__tooltip_text">
                         <div>Data Mapper</div>
@@ -949,55 +788,43 @@
         <div class="data-mapper-content narrow-scroll">
             <div class="data-mapper-content__header">
                 <div class="point-data__header_icon">
-                    <div class="svg-icon w-embed">
-                        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor"
-                                  d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                        </svg>
-                    </div>
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                    </svg></div>
                 </div>
                 <div class="point-data__header_title">
                     <div>Data Mapper</div>
                 </div>
             </div>
             <div class="data-mapper-content__description">
-                <div>Explore data categories available for this location. Click or tap a sub-indicator to show it on the
-                    map.<strong><br></strong></div>
+                <div>Explore data categories available for this location. Click or tap a sub-indicator to show it on the map.<strong><br></strong></div>
             </div>
             <div class="data-mapper-content__loading">
                 <div class="loading">
                     <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                     <div class="loading__text">
-                        <div>Loading...</div>
+                        <div>Loading... </div>
                     </div>
                 </div>
             </div>
             <div class="data-mapper-content__no-data hidden">
                 <div class="no-data__icon">
-                    <div class="svg-icon w-embed">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor"
-                                  d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                        </svg>
-                    </div>
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                    </svg></div>
                 </div>
-                <div>The Data Mapper cannot be used with this location as it doesn&#x27;t contain any sub-areas which
-                    can be used for mapping
-                </div>
+                <div>The Data Mapper cannot be used with this location as it doesn&#x27;t contain any sub-areas which can be used for mapping</div>
             </div>
             <div class="data-mapper-content__list"></div>
         </div>
         <div class="data-mapper-toggles">
             <div data-w-id="82de420b-3451-8ea3-a5a4-f892b059998e" class="panel-toggle rich-data-panel__open">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+                </svg></div>
                 <div class="panel-toggle__tooltip">
                     <div class="panel-toggle__tooltip_text">
                         <div>Rich Data</div>
@@ -1006,15 +833,11 @@
                 </div>
             </div>
             <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599990" class="panel-toggle point-mapper-panel__open">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                        <path fill="currentColor"
-                              d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                    </svg>
-                </div>
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                </svg></div>
                 <div class="panel-toggle__tooltip">
                     <div class="panel-toggle__tooltip_text">
                         <div>Point Mapper</div>
@@ -1022,15 +845,11 @@
                     <div class="panel-toggle__tooltip_notch"></div>
                 </div>
             </div>
-            <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599992"
-                 class="panel-toggle data-mapper-panel__close cc-active">
-                <div class="svg-icon w-embed">
-                    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor"
-                              d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                    </svg>
-                </div>
+            <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599992" class="panel-toggle data-mapper-panel__close cc-active">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                </svg></div>
                 <div class="panel-toggle__tooltip">
                     <div class="panel-toggle__tooltip_text">
                         <div>Data Mapper</div>
@@ -1048,13 +867,10 @@
                 </div>
                 <div class="panel-toggle__tooltip_notch"></div>
             </div>
-            <div class="svg-icon w-embed">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor"
-                          d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-                </svg>
-            </div>
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+            </svg></div>
         </div>
         <div data-w-id="cb33504b-ce21-a841-3478-0f9742bd5340" class="panel-toggle point-mapper-panel__open">
             <div class="panel-toggle__tooltip">
@@ -1063,15 +879,11 @@
                 </div>
                 <div class="panel-toggle__tooltip_notch"></div>
             </div>
-            <div class="svg-icon w-embed">
-                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor"
-                          d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                    <path fill="currentColor"
-                          d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                </svg>
-            </div>
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+            </svg></div>
         </div>
         <div data-w-id="6207c761-ee3d-87bf-d0fb-b9250b5408ec" class="panel-toggle data-mapper-panel__open">
             <div class="panel-toggle__tooltip">
@@ -1080,13 +892,10 @@
                 </div>
                 <div class="panel-toggle__tooltip_notch"></div>
             </div>
-            <div class="svg-icon w-embed">
-                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor"
-                          d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                </svg>
-            </div>
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+            </svg></div>
         </div>
     </div>
 </div>
@@ -1109,13 +918,10 @@
                 <div class="point-mapper__h1">
                     <div class="point-mapper__h1_trigger point-mapper__h1--default-closed">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
@@ -1138,14 +944,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2">
@@ -1160,14 +962,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-1">
@@ -1182,14 +980,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -1201,13 +995,10 @@
                 <div class="point-mapper__h1">
                     <div class="point-mapper__h1_trigger point-mapper__h1--default-open">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
@@ -1230,14 +1021,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2">
@@ -1252,14 +1039,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-1">
@@ -1274,14 +1057,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -1293,21 +1072,17 @@
                 <div class="point-mapper__h1">
                     <div data-w-id="e0cdcac6-d5b6-2780-3500-919c8eb3a735" class="point-mapper__h1_trigger">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -1326,14 +1101,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2">
@@ -1348,14 +1119,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-1">
@@ -1370,14 +1137,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -1387,24 +1150,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="555868a6-ac7f-4f39-8af1-54b777afa871"
-                         class="point-mapper__h1_trigger theme-1 active">
+                    <div data-w-id="555868a6-ac7f-4f39-8af1-54b777afa871" class="point-mapper__h1_trigger theme-1 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -1423,14 +1181,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-1 active">
@@ -1445,14 +1199,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-1">
@@ -1467,14 +1217,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -1484,24 +1230,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="6c86cd6d-a3de-4bf1-d2ef-1b52d687bf4e"
-                         class="point-mapper__h1_trigger theme-2 active">
+                    <div data-w-id="6c86cd6d-a3de-4bf1-d2ef-1b52d687bf4e" class="point-mapper__h1_trigger theme-2 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -1520,14 +1261,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-2 active">
@@ -1542,14 +1279,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-2">
@@ -1564,14 +1297,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -1581,24 +1310,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="bf6a46d9-86a7-67f0-4a2e-794e9e22a39c"
-                         class="point-mapper__h1_trigger theme-3 active">
+                    <div data-w-id="bf6a46d9-86a7-67f0-4a2e-794e9e22a39c" class="point-mapper__h1_trigger theme-3 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -1617,14 +1341,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-3 active">
@@ -1639,14 +1359,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-3">
@@ -1661,14 +1377,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -1678,24 +1390,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="4cef7f0e-21b5-0f03-d39b-d81f3f762e9b"
-                         class="point-mapper__h1_trigger theme-4 active">
+                    <div data-w-id="4cef7f0e-21b5-0f03-d39b-d81f3f762e9b" class="point-mapper__h1_trigger theme-4 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -1714,14 +1421,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-4 active">
@@ -1736,14 +1439,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-4">
@@ -1758,14 +1457,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -1775,24 +1470,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="7744e72b-62fe-c3cd-e2b1-d418a4c81926"
-                         class="point-mapper__h1_trigger theme-5 active">
+                    <div data-w-id="7744e72b-62fe-c3cd-e2b1-d418a4c81926" class="point-mapper__h1_trigger theme-5 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -1811,14 +1501,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-5 active">
@@ -1833,14 +1519,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-5">
@@ -1855,14 +1537,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -1872,24 +1550,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="ac8e408e-8dfd-2bd2-473a-7f80ffe5d8da"
-                         class="point-mapper__h1_trigger theme-6 active">
+                    <div data-w-id="ac8e408e-8dfd-2bd2-473a-7f80ffe5d8da" class="point-mapper__h1_trigger theme-6 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -1908,14 +1581,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-6 active">
@@ -1930,14 +1599,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-6">
@@ -1952,14 +1617,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -1969,24 +1630,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="9cf08a1c-eea4-40f7-7584-7a22af1533c0"
-                         class="point-mapper__h1_trigger theme-7 active">
+                    <div data-w-id="9cf08a1c-eea4-40f7-7584-7a22af1533c0" class="point-mapper__h1_trigger theme-7 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -2005,14 +1661,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-7 active">
@@ -2027,14 +1679,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-7">
@@ -2049,14 +1697,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -2066,24 +1710,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="c7b0b95d-3477-0e3c-db3a-98e3a48fa33a"
-                         class="point-mapper__h1_trigger theme-8 active">
+                    <div data-w-id="c7b0b95d-3477-0e3c-db3a-98e3a48fa33a" class="point-mapper__h1_trigger theme-8 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -2102,14 +1741,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-8 active">
@@ -2124,14 +1759,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-8">
@@ -2146,14 +1777,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -2163,24 +1790,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="5a41969a-edbe-1d60-39e9-b0079ac64c15"
-                         class="point-mapper__h1_trigger theme-9 active">
+                    <div data-w-id="5a41969a-edbe-1d60-39e9-b0079ac64c15" class="point-mapper__h1_trigger theme-9 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -2199,14 +1821,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-9 active">
@@ -2221,14 +1839,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-9">
@@ -2243,14 +1857,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -2260,24 +1870,19 @@
             </div>
             <div class="styles__area_block">
                 <div class="point-mapper__h1">
-                    <div data-w-id="9a2d4f34-e296-5da4-f30e-b15ac204c0da"
-                         class="point-mapper__h1_trigger theme-10 active">
+                    <div data-w-id="9a2d4f34-e296-5da4-f30e-b15ac204c0da" class="point-mapper__h1_trigger theme-10 active">
                         <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
                         <div class="point-data__h1_name">
                             <div class="truncate">Category Name</div>
                         </div>
                     </div>
                     <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
-                                class="switch">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
                             <input type="checkbox">
                             <span class="slider round"></span>
                         </label></div>
@@ -2296,14 +1901,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 theme-10 active">
@@ -2318,14 +1919,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                             <div class="point-mapper__h2 last theme-10">
@@ -2340,14 +1937,10 @@
                                 </div>
                                 <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
                                 <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor"
-                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                    </svg></div>
                                 </div>
                             </div>
                         </div>
@@ -2389,8 +1982,7 @@
             <div class="styles__area_block horizontal wide">
                 <div class="location-highlight">
                     <div class="location-highlight__title">
-                        <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)
-                        </div>
+                        <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)</div>
                     </div>
                     <div class="location-highlight__value">
                         <div class="truncate">Value</div>
@@ -2398,8 +1990,7 @@
                 </div>
                 <div class="location-highlight last">
                     <div class="location-highlight__title">
-                        <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)
-                        </div>
+                        <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)</div>
                     </div>
                     <div class="location-highlight__value">
                         <div class="truncate">Value</div>
@@ -2419,31 +2010,24 @@
                     <div href="#" class="data-category__h1_trigger">
                         <div class="data-category__h1_header">
                             <div class="data-category__h1_icon">
-                                <div class="svg-icon w-embed">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor"
-                                              d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                    </svg>
-                                </div>
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg></div>
                             </div>
                             <div class="data-category__h1_title">
                                 <div class="truncate">Category</div>
                             </div>
                         </div>
                         <div class="data-category__h1_toggle toggle-icon-v">
-                            <div class="toggle-icon-v--first w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
-                                </svg>
-                            </div>
-                            <div class="toggle-icon-v--last w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
-                                </svg>
-                            </div>
+                            <div class="toggle-icon-v--first w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
+                            </svg></div>
+                            <div class="toggle-icon-v--last w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
+                            </svg></div>
                         </div>
                     </div>
                     <div class="data-category__h1_content">
@@ -2455,20 +2039,14 @@
                                 <div class="data-category__h2_content">
                                     <div class="data-category__h2_wrapper">
                                         <div class="data-category__h3">
-                                            <div data-w-id="d9dcf788-413f-9049-8723-d6b050277cba"
-                                                 class="data-category__h3_trigger">
+                                            <div data-w-id="d9dcf788-413f-9049-8723-d6b050277cba" class="data-category__h3_trigger">
                                                 <div class="truncate">Indicator</div>
-                                                <div class="data-category__h3_loading hidden"><img
-                                                        src="images/loading.gif" alt=""></div>
+                                                <div class="data-category__h3_loading hidden"><img src="images/loading.gif" alt=""></div>
                                                 <div class="data-category__h3_load-complete hidden">
-                                                    <div class="svg-icon w-embed">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                             viewbox="0 0 24 24">
-                                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                                            <path fill="currentColor"
-                                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                        </svg>
-                                                    </div>
+                                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                    </svg></div>
                                                 </div>
                                             </div>
                                             <div style="height:0PX" class="data-category__h3_content">
@@ -2477,69 +2055,48 @@
                                                     <a href="#" class="data-category__h4 w-inline-block">
                                                         <div class="data-category__h4_line-h"></div>
                                                         <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img
-                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
                                                         <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
-                                                                     height="24" viewbox="0 0 24 24">
-                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                    <path fill="currentColor"
-                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                                </svg>
-                                                            </div>
+                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                            </svg></div>
                                                         </div>
                                                     </a>
                                                     <a href="#" class="data-category__h4 w-inline-block">
                                                         <div class="data-category__h4_line-h"></div>
                                                         <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading"><img
-                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
                                                         <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
-                                                                     height="24" viewbox="0 0 24 24">
-                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                    <path fill="currentColor"
-                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                                </svg>
-                                                            </div>
+                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                            </svg></div>
                                                         </div>
                                                     </a>
                                                     <a href="#" class="data-category__h4 active w-inline-block">
                                                         <div class="data-category__h4_line-h"></div>
                                                         <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img
-                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
                                                         <div class="data-category__h4_load-complete">
-                                                            <div class="svg-icon w-embed">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
-                                                                     height="24" viewbox="0 0 24 24">
-                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                    <path fill="currentColor"
-                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                                </svg>
-                                                            </div>
+                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                            </svg></div>
                                                         </div>
                                                     </a>
                                                 </div>
                                             </div>
                                         </div>
                                         <div class="data-category__h3">
-                                            <div data-w-id="1e35aa5d-6794-7eaf-27f0-84b06b77495c"
-                                                 class="data-category__h3_trigger">
+                                            <div data-w-id="1e35aa5d-6794-7eaf-27f0-84b06b77495c" class="data-category__h3_trigger">
                                                 <div class="truncate">Indicator</div>
-                                                <div class="data-category__h3_loading"><img src="images/loading.gif"
-                                                                                            alt=""></div>
+                                                <div class="data-category__h3_loading"><img src="images/loading.gif" alt=""></div>
                                                 <div class="data-category__h3_load-complete hidden">
-                                                    <div class="svg-icon w-embed">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                             viewbox="0 0 24 24">
-                                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                                            <path fill="currentColor"
-                                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                        </svg>
-                                                    </div>
+                                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                    </svg></div>
                                                 </div>
                                             </div>
                                             <div class="data-category__h3_content hidden">
@@ -2548,69 +2105,48 @@
                                                     <a href="#" class="data-category__h4 w-inline-block">
                                                         <div class="data-category__h4_line-h"></div>
                                                         <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img
-                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
                                                         <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
-                                                                     height="24" viewbox="0 0 24 24">
-                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                    <path fill="currentColor"
-                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                                </svg>
-                                                            </div>
+                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                            </svg></div>
                                                         </div>
                                                     </a>
                                                     <a href="#" class="data-category__h4 w-inline-block">
                                                         <div class="data-category__h4_line-h"></div>
                                                         <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading"><img
-                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
                                                         <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
-                                                                     height="24" viewbox="0 0 24 24">
-                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                    <path fill="currentColor"
-                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                                </svg>
-                                                            </div>
+                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                            </svg></div>
                                                         </div>
                                                     </a>
                                                     <a href="#" class="data-category__h4 active w-inline-block">
                                                         <div class="data-category__h4_line-h"></div>
                                                         <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img
-                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
                                                         <div class="data-category__h4_load-complete">
-                                                            <div class="svg-icon w-embed">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
-                                                                     height="24" viewbox="0 0 24 24">
-                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                    <path fill="currentColor"
-                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                                </svg>
-                                                            </div>
+                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                            </svg></div>
                                                         </div>
                                                     </a>
                                                 </div>
                                             </div>
                                         </div>
                                         <div class="data-category__h3">
-                                            <div data-w-id="5cc4d99e-ac57-fc58-7a13-748080bb6e5e"
-                                                 class="data-category__h3_trigger active">
+                                            <div data-w-id="5cc4d99e-ac57-fc58-7a13-748080bb6e5e" class="data-category__h3_trigger active">
                                                 <div class="truncate">Indicator</div>
-                                                <div class="data-category__h3_loading hidden"><img
-                                                        src="images/loading.gif" alt=""></div>
+                                                <div class="data-category__h3_loading hidden"><img src="images/loading.gif" alt=""></div>
                                                 <div class="data-category__h3_load-complete">
-                                                    <div class="svg-icon w-embed">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                             viewbox="0 0 24 24">
-                                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                                            <path fill="currentColor"
-                                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                        </svg>
-                                                    </div>
+                                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                    </svg></div>
                                                 </div>
                                             </div>
                                             <div class="data-category__h3_content hidden">
@@ -2619,49 +2155,34 @@
                                                     <a href="#" class="data-category__h4 w-inline-block">
                                                         <div class="data-category__h4_line-h"></div>
                                                         <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img
-                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
                                                         <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
-                                                                     height="24" viewbox="0 0 24 24">
-                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                    <path fill="currentColor"
-                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                                </svg>
-                                                            </div>
+                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                            </svg></div>
                                                         </div>
                                                     </a>
                                                     <a href="#" class="data-category__h4 w-inline-block">
                                                         <div class="data-category__h4_line-h"></div>
                                                         <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading"><img
-                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
                                                         <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
-                                                                     height="24" viewbox="0 0 24 24">
-                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                    <path fill="currentColor"
-                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                                </svg>
-                                                            </div>
+                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                            </svg></div>
                                                         </div>
                                                     </a>
                                                     <a href="#" class="data-category__h4 active w-inline-block">
                                                         <div class="data-category__h4_line-h"></div>
                                                         <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img
-                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
                                                         <div class="data-category__h4_load-complete">
-                                                            <div class="svg-icon w-embed">
-                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
-                                                                     height="24" viewbox="0 0 24 24">
-                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                    <path fill="currentColor"
-                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                                </svg>
-                                                            </div>
+                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                            </svg></div>
                                                         </div>
                                                     </a>
                                                 </div>
@@ -2688,13 +2209,10 @@
                         <div class="truncate">Section title</div>
                     </div>
                     <div class="rich-data-nav__item-icon">
-                        <div class="svg-icon w-embed">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor"
-                                      d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
-                            </svg>
-                        </div>
+                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
+                        </svg></div>
                     </div>
                 </a>
             </div>
@@ -2719,32 +2237,21 @@
                     </div>
                     <div class="location__facilities_header hidden">
                         <div class="location__facilities_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                                    <path fill="currentColor"
-                                          d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                                </svg>
-                            </div>
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                                <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                            </svg></div>
                         </div>
                         <div class="location__facilities_title">
-                            <div>This <span class="location__facilities_geo-type">location</span> has <span
-                                    class="location__facilities_facilities-value"><strong>0000</strong></span><strong>
-                                facilities</strong> in <span
-                                    class="location__facilities_categories-value"><strong>0000</strong></span><strong>
-                                categories</strong>.
-                            </div>
+                            <div>This <span class="location__facilities_geo-type">location</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> facilities</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
                         </div>
                     </div>
                     <div class="location__facilities_trigger hidden">
-                        <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d4" style="display:flex"
-                             class="location__facilities_expand">
+                        <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d4" style="display:flex" class="location__facilities_expand">
                             <div>Show facilities</div>
                         </div>
-                        <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d7" style="display:none"
-                             class="location__facilities_contract">
+                        <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d7" style="display:none" class="location__facilities_contract">
                             <div>Hide facilities</div>
                         </div>
                     </div>
@@ -2754,21 +2261,17 @@
                                 <div class="loading">
                                     <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                                     <div class="loading__text">
-                                        <div>Loading...</div>
+                                        <div>Loading... </div>
                                     </div>
                                 </div>
                             </div>
                             <div class="location__facilities_no-data hidden">
                                 <div class="no-data">
                                     <div class="no-data__icon">
-                                        <div class="svg-icon w-embed">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                 viewbox="0 0 24 24">
-                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                <path fill="currentColor"
-                                                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                                            </svg>
-                                        </div>
+                                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                                        </svg></div>
                                     </div>
                                     <div class="no-data__text">
                                         <div>No facilities for this location</div>
@@ -2780,14 +2283,10 @@
                                     <div class="location-facility__category">
                                         <div class="location-facility__header">
                                             <div class="location-facility__icon">
-                                                <div class="svg-icon w-embed">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" width="100%" height=""
-                                                         viewbox="0 0 24 24">
-                                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                                        <path fill="currentColor"
-                                                              d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                                    </svg>
-                                                </div>
+                                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                                </svg></div>
                                             </div>
                                             <div class="location-facility__name">
                                                 <div>Point data category</div>
@@ -2805,16 +2304,11 @@
                                             <div class="location-facility__item_value">
                                                 <div>0000</div>
                                             </div>
-                                            <div id="w-node-a4312e607bde-e148319d"
-                                                 class="location-facility__item_download">
-                                                <div class="svg-icon small w-embed">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                         viewbox="0 0 24 24">
-                                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                                        <path fill="currentColor"
-                                                              d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-                                                    </svg>
-                                                </div>
+                                            <div id="w-node-a4312e607bde-e148319d" class="location-facility__item_download">
+                                                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                                                </svg></div>
                                             </div>
                                         </a>
                                         <a href="#" class="location-facility__list_item last w-inline-block">
@@ -2824,23 +2318,16 @@
                                             <div class="location-facility__item_value">
                                                 <div>0000</div>
                                             </div>
-                                            <div id="w-node-a4312e607be7-e148319d"
-                                                 class="location-facility__item_download">
-                                                <div class="svg-icon small w-embed">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                         viewbox="0 0 24 24">
-                                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                                        <path fill="currentColor"
-                                                              d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-                                                    </svg>
-                                                </div>
+                                            <div id="w-node-a4312e607be7-e148319d" class="location-facility__item_download">
+                                                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                                                </svg></div>
                                             </div>
                                         </a>
                                     </div>
                                     <div class="location-facility__description">
-                                        <div>Description text that describes this point data category in relation to
-                                            surrounding locations
-                                        </div>
+                                        <div>Description text that describes this point data category in relation to surrounding locations</div>
                                     </div>
                                 </div>
                             </div>
@@ -2852,7 +2339,7 @@
                                     <div class="loading">
                                         <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                                         <div class="loading__text">
-                                            <div>Loading...</div>
+                                            <div>Loading... </div>
                                         </div>
                                     </div>
                                 </div>
@@ -2877,32 +2364,16 @@
                 <div>Search dropdown list items</div>
             </div>
             <div class="styles__area_block horizontal wide">
-                <div class="facility-tooltip">
-                    <div class="facility-tooltip__header">
-                        <div class="facility-tooltip__header_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="facility-tooltip__header_name">Loading...</div>
+                <div data-w-id="0cc195d0-8237-0a5c-88c5-6bd36b98a8c1" class="search__dropdown_list-item">
+                    <div class="search__list-item_location-name">
+                        <div class="truncate">Location name</div>
                     </div>
-                    <div class="facility-tooltip__scroll-wrapper">
-                        <div class="facility-tooltip__items">
-                            <div class="facility-tooltip__item last">
-                                <div class="tooltip__facility-item_label">Loading...</div>
-                                <div class="tooltip__facility-item_value">...</div>
-                            </div>
-                        </div>
+                    <div class="search__list-item_location-parent">
+                        <div class="truncate">Parent </div>
                     </div>
-                    <div class="facility-tooltip__open-modal">More info</div>
-                    <div class="facility-tooltip__close">
-                        <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                        </svg></div>
+                    <div id="w-node-6bd36b98a8c8-e148319d" class="search__list-item_location-type">
+                        <div class="truncate">Location Type</div>
                     </div>
-                    <div class="tooltip__notch"></div>
                 </div>
             </div>
             <div class="styles__area_block horizontal wide">
@@ -2911,7 +2382,7 @@
                         <div class="truncate">Location name</div>
                     </div>
                     <div class="search__list-item_location-parent">
-                        <div class="truncate">Parent</div>
+                        <div class="truncate">Parent </div>
                     </div>
                     <div id="w-node-bca9e2f0f20f-e148319d" class="search__list-item_location-type">
                         <div class="truncate">Location Type</div>
@@ -2931,13 +2402,10 @@
                     <div class="category-header__content">
                         <div class="category-header__title">
                             <div class="category-header__icon">
-                                <div class="svg-icon large w-embed">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor"
-                                              d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                    </svg>
-                                </div>
+                                <div class="svg-icon large w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg></div>
                             </div>
                             <div class="category-header__text">
                                 <h2 class="cc-clear">Category title</h2>
@@ -2961,14 +2429,11 @@
                         </div>
                     </div>
                     <div class="sub-category-header__description">
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros
-                            elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut
-                            commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem
-                            imperdiet. Nunc ut sem vitae risus tristique posuere.</p>
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. Nunc ut sem vitae risus tristique posuere.</p>
                     </div>
                     <div class="sub-category-header__key-metrics">
                         <div class="sub-category-header__key-metrics_title">
-                            <div>KEY METRICS for this indicator</div>
+                            <div>KEY METRICS for this indicator</div>
                         </div>
                         <div class="sub-category-header__key-metrics_wrap">
                             <div class="key-metric">
@@ -2980,9 +2445,7 @@
                                         <div>Metric title</div>
                                     </div>
                                     <div class="key-metric__description">
-                                        <div>Description text that describes this metric in relation to surrounding
-                                            locations
-                                        </div>
+                                        <div>Description text that describes this metric in relation to surrounding locations</div>
                                     </div>
                                 </div>
                             </div>
@@ -2995,9 +2458,7 @@
                                         <div>Metric title</div>
                                     </div>
                                     <div class="key-metric__description">
-                                        <div>Description text that describes this metric in relation to surrounding
-                                            locations
-                                        </div>
+                                        <div>Description text that describes this metric in relation to surrounding locations</div>
                                     </div>
                                 </div>
                             </div>
@@ -3010,9 +2471,7 @@
                                         <div>Metric title</div>
                                     </div>
                                     <div class="key-metric__description">
-                                        <div>Description text that describes this metric in relation to surrounding
-                                            locations
-                                        </div>
+                                        <div>Description text that describes this metric in relation to surrounding locations</div>
                                     </div>
                                 </div>
                             </div>
@@ -3025,9 +2484,7 @@
                                         <div>Metric title</div>
                                     </div>
                                     <div class="key-metric__description">
-                                        <div>Description text that describes this metric in relation to surrounding
-                                            locations
-                                        </div>
+                                        <div>Description text that describes this metric in relation to surrounding locations</div>
                                     </div>
                                 </div>
                             </div>
@@ -3047,34 +2504,24 @@
                         <div class="profile-indicator__options">
                             <div class="hover-menu">
                                 <div class="hover-menu__icon">
-                                    <div class="svg-icon w-embed">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                             viewbox="0 0 24 24">
-                                            <path fill="currentColor"
-                                                  d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
-                                        </svg>
-                                    </div>
+                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
+                                    </svg></div>
                                 </div>
                                 <div class="hover-menu__content">
                                     <div class="hover-menu__content_wrapper">
                                         <a href="#" class="hover-menu__content_item w-inline-block">
-                                            <div class="icon--small"><img
-                                                    src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c397204ee09f13_image-24px.svg"
-                                                    alt=""></div>
+                                            <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c397204ee09f13_image-24px.svg" alt=""></div>
                                             <div class="content__item_title">
                                                 <div>Save as image</div>
                                             </div>
                                         </a>
                                         <div class="hover-menu__content_item--no-link">
                                             <div class="icon--small">
-                                                <div class="svg-icon small w-embed">
-                                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                         viewbox="0 0 24 24">
-                                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                                        <path fill="currentColor"
-                                                              d="M21 6H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v8z"></path>
-                                                    </svg>
-                                                </div>
+                                                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                    <path fill="currentColor" d="M21 6H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v8z"></path>
+                                                </svg></div>
                                             </div>
                                             <div class="content__item_title">
                                                 <div>Chart values as:</div>
@@ -3089,9 +2536,7 @@
                                             </a>
                                         </div>
                                         <div class="hover-menu__content_item--no-link">
-                                            <div class="icon--small"><img
-                                                    src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c3974bdbe09f2e_download-24px.svg"
-                                                    alt=""></div>
+                                            <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c3974bdbe09f2e_download-24px.svg" alt=""></div>
                                             <div class="content__item_title">
                                                 <div>Click to download data:</div>
                                             </div>
@@ -3123,14 +2568,10 @@
                                         <div class="truncate">All values</div>
                                     </div>
                                     <div class="dropdown-menu__icon">
-                                        <div class="svg-icon w-embed">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                 viewbox="0 0 24 24">
-                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                <path fill="currentColor"
-                                                      d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                                            </svg>
-                                        </div>
+                                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                                        </svg></div>
                                     </div>
                                 </div>
                                 <div class="dropdown-menu__content scroll-element">
@@ -3148,7 +2589,7 @@
                         </div>
                         <div class="filter__dropdown_wrap disabled">
                             <div class="dropdown-menu__label">
-                                <div>FILTER BY:</div>
+                                <div>FILTER BY:</div>
                             </div>
                             <div class="dropdown-menu">
                                 <div class="dropdown-menu__trigger">
@@ -3156,14 +2597,10 @@
                                         <div class="truncate">All values</div>
                                     </div>
                                     <div class="dropdown-menu__icon">
-                                        <div class="svg-icon w-embed">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
-                                                 viewbox="0 0 24 24">
-                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                <path fill="currentColor"
-                                                      d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                                            </svg>
-                                        </div>
+                                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                                        </svg></div>
                                     </div>
                                 </div>
                                 <div class="dropdown-menu__content scroll-element">
@@ -3452,67 +2889,27 @@
                 <div class="facility-tooltip">
                     <div class="facility-tooltip__header">
                         <div class="facility-tooltip__header_icon">
-                            <div class="svg-icon w-embed">
-                                <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor"
-                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg>
-                            </div>
-                        </div>
-                        <div class="facility-tooltip__header_name">
-                            <div>Elim High School</div>
-                        </div>
-                    </div>
-                    <div class="facility-tooltip__items">
-                        <div class="facility-tooltip__item">
-                            <div class="tooltip__facility-item_label">
-                                <div>Address:</div>
-                            </div>
-                            <div class="tooltip__facility-item_value">
-                                <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris aliquet libero
-                                    ullamcorper, blandit felis sit amet, rhoncus eros. Nam sed dolor id quam ullamcorper
-                                    rhoncus.
-                                </div>
-                            </div>
-                        </div>
-                        <div class="facility-tooltip__item">
-                            <div class="tooltip__facility-item_label">
-                                <div>Phone:</div>
-                            </div>
-                            <div class="tooltip__facility-item_value">
-                                <div>09123901293</div>
-                            </div>
-                        </div>
-                        <div class="facility-tooltip__item">
-                            <div class="tooltip__facility-item_label">
-                                <div>Website:</div>
-                            </div>
-                            <div class="tooltip__facility-item_value">
-                                <div>
-                                    <a href="#">www.test.com</a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="facility-tooltip__item last">
-                            <div class="tooltip__facility-item_label">
-                                <div>Email:</div>
-                            </div>
-                            <div class="tooltip__facility-item_value">
-                                <div>
-                                    <a target="_blank" href="mailto:appletreenat@gmail.com">appletreenat@gmail.com</a>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="facility-tooltip__close">
-                        <div class="svg-icon svg-icon--no-size w-embed">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
                                 <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor"
-                                      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                            </svg>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
                         </div>
+                        <div class="facility-tooltip__header_name">Loading...</div>
+                    </div>
+                    <div class="facility-tooltip__scroll-wrapper">
+                        <div class="facility-tooltip__items">
+                            <div class="facility-tooltip__item last">
+                                <div class="tooltip__facility-item_label">Loading...</div>
+                                <div class="tooltip__facility-item_value">...</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="facility-tooltip__open-modal">More info</div>
+                    <div class="facility-tooltip__close">
+                        <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                        </svg></div>
                     </div>
                     <div class="tooltip__notch"></div>
                 </div>
@@ -3538,66 +2935,52 @@
             .location__description, .location__sources .profile-indicator {
                 padding-bottom: 0px;
             }
-
             .section {
                 padding-bottom: 20px;
             }
-
             .sub-category-header__key-metrics {
                 padding-bottom: 12px;
             }
-
             .profile-indicator__header {
                 margin-bottom: 0px;
             }
-
             .sub-category-header__title {
                 margin-bottom: 12px;
             }
-
             .profile-indicator__chart {
                 margin-top: 0px;
             }
-
             /*--hide unwanted elements in print--*/
             .nav, .login-modal, .category-header__link, .location__header, .profile-indicator__options, .sticky-header, .tutorial-modal, .styles, .map, .point-mapper, .data-mapper, .panel-toggles, .rich-data-nav, .rich-data-bumper, .rich-data-toggles {
                 display: none;
             }
-
             /*--avoid page breaks--*/
             .sub-category-header {
                 break-inside: avoid;
             }
-
             .profile-indicator {
                 break-inside: avoid;
             }
-
             /*--hide interaction buttons--*/
             .location-facility__list_item {
                 grid-template-columns: 4fr 1fr .0;
             }
-
             .location-facility__item_download {
                 display: none;
             }
-
             /*--adjust rich-data panel to fill page--*/
             .rich-data, .rich-data-content {
                 max-width: 100%;
                 width: 100%;
             }
-
             .rich-data-content {
                 padding: 0px;
                 filter: grayscale(100%);
             }
-
             /*--adjust text size--*/
             .body {
                 font-size: 12px !important;
             }
-
             /*--adjust charts--*/
             .bar-chart__row_bar {
                 background-color: #000 !important;
@@ -3605,17 +2988,13 @@
         }
     </style>
 </div>
-<script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5ecb7ed6bb713f2f4b48319b"
-        type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
-        crossorigin="anonymous"></script>
+<script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5ecb7ed6bb713f2f4b48319b" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
 <script src="js/webflow.js" type="text/javascript"></script>
-<!-- [if lte IE 9]>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
+<!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
 <style>
     #dev-tools {
-        z-index: 200;
+        z-index:200;
     }
-
     #map-download-title {
         position: fixed;
         top: 80px;
@@ -3626,7 +3005,6 @@
         font-weight: bold;
         color: white;
     }
-
     #map-download-legend {
         position: absolute;
         bottom: 50px;
@@ -3635,7 +3013,6 @@
         display: flex;
         justify-content: center;
     }
-
     #map-download-legend .map-options__legend_wrap {
         background: white;
         padding: 5px;
@@ -3650,8 +3027,7 @@
 <!--  Material design icons  -->
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 <!--  used the the autocomplete search box  -->
-<script crossorigin="anonymous" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E="
-        src="https://code.jquery.com/ui/1.12.0/jquery-ui.min.js"></script>
+<script crossorigin="anonymous" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E=" src="https://code.jquery.com/ui/1.12.0/jquery-ui.min.js"></script>
 <script src="https://bevacqua.github.io/dragula/dist/dragula.js"></script>
 <script>
     var drake = dragula({
@@ -3662,8 +3038,8 @@
 </script>
 <script src="js/index.js"></script>
 <script>
-    setTimeout(function () {
-        $('.w-webflow-badge').css({'display': 'none !important'});
+    setTimeout(function(){
+        $('.w-webflow-badge').css({'display':'none !important'});
     }, 2000);
 </script>
 <style>
@@ -3671,7 +3047,6 @@
     .leaflet-control-attribution {
         display: none !important;
     }
-
     /*------------------------------------- Truncation */
     .truncate {
         width: 100%;
@@ -3679,46 +3054,38 @@
         overflow: hidden;
         text-overflow: ellipsis;
     }
-
     /*------------------------------------- Hidden important */
     .hidden {
         display: none !important;
     }
-
     /*------------------------------------- Hide webflow items on deploy */
     .disabled {
         pointer-events: none;
     }
-
     /*------------------------------------- Hide scrollbar for Chrome, Safari and Opera */
     .no-scroll::-webkit-scrollbar {
         display: none;
     }
-
     /*------------------------------------- Hide scrollbar for IE and Edge */
     .no-scroll {
         -ms-overflow-style: none;
     }
-
     /*-------- Narrow scroll bar */
     /*width*/
     .narrow-scroll::-webkit-scrollbar {
-        width: 4px;
+        width:4px;
     }
-
     /*track*/
     .narrow-scroll::-webkit-scrollbar-track {
-        background: rgba(255, 255, 255, 0);
-        border-color: rgb(255, 255, 255);
+        background:rgba(255, 255, 255, 0);
+        border-color:rgb(255, 255, 255);
     }
-
     /*thumb*/
     .narrow-scroll::-webkit-scrollbar-thumb {
-        background: rgb(98, 98, 98);
-        border-color: rgb(51, 51, 51);
-        border-radius: 2px;
+        background:rgb(98, 98, 98);
+        border-color:rgb(51, 51, 51);
+        border-radius:2px;
     }
-
     /*-------- Custom slider checkbox */
     .switch {
         position: relative;
@@ -3726,13 +3093,11 @@
         width: 32px;
         height: 20px;
     }
-
     .switch input {
         opacity: 0;
         width: 0;
         height: 0;
     }
-
     .slider {
         position: absolute;
         cursor: pointer;
@@ -3744,7 +3109,6 @@
         -webkit-transition: .1s;
         transition: .1s;
     }
-
     .slider:before {
         position: absolute;
         content: "";
@@ -3756,31 +3120,25 @@
         -webkit-transition: .1s;
         transition: .1s;
     }
-
     input:checked + .slider {
         background-color: #3c3c3c;
     }
-
     input:checked + .slider:before {
         -webkit-transform: translateX(26px);
         -ms-transform: translateX(12px);
         transform: translateX(12px);
     }
-
     /* Rounded sliders */
     .slider.round {
         border-radius: 34px;
     }
-
     .slider.round:before {
         border-radius: 50%;
     }
-
     /*-------- Fixing Chart Lines */
     .bar-tooltip {
         z-index: 100;
     }
-
     line, .grid {
         stroke: #999;
     }

--- a/src/index.html
+++ b/src/index.html
@@ -2,3152 +2,3788 @@
 <!--  Last Published: Tue Dec 08 2020 09:13:20 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5ecb7ed6bb713f67e148319d" data-wf-site="5ecb7ed6bb713f2f4b48319b">
 <head>
-  <meta charset="utf-8">
-  <title>Wazimap NG</title>
-  <meta content="width=device-width, initial-scale=1" name="viewport">
-  <meta content="Webflow" name="generator">
-  <link href="css/normalize.css" rel="stylesheet" type="text/css">
-  <link href="css/webflow.css" rel="stylesheet" type="text/css">
-  <link href="css/wazimap-ng-v1.webflow.css" rel="stylesheet" type="text/css">
-  <style>@media (max-width:479px) {html.w-mod-js:not(.w-mod-ix) [data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825"] {-webkit-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);}html.w-mod-js:not(.w-mod-ix) [data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50"] {width:44PX;}html.w-mod-js:not(.w-mod-ix) [data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7"] {-webkit-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);-moz-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);-ms-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);}}</style>
-  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
-  <script type="text/javascript">WebFont.load({  google: {    families: ["Roboto:300,regular,italic,500,500italic,700,900"]  }});</script>
-  <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
-  <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon">
-  <link href="images/webclip.png" rel="apple-touch-icon">
-  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-93649482-25"></script>
-  <script>
+    <meta charset="utf-8">
+    <title>Wazimap NG</title>
+    <meta content="width=device-width, initial-scale=1" name="viewport">
+    <meta content="Webflow" name="generator">
+    <link href="css/normalize.css" rel="stylesheet" type="text/css">
+    <link href="css/webflow.css" rel="stylesheet" type="text/css">
+    <link href="css/wazimap-ng-v1.webflow.css" rel="stylesheet" type="text/css">
+    <style>@media (max-width: 479px) {
+        html.w-mod-js:not(.w-mod-ix) [data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825"] {
+            -webkit-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);
+            -moz-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);
+            -ms-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);
+            transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);
+        }
+
+        html.w-mod-js:not(.w-mod-ix) [data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50"] {
+            width: 44PX;
+        }
+
+        html.w-mod-js:not(.w-mod-ix) [data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7"] {
+            -webkit-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);
+            -moz-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);
+            -ms-transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);
+            transform: translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);
+        }
+    }</style>
+    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
+    <script type="text/javascript">WebFont.load({google: {families: ["Roboto:300,regular,italic,500,500italic,700,900"]}});</script>
+    <!-- [if lt IE 9]>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"
+            type="text/javascript"></script><![endif] -->
+    <script type="text/javascript">!function (o, c) {
+        var n = c.documentElement, t = " w-mod-";
+        n.className += t + "js", ("ontouchstart" in o || o.DocumentTouch && c instanceof DocumentTouch) && (n.className += t + "touch")
+    }(window, document);</script>
+    <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon">
+    <link href="images/webclip.png" rel="apple-touch-icon">
+    <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-93649482-25"></script>
+    <script>
         window.dataLayer = window.dataLayer || [];
+
         function gtag() {
             dataLayer.push(arguments);
         }
+
         const analyticsId = 'UA-93649482-25';
         gtag('js', new Date());
-        gtag('config', analyticsId, { 'send_page_view': false });
+        gtag('config', analyticsId, {'send_page_view': false});
         gtag('config', analyticsId, {
             'custom_map': {'dimension1': 'profile'}
         });
         window.gtag = gtag;
     </script>
-  <script src="https://kit.fontawesome.com/95e41092af.js" crossorigin="anonymous"></script>
+    <script src="https://kit.fontawesome.com/95e41092af.js" crossorigin="anonymous"></script>
 </head>
 <body class="body no-scroll">
-  <div class="login-modal hidden">
+<div class="login-modal hidden">
     <div class="login">
-      <div id="w-node-11a67e6ccd44-e148319d" class="login__title">
-        <h1 class="clear">Login Required</h1>
-      </div>
-      <div id="w-node-31f6ef2aede4-e148319d" data-w-id="138f8096-55b2-2cf7-756a-31f6ef2aede4" class="login__close">
-        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-            <path d="M0 0h24v24H0z" fill="none"></path>
-            <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-          </svg></div>
-      </div>
-      <div id="w-node-09c3cf7a9fe2-e148319d" class="login__description">
-        <div>This is private instance of Wazimap and requires you to be an authorized user to access it.</div>
-      </div>
-      <div id="w-node-222d0aaebade-e148319d" class="login__form">
-        <div class="form-block w-form">
-          <form id="wf-form-Login-Form" name="wf-form-Login-Form" data-name="Login Form"><label for="Email">Username</label><input type="email" class="text-field w-input" maxlength="256" name="Email" data-name="Email" placeholder="" id="Email" required=""><label for="Password">Password</label><input type="password" class="text-field w-input" maxlength="256" name="Password" data-name="Password" id="Password" required="">
-            <div class="login-form__actions"><label id="w-node-fefcf113a3cc-e148319d" class="w-checkbox login-form__checkbox">
-                <div class="w-checkbox-input w-checkbox-input--inputType-custom custom-checkbox"></div><input type="checkbox" id="checkbox-2" name="checkbox-2" data-name="Checkbox 2" style="opacity:0;position:absolute;z-index:-1"><span class="checkbox-label w-form-label">Remember me</span>
-              </label><input type="submit" value="Login" data-wait="Please wait..." id="w-node-fceb1157e41b-e148319d" class="button w-button">
-              <a id="w-node-25fe1e234621-e148319d" href="#">Forgot your password?</a>
-            </div>
-          </form>
-          <div class="w-form-done">
-            <div>Thank you! Your submission has been received!</div>
-          </div>
-          <div class="w-form-fail">
-            <div>Oops! Something went wrong while submitting the form.</div>
-          </div>
+        <div id="w-node-11a67e6ccd44-e148319d" class="login__title">
+            <h1 class="clear">Login Required</h1>
         </div>
-      </div>
-    </div>
-  </div>
-  <div class="tutorial-modal">
-    <div class="tutorial">
-      <div class="tutorial__header">
-        <div class="tutorial__title">
-          <h1 class="clear">How to use</h1>
+        <div id="w-node-31f6ef2aede4-e148319d" data-w-id="138f8096-55b2-2cf7-756a-31f6ef2aede4" class="login__close">
+            <div class="svg-icon w-embed">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor"
+                          d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                </svg>
+            </div>
         </div>
-        <div data-w-id="6ca2d157-b860-d2c0-78da-11837bc90d1d" data-testid="tutorial-close" class="tutorial__close">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-            </svg></div>
+        <div id="w-node-09c3cf7a9fe2-e148319d" class="login__description">
+            <div>This is private instance of Wazimap and requires you to be an authorized user to access it.</div>
         </div>
-      </div>
-      <div data-animation="cross" data-nav-spacing="4" data-duration="500" id="w-node-d1064d900402-e148319d" class="tutorial__slider w-slider">
-        <div class="mask w-slider-mask">
-          <div class="slide w-slide">
-            <div class="tutorial__slide-content">
-              <div class="tutorial__slide-info">
-                <div><span class="slide-info__title">Introduction:</span> <span class="slide-info__introduction">This website was developed to enable you to easily find spatial information related to geographic areas. By clicking on the map or using the search bar, you can navigate to an area of interest and find relevant information about it.</span></div>
-              </div>
-              <div class="tutorial__slide-image _1">
-                <div class="tutorial__slide_gradient bottom"></div>
-                <div class="tutorial__slide-number">
-                  <div>1/8</div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="slide w-slide">
-            <div class="tutorial__slide-content">
-              <div class="tutorial__slide-info">
-                <div><span class="slide-info__title">Location Search:</span> To get started, first select a location on the map or use the search box to find the location you would like to analyse.</div>
-              </div>
-              <div class="tutorial__slide-image _2">
-                <div class="tutorial__slide-number">
-                  <div>2/8</div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="slide w-slide">
-            <div class="tutorial__slide-content">
-              <div class="tutorial__slide-info">
-                <div><span class="slide-info__title">Location Panel:</span> Basic information for your selected location can be found in the Location Panel. Use the buttons to navigate to parent locations.</div>
-              </div>
-              <div class="tutorial__slide-image _2b">
-                <div class="tutorial__slide-number">
-                  <div>3/8</div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="slide w-slide">
-            <div class="tutorial__slide-content">
-              <div class="tutorial__slide-info">
-                <div><span class="slide-info__title">Rich Data:</span> To view rich data specific to the location you selected, open the Rich Data panel in the left toolbar.</div>
-              </div>
-              <div class="tutorial__slide-image _3">
-                <div class="tutorial__slide-number">
-                  <div>4/8</div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="slide w-slide">
-            <div class="tutorial__slide-content">
-              <div class="tutorial__slide-info">
-                <div><span class="slide-info__title">Point Mapper:</span> To add point data to the map, use the Point Mapper to show different facilities in that area.</div>
-              </div>
-              <div class="tutorial__slide-image _4">
-                <div class="tutorial__slide-number">
-                  <div>5/8</div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="slide w-slide">
-            <div class="tutorial__slide-content">
-              <div class="tutorial__slide-info">
-                <div><span class="slide-info__title">Data Mapper:</span> To overlay compatible datasets onto your location, open the Data Mapper and choose from the available indicators.</div>
-              </div>
-              <div class="tutorial__slide-image _5">
-                <div class="tutorial__slide-number">
-                  <div>6/8</div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="slide w-slide">
-            <div class="tutorial__slide-content">
-              <div class="tutorial__slide-info">
-                <div><span class="slide-info__title">Data Filtering:</span> Once you&#x27;ve mapped a data-set (eg. gender), use the Data Filter to select a sub-indicator for that data-set (eg. male)</div>
-              </div>
-              <div class="tutorial__slide-image _7">
-                <div class="tutorial__slide-number">
-                  <div>7/8</div>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div class="slide w-slide">
-            <div class="tutorial__slide-content">
-              <div class="tutorial__slide-info">
-                <div><span class="slide-info__title">Learn more:</span> For more information on how to use specific features, look out for tutorial icons. For an in-depth guide on using this site, please see our <a href="https://openup.gitbook.io/wazimap-ng-user-guide/" target="_blank">user manual</a>.</div>
-              </div>
-              <div class="tutorial__slide-image _7">
-                <div class="tutorial__slide-number">
-                  <div>8/8</div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="left-arrow w-slider-arrow-left">
-          <div class="tutorial__slide_button previous">
-            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                <path d="M0 0h24v24H0z" fill="none"></path>
-                <path fill="currentColor" d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path>
-              </svg></div>
-          </div>
-        </div>
-        <div class="right-arrow w-slider-arrow-right">
-          <div class="tutorial__slide_button next">
-            <div class="text-block">Next</div>
-          </div>
-        </div>
-        <div class="slide-nav w-slider-nav w-slider-nav-invert w-round"></div>
-      </div>
-    </div>
-  </div>
-  <div class="warning-modal hidden">
-    <div class="warning">
-      <div class="warning__header">
-        <div class="warning-title">
-          <h1 class="clear">Map boundary change</h1>
-        </div>
-      </div>
-      <div class="warning__content">
-        <div class="w-richtext">
-          <p>Changing your boundary type might deselect your current geography or adjust your view of the map.</p>
-          <p><strong>Are you sure you would like to proceed?</strong></p>
-        </div>
-      </div>
-      <div id="w-node-0df91218fa5c-e148319d" class="warning__actions">
-        <div id="w-node-0df91218fa5d-e148319d" class="dismiss__no-show">
-          <div class="html-embed w-embed">
-            <p><input type="checkbox" class="custom-checkbox" name="dismiss__no-show" id="no-show"></p>
-          </div>
-          <div class="checkbox-label">Don&#x27;t show again</div>
-        </div>
-        <div id="w-node-0df91218fa61-e148319d" class="button-wrapper">
-          <a href="#" class="button button--margin-right button--grey w-button">Cancel</a>
-          <a id="warning-proceed" href="#" class="button button--margin-right w-button">Proceed</a>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="main">
-    <div class="nav">
-      <div data-w-id="66ee4f1f-99f3-8310-c69c-b5d00bdac74c" style="opacity:1;display:none" class="nav__search-deselect"></div>
-      <div class="nav__shadow"></div>
-      <div class="nav__content">
-        <a id="w-node-926b3e9c855a-e148319d" href="#" class="nav__content_title w-inline-block">
-          <div class="nav__profile-logo"><img src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg" alt="" class="profile-logo"></div>
-        </a>
-        <div id="w-node-926b3e9c8568-e148319d" class="nav__content_search">
-          <div class="nav__search_input">
-            <div data-w-id="2331a044-806f-907c-13ce-926b3e9c8576" class="search__input w-form">
-              <form id="email-form" name="email-form" data-name="Email Form" method="post" class="form"><input type="text" class="location__search_input w-input" autocomplete="off" maxlength="256" name="Location" data-name="Location" placeholder="Search for a location..." id="Location">
-                <div class="location__search_loading hidden"><img src="images/loading.gif" alt=""></div>
-              </form>
-              <div class="w-form-done">
-                <div>Thank you! Your submission has been received!</div>
-              </div>
-              <div class="w-form-fail">
-                <div>Oops! Something went wrong while submitting the form.</div>
-              </div>
-            </div>
-            <div class="nav__search_button">
-              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"></path>
-                  <path fill="currentColor" d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
-                </svg></div>
-            </div>
-          </div>
-          <div style="display:none;opacity:0" class="nav__search_dropdown">
-            <div class="search__dropdown_plate">
-              <div class="search__dropdown_scroll narrow-scroll">
-                <div class="search__dropdown_content">
-                  <div class="search__dropdown_results-label">
-                    <div>Results (<span class="search__dropdown_results-value">0</span>):</div>
-                  </div>
-                  <div class="search__dropdown_list">
-                    <div class="search__dropdown_no-data">
-                      <div class="no-data">
-                        <div class="no-data__icon">
-                          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                              <path d="M0 0h24v24H0z" fill="none"></path>
-                              <path fill="currentColor" d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="no-data__text">
-                          <div>Start typing to begin...</div>
-                        </div>
-                      </div>
+        <div id="w-node-222d0aaebade-e148319d" class="login__form">
+            <div class="form-block w-form">
+                <form id="wf-form-Login-Form" name="wf-form-Login-Form" data-name="Login Form"><label for="Email">Username</label><input
+                        type="email" class="text-field w-input" maxlength="256" name="Email" data-name="Email"
+                        placeholder="" id="Email" required=""><label for="Password">Password</label><input
+                        type="password" class="text-field w-input" maxlength="256" name="Password" data-name="Password"
+                        id="Password" required="">
+                    <div class="login-form__actions"><label id="w-node-fefcf113a3cc-e148319d"
+                                                            class="w-checkbox login-form__checkbox">
+                        <div class="w-checkbox-input w-checkbox-input--inputType-custom custom-checkbox"></div>
+                        <input type="checkbox" id="checkbox-2" name="checkbox-2" data-name="Checkbox 2"
+                               style="opacity:0;position:absolute;z-index:-1"><span class="checkbox-label w-form-label">Remember me</span>
+                    </label><input type="submit" value="Login" data-wait="Please wait..."
+                                   id="w-node-fceb1157e41b-e148319d" class="button w-button">
+                        <a id="w-node-25fe1e234621-e148319d" href="#">Forgot your password?</a>
                     </div>
-                  </div>
+                </form>
+                <div class="w-form-done">
+                    <div>Thank you! Your submission has been received!</div>
                 </div>
-              </div>
+                <div class="w-form-fail">
+                    <div>Oops! Something went wrong while submitting the form.</div>
+                </div>
             </div>
-          </div>
         </div>
-        <div id="w-node-926b3e9c85a0-e148319d" class="nav__content_menu">
-          <div class="nav__link-wrap">
-            <a data-w-id="2331a044-806f-907c-13ce-926b3e9c8565" href="#" class="nav__link tutorial__open w-inline-block">
-              <div class="nav__link_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-                  </svg></div>
-              </div>
-              <div class="nav__link_text">
-                <div>Tutorial</div>
-              </div>
-            </a>
-            <a data-w-id="9ed47308-e332-9825-644e-4ad6bb204fab" href="#" class="nav__link hidden w-inline-block">
-              <div class="nav__link_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5c-1.11 0-2 .9-2 2v4h2V5h14v14H5v-4H3v4c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"></path>
-                  </svg></div>
-              </div>
-              <div class="nav__link_text">
-                <div>Login</div>
-              </div>
-            </a>
-          </div>
-          <div class="nav__menu-trigger hidden">
-            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
-              </svg></div>
-          </div>
+    </div>
+</div>
+<div class="tutorial-modal">
+    <div class="tutorial">
+        <div class="tutorial__header">
+            <div class="tutorial__title">
+                <h1 class="clear">How to use</h1>
+            </div>
+            <div data-w-id="6ca2d157-b860-d2c0-78da-11837bc90d1d" data-testid="tutorial-close" class="tutorial__close">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                    </svg>
+                </div>
+            </div>
         </div>
-      </div>
+        <div data-animation="cross" data-nav-spacing="4" data-duration="500" id="w-node-d1064d900402-e148319d"
+             class="tutorial__slider w-slider">
+            <div class="mask w-slider-mask">
+                <div class="slide w-slide">
+                    <div class="tutorial__slide-content">
+                        <div class="tutorial__slide-info">
+                            <div><span class="slide-info__title">Introduction:</span> <span
+                                    class="slide-info__introduction">This website was developed to enable you to easily find spatial information related to geographic areas. By clicking on the map or using the search bar, you can navigate to an area of interest and find relevant information about it.</span>
+                            </div>
+                        </div>
+                        <div class="tutorial__slide-image _1">
+                            <div class="tutorial__slide_gradient bottom"></div>
+                            <div class="tutorial__slide-number">
+                                <div>1/8</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="slide w-slide">
+                    <div class="tutorial__slide-content">
+                        <div class="tutorial__slide-info">
+                            <div><span class="slide-info__title">Location Search:</span> To get started, first select a
+                                location on the map or use the search box to find the location you would like to
+                                analyse.
+                            </div>
+                        </div>
+                        <div class="tutorial__slide-image _2">
+                            <div class="tutorial__slide-number">
+                                <div>2/8</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="slide w-slide">
+                    <div class="tutorial__slide-content">
+                        <div class="tutorial__slide-info">
+                            <div><span class="slide-info__title">Location Panel:</span> Basic information for your
+                                selected location can be found in the Location Panel. Use the buttons to navigate to
+                                parent locations.
+                            </div>
+                        </div>
+                        <div class="tutorial__slide-image _2b">
+                            <div class="tutorial__slide-number">
+                                <div>3/8</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="slide w-slide">
+                    <div class="tutorial__slide-content">
+                        <div class="tutorial__slide-info">
+                            <div><span class="slide-info__title">Rich Data:</span> To view rich data specific to the
+                                location you selected, open the Rich Data panel in the left toolbar.
+                            </div>
+                        </div>
+                        <div class="tutorial__slide-image _3">
+                            <div class="tutorial__slide-number">
+                                <div>4/8</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="slide w-slide">
+                    <div class="tutorial__slide-content">
+                        <div class="tutorial__slide-info">
+                            <div><span class="slide-info__title">Point Mapper:</span> To add point data to the map, use
+                                the Point Mapper to show different facilities in that area.
+                            </div>
+                        </div>
+                        <div class="tutorial__slide-image _4">
+                            <div class="tutorial__slide-number">
+                                <div>5/8</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="slide w-slide">
+                    <div class="tutorial__slide-content">
+                        <div class="tutorial__slide-info">
+                            <div><span class="slide-info__title">Data Mapper:</span> To overlay compatible datasets onto
+                                your location, open the Data Mapper and choose from the available indicators.
+                            </div>
+                        </div>
+                        <div class="tutorial__slide-image _5">
+                            <div class="tutorial__slide-number">
+                                <div>6/8</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="slide w-slide">
+                    <div class="tutorial__slide-content">
+                        <div class="tutorial__slide-info">
+                            <div><span class="slide-info__title">Data Filtering:</span> Once you&#x27;ve mapped a
+                                data-set (eg. gender), use the Data Filter to select a sub-indicator for that data-set
+                                (eg. male)
+                            </div>
+                        </div>
+                        <div class="tutorial__slide-image _7">
+                            <div class="tutorial__slide-number">
+                                <div>7/8</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="slide w-slide">
+                    <div class="tutorial__slide-content">
+                        <div class="tutorial__slide-info">
+                            <div><span class="slide-info__title">Learn more:</span> For more information on how to use
+                                specific features, look out for tutorial icons. For an in-depth guide on using this
+                                site, please see our <a href="https://openup.gitbook.io/wazimap-ng-user-guide/"
+                                                        target="_blank">user manual</a>.
+                            </div>
+                        </div>
+                        <div class="tutorial__slide-image _7">
+                            <div class="tutorial__slide-number">
+                                <div>8/8</div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="left-arrow w-slider-arrow-left">
+                <div class="tutorial__slide_button previous">
+                    <div class="svg-icon w-embed">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path>
+                        </svg>
+                    </div>
+                </div>
+            </div>
+            <div class="right-arrow w-slider-arrow-right">
+                <div class="tutorial__slide_button next">
+                    <div class="text-block">Next</div>
+                </div>
+            </div>
+            <div class="slide-nav w-slider-nav w-slider-nav-invert w-round"></div>
+        </div>
+    </div>
+</div>
+<div class="warning-modal hidden">
+    <div class="warning">
+        <div class="warning__header">
+            <div class="warning-title">
+                <h1 class="clear">Map boundary change</h1>
+            </div>
+        </div>
+        <div class="warning__content">
+            <div class="w-richtext">
+                <p>Changing your boundary type might deselect your current geography or adjust your view of the map.</p>
+                <p><strong>Are you sure you would like to proceed?</strong></p>
+            </div>
+        </div>
+        <div id="w-node-0df91218fa5c-e148319d" class="warning__actions">
+            <div id="w-node-0df91218fa5d-e148319d" class="dismiss__no-show">
+                <div class="html-embed w-embed">
+                    <p><input type="checkbox" class="custom-checkbox" name="dismiss__no-show" id="no-show"></p>
+                </div>
+                <div class="checkbox-label">Don&#x27;t show again</div>
+            </div>
+            <div id="w-node-0df91218fa61-e148319d" class="button-wrapper">
+                <a href="#" class="button button--margin-right button--grey w-button">Cancel</a>
+                <a id="warning-proceed" href="#" class="button button--margin-right w-button">Proceed</a>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="main">
+    <div class="nav">
+        <div data-w-id="66ee4f1f-99f3-8310-c69c-b5d00bdac74c" style="opacity:1;display:none"
+             class="nav__search-deselect"></div>
+        <div class="nav__shadow"></div>
+        <div class="nav__content">
+            <a id="w-node-926b3e9c855a-e148319d" href="#" class="nav__content_title w-inline-block">
+                <div class="nav__profile-logo"><img
+                        src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg"
+                        alt="" class="profile-logo"></div>
+            </a>
+            <div id="w-node-926b3e9c8568-e148319d" class="nav__content_search">
+                <div class="nav__search_input">
+                    <div data-w-id="2331a044-806f-907c-13ce-926b3e9c8576" class="search__input w-form">
+                        <form id="email-form" name="email-form" data-name="Email Form" method="post" class="form"><input
+                                type="text" class="location__search_input w-input" autocomplete="off" maxlength="256"
+                                name="Location" data-name="Location" placeholder="Search for a location..."
+                                id="Location">
+                            <div class="location__search_loading hidden"><img src="images/loading.gif" alt=""></div>
+                        </form>
+                        <div class="w-form-done">
+                            <div>Thank you! Your submission has been received!</div>
+                        </div>
+                        <div class="w-form-fail">
+                            <div>Oops! Something went wrong while submitting the form.</div>
+                        </div>
+                    </div>
+                    <div class="nav__search_button">
+                        <div class="svg-icon w-embed">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor"
+                                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+                <div style="display:none;opacity:0" class="nav__search_dropdown">
+                    <div class="search__dropdown_plate">
+                        <div class="search__dropdown_scroll narrow-scroll">
+                            <div class="search__dropdown_content">
+                                <div class="search__dropdown_results-label">
+                                    <div>Results (<span class="search__dropdown_results-value">0</span>):</div>
+                                </div>
+                                <div class="search__dropdown_list">
+                                    <div class="search__dropdown_no-data">
+                                        <div class="no-data">
+                                            <div class="no-data__icon">
+                                                <div class="svg-icon w-embed">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                         viewbox="0 0 24 24">
+                                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                                        <path fill="currentColor"
+                                                              d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"></path>
+                                                    </svg>
+                                                </div>
+                                            </div>
+                                            <div class="no-data__text">
+                                                <div>Start typing to begin...</div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div id="w-node-926b3e9c85a0-e148319d" class="nav__content_menu">
+                <div class="nav__link-wrap">
+                    <a data-w-id="2331a044-806f-907c-13ce-926b3e9c8565" href="#"
+                       class="nav__link tutorial__open w-inline-block">
+                        <div class="nav__link_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="nav__link_text">
+                            <div>Tutorial</div>
+                        </div>
+                    </a>
+                    <a data-w-id="9ed47308-e332-9825-644e-4ad6bb204fab" href="#"
+                       class="nav__link hidden w-inline-block">
+                        <div class="nav__link_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5c-1.11 0-2 .9-2 2v4h2V5h14v14H5v-4H3v4c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="nav__link_text">
+                            <div>Login</div>
+                        </div>
+                    </a>
+                </div>
+                <div class="nav__menu-trigger hidden">
+                    <div class="svg-icon w-embed">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
+                        </svg>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
     <div class="map">
-      <div class="map-about hidden">
-        <div class="map-about__icon">
-          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
-            </svg></div>
-        </div>
-        <div class="map-about__profile-name">
-          <div>Profile name</div>
-        </div>
-        <div>. <a href="#">Learn more</a>
-          <a href="#"></a>
-        </div>
-      </div>
-      <div class="map-location">
-        <div class="map-location__tags">
-          <div title="Click to make this your primary search" class="location-tag__loading">
-            <div class="location-tag__type">
-              <div>LOCATION TYPE</div>
-            </div>
-            <div class="location-tag__name">
-              <div class="truncate text-center">Loading...</div>
-            </div>
-            <div class="location-tag__loading-icon"><img src="images/loading.gif" width="10" alt=""></div>
-          </div>
-        </div>
-        <div class="map-location__info"></div>
-      </div>
-      <div class="map-options hidden">
-        <div class="map-options__filters">
-          <div class="map-options__filters_header">
-            <div class="filter__header_sub-indicator">
-              <div class="filters__header_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                  </svg></div>
-              </div>
-              <div class="filters__header_name">
-                <div class="truncate">indicator name</div>
-              </div>
-            </div>
-            <div data-w-id="a0a0a80b-723d-9f06-08f8-22ecf4a4bddb" class="filters__header_toggle">
-              <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="toggle-icon-v--first w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"></path>
-                  <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
-                </svg></div>
-              <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="toggle-icon-v--last w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"></path>
-                  <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
-                </svg></div>
-            </div>
-            <div data-w-id="f7f05345-5dc5-101e-109a-a0291cc7b897" class="filters__header_close">
-              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"></path>
-                  <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                </svg></div>
-            </div>
-          </div>
-          <div style="display:flex" class="map-options__filters_content">
-            <div class="mapping-options__filter">
-              <div class="mapping-options__filter_label">
-                <div>Select a value:</div>
-              </div>
-              <div data-w-id="c3edb6cb-8fc8-3508-f112-94613483dd79" class="mapping-options__filter_menu">
-                <div class="dropdown-menu__trigger narrow">
-                  <div class="dropdown-menu__selected-item">
-                    <div class="truncate">All values</div>
-                  </div>
-                  <div class="dropdown-menu__icon">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+        <div class="map-about hidden">
+            <div class="map-about__icon">
+                <div class="svg-icon small w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
                         <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                      </svg></div>
-                  </div>
+                        <path fill="currentColor"
+                              d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
+                    </svg>
                 </div>
-                <div class="dropdown-menu__content position-top scroll-element">
-                  <div class="dropdown__list_item selected">
-                    <div class="truncate">All values</div>
-                  </div>
-                  <div class="dropdown__list_item">
-                    <div class="truncate">Value</div>
-                  </div>
-                </div>
-              </div>
             </div>
-            <div class="mapping-options__filter disabled">
-              <div class="mapping-options__filter_label">
-                <div>FILTER BY:</div>
-              </div>
-              <div data-w-id="fd26a4e0-f0f7-aaf0-9eee-32c6e9fb2e19" class="mapping-options__filter_menu">
-                <div class="dropdown-menu__trigger narrow">
-                  <div class="dropdown-menu__selected-item">
-                    <div class="truncate">All filters</div>
-                  </div>
-                  <div class="dropdown-menu__icon">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="dropdown-menu__content position-top scroll-element">
-                  <div class="dropdown__list_item selected">
-                    <div class="truncate">All Filters</div>
-                  </div>
-                  <div class="dropdown__list_item">
-                    <div class="truncate">Filter</div>
-                  </div>
-                </div>
-              </div>
+            <div class="map-about__profile-name">
+                <div>Profile name</div>
             </div>
-          </div>
+            <div>. <a href="#">Learn more</a>
+                <a href="#"></a>
+            </div>
         </div>
-        <div class="map-options__legend">
-          <div class="map-options__legend_label">
-            <div>LEGEND:</div>
-          </div>
-          <div class="map-options__legend_wrap">
-            <div class="map-options__legend_loading">
-              <div class="truncate">Loading...</div>
-              <div class="legend-block__loading-icon"><img src="images/loading.gif" alt=""></div>
-            </div>
-          </div>
-        </div>
-        <div style="display:flex" class="map-options__context">
-          <div class="map-option__context_text">
-            <div>Indicator context</div>
-          </div>
-          <div data-w-id="dfcf026d-123b-ec2d-3d1f-5646d4025e7b" class="map-options__context_tooltip">
-            <div style="display:none" class="tooltip">
-              <div class="tooltip-card dark">
-                <div class="tooltip-text">
-                  <div>Tooltip text</div>
+        <div class="map-location">
+            <div class="map-location__tags">
+                <div title="Click to make this your primary search" class="location-tag__loading">
+                    <div class="location-tag__type">
+                        <div>LOCATION TYPE</div>
+                    </div>
+                    <div class="location-tag__name">
+                        <div class="truncate text-center">Loading...</div>
+                    </div>
+                    <div class="location-tag__loading-icon"><img src="images/loading.gif" width="10" alt=""></div>
                 </div>
-                <div class="tooltip-notch dark"></div>
-              </div>
             </div>
-            <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                <path d="M0 0h24v24H0z" fill="none"></path>
-                <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
-              </svg></div>
-          </div>
+            <div class="map-location__info"></div>
         </div>
-      </div>
-      <div class="map-geo-select hidden">
-        <div class="mag-geo__dropdown_wrap">
-          <div class="dropdown-menu__label">
-            <div>BOUNDARY type select:</div>
-          </div>
-          <div class="dropdown-menu">
-            <div class="dropdown-menu__trigger">
-              <div class="dropdown-menu__selected-item">
-                <div class="truncate">Loading...</div>
-              </div>
-              <div class="dropdown-menu__icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+        <div class="map-options hidden">
+            <div class="map-options__filters">
+                <div class="map-options__filters_header">
+                    <div class="filter__header_sub-indicator">
+                        <div class="filters__header_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="filters__header_name">
+                            <div class="truncate">indicator name</div>
+                        </div>
+                    </div>
+                    <div data-w-id="a0a0a80b-723d-9f06-08f8-22ecf4a4bddb" class="filters__header_toggle">
+                        <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)"
+                             class="toggle-icon-v--first w-embed">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
+                            </svg>
+                        </div>
+                        <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)"
+                             class="toggle-icon-v--last w-embed">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
+                            </svg>
+                        </div>
+                    </div>
+                    <div data-w-id="f7f05345-5dc5-101e-109a-a0291cc7b897" class="filters__header_close">
+                        <div class="svg-icon w-embed">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor"
+                                      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </div>
+                <div style="display:flex" class="map-options__filters_content">
+                    <div class="mapping-options__filter">
+                        <div class="mapping-options__filter_label">
+                            <div>Select a value:</div>
+                        </div>
+                        <div data-w-id="c3edb6cb-8fc8-3508-f112-94613483dd79" class="mapping-options__filter_menu">
+                            <div class="dropdown-menu__trigger narrow">
+                                <div class="dropdown-menu__selected-item">
+                                    <div class="truncate">All values</div>
+                                </div>
+                                <div class="dropdown-menu__icon">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="dropdown-menu__content position-top scroll-element">
+                                <div class="dropdown__list_item selected">
+                                    <div class="truncate">All values</div>
+                                </div>
+                                <div class="dropdown__list_item">
+                                    <div class="truncate">Value</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="mapping-options__filter disabled">
+                        <div class="mapping-options__filter_label">
+                            <div>FILTER BY:</div>
+                        </div>
+                        <div data-w-id="fd26a4e0-f0f7-aaf0-9eee-32c6e9fb2e19" class="mapping-options__filter_menu">
+                            <div class="dropdown-menu__trigger narrow">
+                                <div class="dropdown-menu__selected-item">
+                                    <div class="truncate">All filters</div>
+                                </div>
+                                <div class="dropdown-menu__icon">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="dropdown-menu__content position-top scroll-element">
+                                <div class="dropdown__list_item selected">
+                                    <div class="truncate">All Filters</div>
+                                </div>
+                                <div class="dropdown__list_item">
+                                    <div class="truncate">Filter</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="map-options__legend">
+                <div class="map-options__legend_label">
+                    <div>LEGEND:</div>
+                </div>
+                <div class="map-options__legend_wrap">
+                    <div class="map-options__legend_loading">
+                        <div class="truncate">Loading...</div>
+                        <div class="legend-block__loading-icon"><img src="images/loading.gif" alt=""></div>
+                    </div>
+                </div>
+            </div>
+            <div style="display:flex" class="map-options__context">
+                <div class="map-option__context_text">
+                    <div>Indicator context</div>
+                </div>
+                <div data-w-id="dfcf026d-123b-ec2d-3d1f-5646d4025e7b" class="map-options__context_tooltip">
+                    <div style="display:none" class="tooltip">
+                        <div class="tooltip-card dark">
+                            <div class="tooltip-text">
+                                <div>Tooltip text</div>
+                            </div>
+                            <div class="tooltip-notch dark"></div>
+                        </div>
+                    </div>
+                    <div class="svg-icon small w-embed">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor"
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
+                        </svg>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="map-geo-select hidden">
+            <div class="mag-geo__dropdown_wrap">
+                <div class="dropdown-menu__label">
+                    <div>BOUNDARY type select:</div>
+                </div>
+                <div class="dropdown-menu">
+                    <div class="dropdown-menu__trigger">
+                        <div class="dropdown-menu__selected-item">
+                            <div class="truncate">Loading...</div>
+                        </div>
+                        <div class="dropdown-menu__icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="dropdown-menu__content dropdown-menu__content--top scroll-element">
+                        <div class="dropdown__list_item selected">
+                            <div class="truncate">Loading...</div>
+                        </div>
+                        <div class="dropdown__list_item">
+                            <div class="truncate">Loading...</div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div title="Download map" class="map-download">
+            <div class="svg-icon w-embed">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
                     <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                  </svg></div>
-              </div>
+                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                </svg>
             </div>
-            <div class="dropdown-menu__content dropdown-menu__content--top scroll-element">
-              <div class="dropdown__list_item selected">
-                <div class="truncate">Loading...</div>
-              </div>
-              <div class="dropdown__list_item">
-                <div class="truncate">Loading...</div>
-              </div>
-            </div>
-          </div>
         </div>
-      </div>
-      <div title="Download map" class="map-download">
-        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-            <path d="M0 0h24v24H0z" fill="none"></path>
-            <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-          </svg></div>
-      </div>
-      <div id="main-map" class="map-area"></div>
+        <div id="main-map" class="map-area"></div>
     </div>
     <div class="rich-data">
-      <div data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825" class="rich-data-nav">
-        <div data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7" class="rich-data-nav__toggle">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M3 18h13v-2H3v2zm0-5h10v-2H3v2zm0-7v2h13V6H3zm18 9.59L17.42 12 21 8.41 19.59 7l-5 5 5 5L21 15.59z"></path>
-            </svg></div>
-        </div>
-        <div class="rich-data-nav__list">
-          <a href="#top" class="rich-data-nav__item w-inline-block">
-            <div class="rich-data-nav__item-text">
-              <div class="truncate">Summary</div>
-            </div>
-            <div class="rich-data-nav__item-icon">
-              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"></path>
-                  <path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
-                </svg></div>
-            </div>
-          </a>
-        </div>
-      </div>
-      <div data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50" class="rich-data-bumper"></div>
-      <div class="rich-data-content">
-        <div class="rich-data__shadow"></div>
-        <div style="-webkit-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="sticky-header">
-          <div title="Click to make this your primary search" class="sticky-header__current-location">
-            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-            <div class="loading__text">
-              <div class="truncate">Loading... </div>
-            </div>
-          </div>
-          <div class="sticky-header__tutorial hidden">
-            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                <path d="M0 0h24v24H0z" fill="none"></path>
-                <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-              </svg></div>
-          </div>
-        </div>
-        <section class="section header">
-          <div id="top" class="section-link"></div>
-          <div class="location__header">
-            <div class="location__breadcrumbs hidden">
-              <div class="label">
-                <div>Navigate to:</div>
-              </div>
-              <div class="breadcrumb">
-                <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                <div class="loading__text">
-                  <div>Loading... </div>
-                </div>
-              </div>
-            </div>
-            <div class="location__tutorial hidden">
-              <div class="location__tutorial_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-                  </svg></div>
-              </div>
-              <div>Quick tutorial</div>
-            </div>
-          </div>
-          <div data-w-id="a462ef20-a798-735c-f166-106a34080855" class="location__title">
-            <div class="loading">
-              <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-              <div class="loading__text">
-                <div>Loading... </div>
-              </div>
-            </div>
-          </div>
-          <div class="location__description hidden">
-            <div>A <span class="location-type">Location type</span> in <span class="parent-geography">parent geography</span></div>
-          </div>
-          <div class="location__facilities">
-            <div class="location__facilities_no-data hidden">
-              <div class="no-data">
-                <div class="no-data__icon">
-                  <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                      <path d="M0 0h24v24H0z" fill="none"></path>
-                      <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                    </svg></div>
-                </div>
-                <div class="no-data__text">
-                  <div>No facilities for this location</div>
-                </div>
-              </div>
-            </div>
-            <div class="location__facilities_loading">
-              <div class="loading">
-                <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                <div class="loading__text">
-                  <div>Loading... </div>
-                </div>
-              </div>
-            </div>
-            <div class="location__facilities_header hidden">
-              <div class="location__facilities_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                  </svg></div>
-              </div>
-              <div class="location__facilities_title">
-                <div>This <span class="location__facilities_geo-type">location</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> facilities</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
-              </div>
-            </div>
-            <div class="location__facilities_trigger hidden">
-              <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6ad" style="display:flex" class="location__facilities_expand">
-                <div>Show facilities</div>
-              </div>
-              <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6b0" style="display:none" class="location__facilities_contract">
-                <div>Hide facilities</div>
-              </div>
-            </div>
-            <div style="height:0PX" class="location__facilities_content">
-              <div class="location__facilities_content-wrapper">
-                <div class="location__facilities_sources">
-                  <div class="label">
-                    <div>Sources:</div>
-                  </div>
-                  <div class="location__sources_loading">
-                    <div class="loading">
-                      <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                      <div class="loading__text">
-                        <div>Loading... </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="location__sources_no-data hidden">
-                    <div class="no-data">
-                      <div class="no-data__text">
-                        <div>No source data available</div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-        <div class="section">
-          <div class="section-link"></div>
-        </div>
-      </div>
-      <div class="rich-data-toggles">
-        <div data-w-id="1b738c3c-f509-9ebc-f15d-d66894a02164" class="panel-toggle rich-data-panel__close cc-active">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-            </svg></div>
-          <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Rich Data</div>
-            </div>
-            <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-        <div data-w-id="1260faa6-080e-87e0-2b01-fe2eba016dcb" class="panel-toggle point-mapper-panel__open">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-              <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-            </svg></div>
-          <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Point Mapper</div>
-            </div>
-            <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-        <div data-w-id="ef6902f7-5288-a426-a2e6-ee2a693e86d7" class="panel-toggle data-mapper-panel__open">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-            </svg></div>
-          <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Data Mapper</div>
-            </div>
-            <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="point-mapper">
-      <div class="point-mapper-content narrow-scroll">
-        <div class="point-mapper-content__header">
-          <div class="point-data__header_icon">
-            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                <path d="M0 0h24v24H0z" fill="none"></path>
-                <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-              </svg></div>
-          </div>
-          <div class="point-data__header_title">
-            <div>Point Mapper </div>
-          </div>
-        </div>
-        <div class="point-mapper-content__description">
-          <div>Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong></div>
-        </div>
-        <div class="point-mapper-content__loading">
-          <div class="loading">
-            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-            <div class="loading__text">
-              <div>Loading... </div>
-            </div>
-          </div>
-        </div>
-        <div class="point-mapper-content__no-data hidden">
-          <div class="no-data">
-            <div class="no-data__icon">
-              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"></path>
-                  <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                </svg></div>
-            </div>
-            <div class="no-data__text">
-              <div>No points available for this location</div>
-            </div>
-          </div>
-        </div>
-        <div class="point-mapper-content__list"></div>
-      </div>
-      <div class="point-mapper-toggles">
-        <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de47" class="panel-toggle rich-data-panel__open">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-            </svg></div>
-          <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Rich Data</div>
-            </div>
-            <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-        <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de4a" class="panel-toggle point-mapper-panel__close cc-active">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-              <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-            </svg></div>
-          <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Point Mapper</div>
-            </div>
-            <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-        <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de49" class="panel-toggle data-mapper-panel__open">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-            </svg></div>
-          <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Data Mapper</div>
-            </div>
-            <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="data-mapper">
-      <div class="data-mapper-content narrow-scroll">
-        <div class="data-mapper-content__header">
-          <div class="point-data__header_icon">
-            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                <path d="M0 0h24v24H0z" fill="none"></path>
-                <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-              </svg></div>
-          </div>
-          <div class="point-data__header_title">
-            <div>Data Mapper</div>
-          </div>
-        </div>
-        <div class="data-mapper-content__description">
-          <div>Explore data categories available for this location. Click or tap a sub-indicator to show it on the map.<strong><br></strong></div>
-        </div>
-        <div class="data-mapper-content__loading">
-          <div class="loading">
-            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-            <div class="loading__text">
-              <div>Loading... </div>
-            </div>
-          </div>
-        </div>
-        <div class="data-mapper-content__no-data hidden">
-          <div class="no-data__icon">
-            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                <path d="M0 0h24v24H0z" fill="none"></path>
-                <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-              </svg></div>
-          </div>
-          <div>The Data Mapper cannot be used with this location as it doesn&#x27;t contain any sub-areas which can be used for mapping</div>
-        </div>
-        <div class="data-mapper-content__list"></div>
-      </div>
-      <div class="data-mapper-toggles">
-        <div data-w-id="82de420b-3451-8ea3-a5a4-f892b059998e" class="panel-toggle rich-data-panel__open">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-            </svg></div>
-          <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Rich Data</div>
-            </div>
-            <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-        <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599990" class="panel-toggle point-mapper-panel__open">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-              <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-            </svg></div>
-          <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Point Mapper</div>
-            </div>
-            <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-        <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599992" class="panel-toggle data-mapper-panel__close cc-active">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-            </svg></div>
-          <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Data Mapper</div>
-            </div>
-            <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="panel-toggles">
-      <div data-w-id="b8845a6b-d018-3723-9163-c2bb32f2a4ea" class="panel-toggle rich-data-panel__open">
-        <div class="panel-toggle__tooltip">
-          <div class="panel-toggle__tooltip_text">
-            <div>Rich Data</div>
-          </div>
-          <div class="panel-toggle__tooltip_notch"></div>
-        </div>
-        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-            <path d="M0 0h24v24H0z" fill="none"></path>
-            <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-          </svg></div>
-      </div>
-      <div data-w-id="cb33504b-ce21-a841-3478-0f9742bd5340" class="panel-toggle point-mapper-panel__open">
-        <div class="panel-toggle__tooltip">
-          <div class="panel-toggle__tooltip_text">
-            <div>Point Mapper</div>
-          </div>
-          <div class="panel-toggle__tooltip_notch"></div>
-        </div>
-        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-            <path d="M0 0h24v24H0z" fill="none"></path>
-            <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-            <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-          </svg></div>
-      </div>
-      <div data-w-id="6207c761-ee3d-87bf-d0fb-b9250b5408ec" class="panel-toggle data-mapper-panel__open">
-        <div class="panel-toggle__tooltip">
-          <div class="panel-toggle__tooltip_text">
-            <div>Data Mapper</div>
-          </div>
-          <div class="panel-toggle__tooltip_notch"></div>
-        </div>
-        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-            <path d="M0 0h24v24H0z" fill="none"></path>
-            <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-          </svg></div>
-      </div>
-    </div>
-  </div>
-  <div class="styles hidden">
-    <div class="styles__wrapper">
-      <div class="styles__section">
-        <div class="styles__title">
-          <div>General</div>
-        </div>
-        <div class="styles__subsection">
-          <div>Data sources</div>
-        </div>
-        <div class="styles__title">
-          <div>Point Mapper</div>
-        </div>
-        <div class="styles__subsection">
-          <div>Categories</div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div class="point-mapper__h1_trigger point-mapper__h1--default-closed">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-              <div class="point-mapper__h1_trigger-arrow">
-                <div class="fas fa-angle-up"></div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_content default-state--closed">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-1">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+        <div data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825" class="rich-data-nav">
+            <div data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7" class="rich-data-nav__toggle">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
                         <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
+                        <path fill="currentColor"
+                              d="M3 18h13v-2H3v2zm0-5h10v-2H3v2zm0-7v2h13V6H3zm18 9.59L17.42 12 21 8.41 19.59 7l-5 5 5 5L21 15.59z"></path>
+                    </svg>
                 </div>
-                <div class="point-mapper__h2">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-1">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
             </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div class="point-mapper__h1_trigger point-mapper__h1--default-open">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-              <div class="point-mapper__h1_trigger-arrow">
-                <div class="fas fa-angle-up"></div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_content default-state--open">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-1">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-1">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="e0cdcac6-d5b6-2780-3500-919c8eb3a735" class="point-mapper__h1_trigger">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-1">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-1">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="555868a6-ac7f-4f39-8af1-54b777afa871" class="point-mapper__h1_trigger theme-1 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-1">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-1 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-1">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="6c86cd6d-a3de-4bf1-d2ef-1b52d687bf4e" class="point-mapper__h1_trigger theme-2 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-2">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-2 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-2">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="bf6a46d9-86a7-67f0-4a2e-794e9e22a39c" class="point-mapper__h1_trigger theme-3 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-3">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-3 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-3">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="4cef7f0e-21b5-0f03-d39b-d81f3f762e9b" class="point-mapper__h1_trigger theme-4 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-4">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-4 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-4">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="7744e72b-62fe-c3cd-e2b1-d418a4c81926" class="point-mapper__h1_trigger theme-5 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-5">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-5 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-5">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="ac8e408e-8dfd-2bd2-473a-7f80ffe5d8da" class="point-mapper__h1_trigger theme-6 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-6">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-6 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-6">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="9cf08a1c-eea4-40f7-7584-7a22af1533c0" class="point-mapper__h1_trigger theme-7 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-7">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-7 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-7">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="c7b0b95d-3477-0e3c-db3a-98e3a48fa33a" class="point-mapper__h1_trigger theme-8 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-8">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-8 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-8">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="5a41969a-edbe-1d60-39e9-b0079ac64c15" class="point-mapper__h1_trigger theme-9 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-9">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-9 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div title="test test" class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-9">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block">
-          <div class="point-mapper__h1">
-            <div data-w-id="9a2d4f34-e296-5da4-f30e-b15ac204c0da" class="point-mapper__h1_trigger theme-10 active">
-              <div class="point-data__h1_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="point-data__h1_name">
-                <div class="truncate">Category Name</div>
-              </div>
-            </div>
-            <div class="point-mapper__h1_checkbox">
-              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                  <input type="checkbox">
-                  <span class="slider round"></span>
-                </label></div>
-            </div>
-            <div style="display:block" class="point-mapper__h1_content">
-              <div class="point-mapper__h2_wrapper">
-                <div class="point-mapper__h2 theme-10">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 theme-10 active">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-                <div class="point-mapper__h2 last theme-10">
-                  <div class="point-mapper__h2_line-h"></div>
-                  <div class="point-mapper__h2_label">
-                    <div class="point-mapper__h2_name">
-                      <div class="truncate">Point data name</div>
-                    </div>
-                    <div class="point-mapper__h2_source">
-                      <div class="truncate">Point data source name</div>
-                    </div>
-                  </div>
-                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                  <div class="point-mapper__h2_load-complete hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                      </svg></div>
-                  </div>
-                </div>
-              </div>
-              <div class="point-data__h2_line-v"></div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="styles__section">
-        <div class="styles__title">
-          <div>Map Location</div>
-        </div>
-        <div class="styles__subsection">
-          <div>Location tags</div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <div title="Click to make this your primary search" class="location-tag">
-            <div class="location-tag__type">
-              <div>Location type</div>
-            </div>
-            <div class="location-tag__name">
-              <div class="truncate text-center">Location name</div>
-            </div>
-            <div class="location-tag__loading-icon"><img src="images/loading.gif" alt=""></div>
-          </div>
-          <div title="Click to make this your primary search" class="location-tag active">
-            <div class="location-tag__type">
-              <div>Location type</div>
-            </div>
-            <div class="location-tag__name">
-              <div class="truncate text-center">Location name</div>
-            </div>
-            <div class="location-tag__loading-icon hidden"><img src="images/loading.gif" alt=""></div>
-          </div>
-        </div>
-        <div class="styles__subsection">
-          <div>Location tags</div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <div class="location-highlight">
-            <div class="location-highlight__title">
-              <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)</div>
-            </div>
-            <div class="location-highlight__value">
-              <div class="truncate">Value</div>
-            </div>
-          </div>
-          <div class="location-highlight last">
-            <div class="location-highlight__title">
-              <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)</div>
-            </div>
-            <div class="location-highlight__value">
-              <div class="truncate">Value</div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="styles__section">
-        <div class="styles__title">
-          <div>Data Mapper</div>
-        </div>
-        <div class="styles__subsection">
-          <div>Categories</div>
-        </div>
-        <div class="styles__area_block">
-          <div class="data-category">
-            <div href="#" class="data-category__h1_trigger">
-              <div class="data-category__h1_header">
-                <div class="data-category__h1_icon">
-                  <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                      <path d="M0 0h24v24H0z" fill="none"></path>
-                      <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                    </svg></div>
-                </div>
-                <div class="data-category__h1_title">
-                  <div class="truncate">Category</div>
-                </div>
-              </div>
-              <div class="data-category__h1_toggle toggle-icon-v">
-                <div class="toggle-icon-v--first w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
-                  </svg></div>
-                <div class="toggle-icon-v--last w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
-                  </svg></div>
-              </div>
-            </div>
-            <div class="data-category__h1_content">
-              <div class="data-category__h1_wrapper">
-                <div class="data-category__h2">
-                  <div href="#" class="data-category__h2_trigger">
-                    <div class="truncate">Subcategory</div>
-                  </div>
-                  <div class="data-category__h2_content">
-                    <div class="data-category__h2_wrapper">
-                      <div class="data-category__h3">
-                        <div data-w-id="d9dcf788-413f-9049-8723-d6b050277cba" class="data-category__h3_trigger">
-                          <div class="truncate">Indicator</div>
-                          <div class="data-category__h3_loading hidden"><img src="images/loading.gif" alt=""></div>
-                          <div class="data-category__h3_load-complete hidden">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+            <div class="rich-data-nav__list">
+                <a href="#top" class="rich-data-nav__item w-inline-block">
+                    <div class="rich-data-nav__item-text">
+                        <div class="truncate">Summary</div>
+                    </div>
+                    <div class="rich-data-nav__item-icon">
+                        <div class="svg-icon w-embed">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
                                 <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                              </svg></div>
-                          </div>
+                                <path fill="currentColor"
+                                      d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
+                            </svg>
                         </div>
-                        <div style="height:0PX" class="data-category__h3_content">
-                          <div class="data-category__h3_wrapper">
-                            <div class="data-category__h4_line-v"></div>
-                            <a href="#" class="data-category__h4 w-inline-block">
-                              <div class="data-category__h4_line-h"></div>
-                              <div class="truncate">Subindicator</div>
-                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                              <div class="data-category__h4_load-complete hidden">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                  </svg></div>
-                              </div>
-                            </a>
-                            <a href="#" class="data-category__h4 w-inline-block">
-                              <div class="data-category__h4_line-h"></div>
-                              <div class="truncate">Subindicator</div>
-                              <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
-                              <div class="data-category__h4_load-complete hidden">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                  </svg></div>
-                              </div>
-                            </a>
-                            <a href="#" class="data-category__h4 active w-inline-block">
-                              <div class="data-category__h4_line-h"></div>
-                              <div class="truncate">Subindicator</div>
-                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                              <div class="data-category__h4_load-complete">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                  </svg></div>
-                              </div>
-                            </a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="data-category__h3">
-                        <div data-w-id="1e35aa5d-6794-7eaf-27f0-84b06b77495c" class="data-category__h3_trigger">
-                          <div class="truncate">Indicator</div>
-                          <div class="data-category__h3_loading"><img src="images/loading.gif" alt=""></div>
-                          <div class="data-category__h3_load-complete hidden">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                              </svg></div>
-                          </div>
-                        </div>
-                        <div class="data-category__h3_content hidden">
-                          <div class="data-category__h3_wrapper">
-                            <div class="data-category__h4_line-v"></div>
-                            <a href="#" class="data-category__h4 w-inline-block">
-                              <div class="data-category__h4_line-h"></div>
-                              <div class="truncate">Subindicator</div>
-                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                              <div class="data-category__h4_load-complete hidden">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                  </svg></div>
-                              </div>
-                            </a>
-                            <a href="#" class="data-category__h4 w-inline-block">
-                              <div class="data-category__h4_line-h"></div>
-                              <div class="truncate">Subindicator</div>
-                              <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
-                              <div class="data-category__h4_load-complete hidden">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                  </svg></div>
-                              </div>
-                            </a>
-                            <a href="#" class="data-category__h4 active w-inline-block">
-                              <div class="data-category__h4_line-h"></div>
-                              <div class="truncate">Subindicator</div>
-                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                              <div class="data-category__h4_load-complete">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                  </svg></div>
-                              </div>
-                            </a>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="data-category__h3">
-                        <div data-w-id="5cc4d99e-ac57-fc58-7a13-748080bb6e5e" class="data-category__h3_trigger active">
-                          <div class="truncate">Indicator</div>
-                          <div class="data-category__h3_loading hidden"><img src="images/loading.gif" alt=""></div>
-                          <div class="data-category__h3_load-complete">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                              </svg></div>
-                          </div>
-                        </div>
-                        <div class="data-category__h3_content hidden">
-                          <div class="data-category__h3_wrapper">
-                            <div class="data-category__h4_line-v"></div>
-                            <a href="#" class="data-category__h4 w-inline-block">
-                              <div class="data-category__h4_line-h"></div>
-                              <div class="truncate">Subindicator</div>
-                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                              <div class="data-category__h4_load-complete hidden">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                  </svg></div>
-                              </div>
-                            </a>
-                            <a href="#" class="data-category__h4 w-inline-block">
-                              <div class="data-category__h4_line-h"></div>
-                              <div class="truncate">Subindicator</div>
-                              <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
-                              <div class="data-category__h4_load-complete hidden">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                  </svg></div>
-                              </div>
-                            </a>
-                            <a href="#" class="data-category__h4 active w-inline-block">
-                              <div class="data-category__h4_line-h"></div>
-                              <div class="truncate">Subindicator</div>
-                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                              <div class="data-category__h4_load-complete">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                  </svg></div>
-                              </div>
-                            </a>
-                          </div>
-                        </div>
-                      </div>
                     </div>
-                  </div>
-                </div>
-              </div>
+                </a>
             </div>
-          </div>
         </div>
-      </div>
-      <div class="styles__section">
-        <div class="styles__title">
-          <div>Rich Data Header</div>
-        </div>
-        <div class="styles__subsection">
-          <div>Rich data nav item</div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <a href="#top" class="rich-data-nav__item w-inline-block">
-            <div class="rich-data-nav__item-text">
-              <div class="truncate">Section title</div>
-            </div>
-            <div class="rich-data-nav__item-icon">
-              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"></path>
-                  <path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
-                </svg></div>
-            </div>
-          </a>
-        </div>
-        <div class="styles__subsection">
-          <div>Location breadcrumbs</div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <div class="breadcrumb">
-            <div class="truncate">Parent geography</div>
-          </div>
-        </div>
-        <div class="styles__subsection">
-          <div>Location facilities</div>
-        </div>
-        <div class="styles__area_block wide">
-          <div class="location__facilities">
-            <div class="location__facilities_header--loading">
-              <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-              <div class="location__facilities_title_loading">
-                <div>Loading facilities...</div>
-              </div>
-            </div>
-            <div class="location__facilities_header hidden">
-              <div class="location__facilities_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                  </svg></div>
-              </div>
-              <div class="location__facilities_title">
-                <div>This <span class="location__facilities_geo-type">location</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> facilities</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
-              </div>
-            </div>
-            <div class="location__facilities_trigger hidden">
-              <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d4" style="display:flex" class="location__facilities_expand">
-                <div>Show facilities</div>
-              </div>
-              <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d7" style="display:none" class="location__facilities_contract">
-                <div>Hide facilities</div>
-              </div>
-            </div>
-            <div style="height:0PX" class="location__facilities_content">
-              <div class="location__facilities_content-wrapper">
-                <div class="location__facilities_loading hidden">
-                  <div class="loading">
+        <div data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50" class="rich-data-bumper"></div>
+        <div class="rich-data-content">
+            <div class="rich-data__shadow"></div>
+            <div style="-webkit-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)"
+                 class="sticky-header">
+                <div title="Click to make this your primary search" class="sticky-header__current-location">
                     <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
                     <div class="loading__text">
-                      <div>Loading... </div>
+                        <div class="truncate">Loading...</div>
                     </div>
-                  </div>
                 </div>
-                <div class="location__facilities_no-data hidden">
-                  <div class="no-data">
+                <div class="sticky-header__tutorial hidden">
+                    <div class="svg-icon w-embed">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor"
+                                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+                        </svg>
+                    </div>
+                </div>
+            </div>
+            <section class="section header">
+                <div id="top" class="section-link"></div>
+                <div class="location__header">
+                    <div class="location__breadcrumbs hidden">
+                        <div class="label">
+                            <div>Navigate to:</div>
+                        </div>
+                        <div class="breadcrumb">
+                            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                            <div class="loading__text">
+                                <div>Loading...</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="location__tutorial hidden">
+                        <div class="location__tutorial_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div>Quick tutorial</div>
+                    </div>
+                </div>
+                <div data-w-id="a462ef20-a798-735c-f166-106a34080855" class="location__title">
+                    <div class="loading">
+                        <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                        <div class="loading__text">
+                            <div>Loading...</div>
+                        </div>
+                    </div>
+                </div>
+                <div class="location__description hidden">
+                    <div>A <span class="location-type">Location type</span> in <span class="parent-geography">parent geography</span>
+                    </div>
+                </div>
+                <div class="location__facilities">
+                    <div class="location__facilities_no-data hidden">
+                        <div class="no-data">
+                            <div class="no-data__icon">
+                                <div class="svg-icon w-embed">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor"
+                                              d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                                    </svg>
+                                </div>
+                            </div>
+                            <div class="no-data__text">
+                                <div>No facilities for this location</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="location__facilities_loading">
+                        <div class="loading">
+                            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                            <div class="loading__text">
+                                <div>Loading...</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="location__facilities_header hidden">
+                        <div class="location__facilities_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                                    <path fill="currentColor"
+                                          d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="location__facilities_title">
+                            <div>This <span class="location__facilities_geo-type">location</span> has <span
+                                    class="location__facilities_facilities-value"><strong>0000</strong></span><strong>
+                                facilities</strong> in <span
+                                    class="location__facilities_categories-value"><strong>0000</strong></span><strong>
+                                categories</strong>.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="location__facilities_trigger hidden">
+                        <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6ad" style="display:flex"
+                             class="location__facilities_expand">
+                            <div>Show facilities</div>
+                        </div>
+                        <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6b0" style="display:none"
+                             class="location__facilities_contract">
+                            <div>Hide facilities</div>
+                        </div>
+                    </div>
+                    <div style="height:0PX" class="location__facilities_content">
+                        <div class="location__facilities_content-wrapper">
+                            <div class="location__facilities_sources">
+                                <div class="label">
+                                    <div>Sources:</div>
+                                </div>
+                                <div class="location__sources_loading">
+                                    <div class="loading">
+                                        <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                                        <div class="loading__text">
+                                            <div>Loading...</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="location__sources_no-data hidden">
+                                    <div class="no-data">
+                                        <div class="no-data__text">
+                                            <div>No source data available</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <div class="section">
+                <div class="section-link"></div>
+            </div>
+        </div>
+        <div class="rich-data-toggles">
+            <div data-w-id="1b738c3c-f509-9ebc-f15d-d66894a02164" class="panel-toggle rich-data-panel__close cc-active">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+                    </svg>
+                </div>
+                <div class="panel-toggle__tooltip">
+                    <div class="panel-toggle__tooltip_text">
+                        <div>Rich Data</div>
+                    </div>
+                    <div class="panel-toggle__tooltip_notch"></div>
+                </div>
+            </div>
+            <div data-w-id="ef6902f7-5288-a426-a2e6-ee2a693e86d7" class="panel-toggle data-mapper-panel__open">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                    </svg>
+                </div>
+                <div class="panel-toggle__tooltip">
+                    <div class="panel-toggle__tooltip_text">
+                        <div>Data Mapper</div>
+                    </div>
+                    <div class="panel-toggle__tooltip_notch"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="facility-info">
+        <div class="facility-info__header">
+            <h3 class="facility-info__title">Loading...</h3>
+            <div title="Download information (.pdf)" class="facility-info__download">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                    </svg>
+                </div>
+            </div>
+            <div title="Close" class="facility-info__close">
+                <div class="svg-icon svg-icon--no-size w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                    </svg>
+                </div>
+            </div>
+        </div>
+        <div class="facility-info__content">
+            <div class="facility-info__items">
+                <div class="facility-info__item last">
+                    <div class="facility-info__item_label">Loading...</div>
+                    <div class="facility-info__item_value">...</div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="point-mapper">
+        <div class="point-mapper-content narrow-scroll">
+            <div class="point-mapper-content__header">
+                <div class="point-data__header_icon">
+                    <div class="svg-icon w-embed">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor"
+                                  d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                            <path fill="currentColor"
+                                  d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                        </svg>
+                    </div>
+                </div>
+                <div class="point-data__header_title">
+                    <div>Point Mapper</div>
+                </div>
+            </div>
+            <div class="point-mapper-content__description">
+                <div>Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong>
+                </div>
+            </div>
+            <div class="point-mapper-content__loading">
+                <div class="loading">
+                    <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                    <div class="loading__text">
+                        <div>Loading...</div>
+                    </div>
+                </div>
+            </div>
+            <div class="point-mapper-content__no-data hidden">
+                <div class="no-data">
                     <div class="no-data__icon">
-                      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                          <path d="M0 0h24v24H0z" fill="none"></path>
-                          <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                        </svg></div>
+                        <div class="svg-icon w-embed">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor"
+                                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                            </svg>
+                        </div>
                     </div>
                     <div class="no-data__text">
-                      <div>No facilities for this location</div>
+                        <div>No points available for this location</div>
                     </div>
-                  </div>
                 </div>
-                <div class="location-facility">
-                  <div class="location-facility__card">
-                    <div class="location-facility__category">
-                      <div class="location-facility__header">
-                        <div class="location-facility__icon">
-                          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
-                              <path d="M0 0h24v24H0z" fill="none"></path>
-                              <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="location-facility__name">
-                          <div>Point data category</div>
-                        </div>
-                      </div>
-                      <div class="location-facility__value">
-                        <div>0000</div>
-                      </div>
-                    </div>
-                    <div class="location-facility__list">
-                      <a href="#" class="location-facility__list_item w-inline-block">
-                        <div class="location-facility__item_name">
-                          <div class="truncate">Point data item</div>
-                        </div>
-                        <div class="location-facility__item_value">
-                          <div>0000</div>
-                        </div>
-                        <div id="w-node-a4312e607bde-e148319d" class="location-facility__item_download">
-                          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                              <path d="M0 0h24v24H0z" fill="none"></path>
-                              <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-                            </svg></div>
-                        </div>
-                      </a>
-                      <a href="#" class="location-facility__list_item last w-inline-block">
-                        <div class="location-facility__item_name">
-                          <div class="truncate">Point data item</div>
-                        </div>
-                        <div class="location-facility__item_value">
-                          <div>0000</div>
-                        </div>
-                        <div id="w-node-a4312e607be7-e148319d" class="location-facility__item_download">
-                          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                              <path d="M0 0h24v24H0z" fill="none"></path>
-                              <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-                            </svg></div>
-                        </div>
-                      </a>
-                    </div>
-                    <div class="location-facility__description">
-                      <div>Description text that describes this point data category in relation to surrounding locations</div>
-                    </div>
-                  </div>
-                </div>
-                <div class="location__facilities_sources">
-                  <div class="label">
-                    <div>Sources:</div>
-                  </div>
-                  <div class="location__sources_loading">
-                    <div class="loading">
-                      <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                      <div class="loading__text">
-                        <div>Loading... </div>
-                      </div>
-                    </div>
-                  </div>
-                  <div class="location__sources_no-data hidden">
-                    <div class="no-data">
-                      <div class="no-data__text">
-                        <div>No source data available</div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
             </div>
-          </div>
+            <div class="point-mapper-content__list"></div>
         </div>
-      </div>
-      <div class="styles__section">
-        <div class="styles__title">
-          <div>Navigation search</div>
+        <div class="point-mapper-toggles">
+            <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de47" class="panel-toggle rich-data-panel__open">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+                    </svg>
+                </div>
+                <div class="panel-toggle__tooltip">
+                    <div class="panel-toggle__tooltip_text">
+                        <div>Rich Data</div>
+                    </div>
+                    <div class="panel-toggle__tooltip_notch"></div>
+                </div>
+            </div>
+            <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de4a"
+                 class="panel-toggle point-mapper-panel__close cc-active">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                        <path fill="currentColor"
+                              d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                    </svg>
+                </div>
+                <div class="panel-toggle__tooltip">
+                    <div class="panel-toggle__tooltip_text">
+                        <div>Point Mapper</div>
+                    </div>
+                    <div class="panel-toggle__tooltip_notch"></div>
+                </div>
+            </div>
+            <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de49" class="panel-toggle data-mapper-panel__open">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                    </svg>
+                </div>
+                <div class="panel-toggle__tooltip">
+                    <div class="panel-toggle__tooltip_text">
+                        <div>Data Mapper</div>
+                    </div>
+                    <div class="panel-toggle__tooltip_notch"></div>
+                </div>
+            </div>
         </div>
-        <div class="styles__subsection">
-          <div>Search dropdown list items</div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <div data-w-id="0cc195d0-8237-0a5c-88c5-6bd36b98a8c1" class="search__dropdown_list-item">
-            <div class="search__list-item_location-name">
-              <div class="truncate">Location name</div>
-            </div>
-            <div class="search__list-item_location-parent">
-              <div class="truncate">Parent </div>
-            </div>
-            <div id="w-node-6bd36b98a8c8-e148319d" class="search__list-item_location-type">
-              <div class="truncate">Location Type</div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <div data-w-id="8d9eb87a-805a-ef6a-0ef3-bca9e2f0f208" class="search__dropdown_list-item active">
-            <div class="search__list-item_location-name">
-              <div class="truncate">Location name</div>
-            </div>
-            <div class="search__list-item_location-parent">
-              <div class="truncate">Parent </div>
-            </div>
-            <div id="w-node-bca9e2f0f20f-e148319d" class="search__list-item_location-type">
-              <div class="truncate">Location Type</div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="styles__section">
-        <div class="styles__title">
-          <div>Rich Data Indicator</div>
-        </div>
-        <div class="styles__subsection">
-          <div>Rich data section title</div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <div class="category-header">
-            <div class="category-header__content">
-              <div class="category-header__title">
-                <div class="category-header__icon">
-                  <div class="svg-icon large w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
-                      <path d="M0 0h24v24H0z" fill="none"></path>
-                      <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                    </svg></div>
-                </div>
-                <div class="category-header__text">
-                  <h2 class="cc-clear">Category title</h2>
-                </div>
-              </div>
-            </div>
-            <div class="category-header__description">
-              <p>Category description. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-            </div>
-          </div>
-        </div>
-        <div class="styles__subsection">
-          <div>Rich data indicator header</div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <div class="sub-category-header first">
-            <div class="sub-category-header__title">
-              <div class="indicator__title_wrapper">
-                <h3 class="cc-clear">Indicator title</h3>
-                <div class="h3__line-v"></div>
-              </div>
-            </div>
-            <div class="sub-category-header__description">
-              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. Nunc ut sem vitae risus tristique posuere.</p>
-            </div>
-            <div class="sub-category-header__key-metrics">
-              <div class="sub-category-header__key-metrics_title">
-                <div>KEY METRICS for this indicator</div>
-              </div>
-              <div class="sub-category-header__key-metrics_wrap">
-                <div class="key-metric">
-                  <div class="key-metric__card">
-                    <div class="key-metric__value">
-                      <div class="truncate">00</div>
-                    </div>
-                    <div class="key-metric__title">
-                      <div>Metric title</div>
-                    </div>
-                    <div class="key-metric__description">
-                      <div>Description text that describes this metric in relation to surrounding locations</div>
-                    </div>
-                  </div>
-                </div>
-                <div class="key-metric">
-                  <div class="key-metric__card">
-                    <div class="key-metric__value">
-                      <div class="truncate">00</div>
-                    </div>
-                    <div class="key-metric__title">
-                      <div>Metric title</div>
-                    </div>
-                    <div class="key-metric__description">
-                      <div>Description text that describes this metric in relation to surrounding locations</div>
-                    </div>
-                  </div>
-                </div>
-                <div class="key-metric">
-                  <div class="key-metric__card">
-                    <div class="key-metric__value">
-                      <div class="truncate">00</div>
-                    </div>
-                    <div class="key-metric__title">
-                      <div>Metric title</div>
-                    </div>
-                    <div class="key-metric__description">
-                      <div>Description text that describes this metric in relation to surrounding locations</div>
-                    </div>
-                  </div>
-                </div>
-                <div class="key-metric">
-                  <div class="key-metric__card">
-                    <div class="key-metric__value">
-                      <div class="truncate">00</div>
-                    </div>
-                    <div class="key-metric__title">
-                      <div>Metric title</div>
-                    </div>
-                    <div class="key-metric__description">
-                      <div>Description text that describes this metric in relation to surrounding locations</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        <div class="styles__subsection">
-          <div>Rich data sub-indicator</div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <div class="profile-indicator last">
-            <div class="profile-indicator__header">
-              <div class="profile-indicator__title">
-                <h4>Indicator chart title</h4>
-              </div>
-              <div class="profile-indicator__options">
-                <div class="hover-menu">
-                  <div class="hover-menu__icon">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
-                      </svg></div>
-                  </div>
-                  <div class="hover-menu__content">
-                    <div class="hover-menu__content_wrapper">
-                      <a href="#" class="hover-menu__content_item w-inline-block">
-                        <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c397204ee09f13_image-24px.svg" alt=""></div>
-                        <div class="content__item_title">
-                          <div>Save as image</div>
-                        </div>
-                      </a>
-                      <div class="hover-menu__content_item--no-link">
-                        <div class="icon--small">
-                          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                              <path d="M0 0h24v24H0z" fill="none"></path>
-                              <path fill="currentColor" d="M21 6H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v8z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="content__item_title">
-                          <div>Chart values as:</div>
-                        </div>
-                      </div>
-                      <div class="hover-menu__content_list">
-                        <a href="#" class="hover-menu__content_list-item active w-inline-block">
-                          <div>Percentage</div>
-                        </a>
-                        <a href="#" class="hover-menu__content_list-item--last w-inline-block">
-                          <div>Value</div>
-                        </a>
-                      </div>
-                      <div class="hover-menu__content_item--no-link">
-                        <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c3974bdbe09f2e_download-24px.svg" alt=""></div>
-                        <div class="content__item_title">
-                          <div>Click to download data:</div>
-                        </div>
-                      </div>
-                      <div class="hover-menu__content_list--last">
-                        <a href="#" class="hover-menu__content_list-item w-inline-block">
-                          <div>CSV</div>
-                        </a>
-                        <a href="#" class="hover-menu__content_list-item w-inline-block">
-                          <div>Excel</div>
-                        </a>
-                        <a href="#" class="hover-menu__content_list-item w-inline-block">
-                          <div>JSON</div>
-                        </a>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="profile-indicator__filters">
-              <div class="filter__dropdown_wrap">
-                <div class="dropdown-menu__label">
-                  <div>Select a value:</div>
-                </div>
-                <div class="dropdown-menu">
-                  <div class="dropdown-menu__trigger">
-                    <div class="dropdown-menu__selected-item">
-                      <div class="truncate">All values</div>
-                    </div>
-                    <div class="dropdown-menu__icon">
-                      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                          <path d="M0 0h24v24H0z" fill="none"></path>
-                          <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                        </svg></div>
-                    </div>
-                  </div>
-                  <div class="dropdown-menu__content scroll-element">
-                    <div class="dropdown__list_item selected">
-                      <div class="truncate">All values</div>
-                    </div>
-                    <div class="dropdown__list_item">
-                      <div class="truncate">Value name</div>
-                    </div>
-                    <div class="dropdown__list_item">
-                      <div class="truncate">Value name</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="filter__dropdown_wrap disabled">
-                <div class="dropdown-menu__label">
-                  <div>FILTER BY:</div>
-                </div>
-                <div class="dropdown-menu">
-                  <div class="dropdown-menu__trigger">
-                    <div class="dropdown-menu__selected-item">
-                      <div class="truncate">All values</div>
-                    </div>
-                    <div class="dropdown-menu__icon">
-                      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                          <path d="M0 0h24v24H0z" fill="none"></path>
-                          <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                        </svg></div>
-                    </div>
-                  </div>
-                  <div class="dropdown-menu__content scroll-element">
-                    <div class="dropdown__list_item selected">
-                      <div class="truncate">All filters</div>
-                    </div>
-                    <div class="dropdown__list_item">
-                      <div class="truncate">Filter name</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="profile-indicator__chart">
-              <div class="profile-indicator__chart_body">
-                <div class="indicator__chart full">
-                  <div class="bar-chart">
-                    <div class="bar-chart__main">
-                      <div class="bar-chart__labels">
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__label">
-                          <div class="bar-chart__label_position">
-                            <div class="bar-chart__label_value">
-                              <div>0%</div>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                      <div class="bar-chart__rows">
-                        <div class="bar-chart__row">
-                          <div class="bar-chart__row_label">
-                            <div class="truncate">Truncation of the following sentence</div>
-                          </div>
-                          <div class="bar-chart__row-wrapper">
-                            <div class="bar-chart__row_bar _1">
-                              <div class="bar-chart__row_tooltip">
-                                <div class="bar-chart__row_tooltip-card">
-                                  <div class="bar-chart__tooltip_name">
-                                    <div>Long chart label looks like this</div>
-                                  </div>
-                                  <div class="bar-chart__tooltip_value">
-                                    <div>00%</div>
-                                  </div>
-                                  <div class="bar-chart__tooltip_alt-value">
-                                    <div>000,000,000</div>
-                                  </div>
-                                  <div class="bar-chart__row_tooltip-notch"></div>
-                                </div>
-                              </div>
-                            </div>
-                            <div class="bar-chart__row_value">
-                              <div class="truncate">00%</div>
-                            </div>
-                          </div>
-                        </div>
-                        <div class="bar-chart__underline"></div>
-                      </div>
-                    </div>
-                    <div class="bar-chart__x-label">
-                      <div>Label Goes here</div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div class="profile-indicator__chart_footer">
-                <div class="profile-indicator__chart_description">
-                  <p>Sub-indicator chart footnote goes here and helps to describe the data presented</p>
-                </div>
-                <div class="profile-indicator__chart_source">
-                  <div class="chart__footer_label">
-                    <div>Source:</div>
-                  </div>
-                  <div class="data-source">
-                    <div>Data source name</div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div class="styles__section">
-        <div class="styles__title">
-          <div>Map</div>
-        </div>
-        <div class="styles__subsection">
-          <div>Map tooltip</div>
-        </div>
-        <div class="styles__area_block test">
-          <div class="map-tooltip">
-            <div class="map-tooltip__geography-chip">
-              <div>MUNICIPALITY</div>
-            </div>
-            <div class="map-tooltip__name">
-              <div>Elim</div>
-            </div>
-            <div class="map-tooltip__value hidden">
-              <div class="tooltip__value_label">
-                <div class="truncate">Language most spoken at home:</div>
-              </div>
-              <div class="tooltip__value_wrapper">
-                <div class="tooltip__value_amount">
-                  <div>24,539</div>
-                </div>
-                <div class="tooltip__value_detail">
-                  <div>(24%)</div>
-                </div>
-              </div>
-            </div>
-            <div class="tooltip__notch"></div>
-          </div>
-        </div>
-        <div class="styles__area_block test">
-          <div class="map-tooltip">
-            <div class="map-tooltip__geography-chip">
-              <div>MUNICIPALITY</div>
-            </div>
-            <div class="map-tooltip__name">
-              <div>Elim</div>
-            </div>
-            <div class="map-tooltip__value">
-              <div class="tooltip__value_label">
-                <div class="truncate">Short label:</div>
-              </div>
-              <div class="tooltip__value_wrapper">
-                <div class="tooltip__value_amount">
-                  <div>24,539</div>
-                </div>
-                <div class="tooltip__value_detail">
-                  <div>(24%)</div>
-                </div>
-              </div>
-            </div>
-            <div class="map-tooltip__value">
-              <div class="tooltip__value_label">
-                <div class="truncate">Short label:</div>
-              </div>
-              <div class="tooltip__value_wrapper">
-                <div class="tooltip__value_amount">
-                  <div>24,539</div>
-                </div>
-                <div class="tooltip__value_detail">
-                  <div>(24%)</div>
-                </div>
-              </div>
-            </div>
-            <div class="map-tooltip__value">
-              <div class="tooltip__value_label">
-                <div class="truncate">Short label:</div>
-              </div>
-              <div class="tooltip__value_wrapper">
-                <div class="tooltip__value_amount">
-                  <div>24,539</div>
-                </div>
-                <div class="tooltip__value_detail">
-                  <div>(24%)</div>
-                </div>
-              </div>
-            </div>
-            <div class="tooltip__notch"></div>
-          </div>
-        </div>
-        <div class="styles__area_block test">
-          <div class="map-tooltip">
-            <div class="map-tooltip__geography-chip">
-              <div>MUNICIPALITY</div>
-            </div>
-            <div class="map-tooltip__name">
-              <div>Elim</div>
-            </div>
-            <div class="map-tooltip__value">
-              <div class="tooltip__value_label">
-                <div class="truncate">Long label that gets truncated outside of the box width:</div>
-              </div>
-              <div class="tooltip__value_wrapper">
-                <div class="tooltip__value_amount">
-                  <div>24,539</div>
-                </div>
-                <div class="tooltip__value_detail">
-                  <div>(24%)</div>
-                </div>
-              </div>
-            </div>
-            <div class="map-tooltip__value">
-              <div class="tooltip__value_label">
-                <div class="truncate">Long label that gets truncated outside of the box width:</div>
-              </div>
-              <div class="tooltip__value_wrapper">
-                <div class="tooltip__value_amount">
-                  <div>24,539</div>
-                </div>
-                <div class="tooltip__value_detail">
-                  <div>(24%)</div>
-                </div>
-              </div>
-            </div>
-            <div class="map-tooltip__value">
-              <div class="tooltip__value_label">
-                <div class="truncate">Long label that gets truncated outside of the box width:</div>
-              </div>
-              <div class="tooltip__value_wrapper">
-                <div class="tooltip__value_amount">
-                  <div>24,539</div>
-                </div>
-                <div class="tooltip__value_detail">
-                  <div>(24%)</div>
-                </div>
-              </div>
-            </div>
-            <div class="tooltip__notch"></div>
-          </div>
-        </div>
-        <div class="styles__subsection">
-          <div>Facility tooltip</div>
-        </div>
-        <div class="styles__area_block horizontal wide">
-          <div class="facility-tooltip">
-            <div class="facility-tooltip__header">
-              <div class="facility-tooltip__header_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                  </svg></div>
-              </div>
-              <div class="facility-tooltip__header_name">
-                <div>Elim High School</div>
-              </div>
-            </div>
-            <div class="facility-tooltip__items">
-              <div class="facility-tooltip__item">
-                <div class="tooltip__facility-item_label">
-                  <div>Address:</div>
-                </div>
-                <div class="tooltip__facility-item_value">
-                  <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris aliquet libero ullamcorper, blandit felis sit amet, rhoncus eros. Nam sed dolor id quam ullamcorper rhoncus.</div>
-                </div>
-              </div>
-              <div class="facility-tooltip__item">
-                <div class="tooltip__facility-item_label">
-                  <div>Phone:</div>
-                </div>
-                <div class="tooltip__facility-item_value">
-                  <div>09123901293</div>
-                </div>
-              </div>
-              <div class="facility-tooltip__item">
-                <div class="tooltip__facility-item_label">
-                  <div>Website:</div>
-                </div>
-                <div class="tooltip__facility-item_value">
-                  <div>
-                    <a href="#">www.test.com</a>
-                  </div>
-                </div>
-              </div>
-              <div class="facility-tooltip__item last">
-                <div class="tooltip__facility-item_label">
-                  <div>Email:</div>
-                </div>
-                <div class="tooltip__facility-item_value">
-                  <div>
-                    <a target="_blank" href="mailto:appletreenat@gmail.com">appletreenat@gmail.com</a>
-                  </div>
-                </div>
-              </div>
-            </div>
-            <div class="facility-tooltip__close">
-              <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                  <path d="M0 0h24v24H0z" fill="none"></path>
-                  <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                </svg></div>
-            </div>
-            <div class="tooltip__notch"></div>
-          </div>
-        </div>
-        <div class="styles__subsection">
-          <div>Map legend</div>
-        </div>
-        <div class="styles__area_block horizontal">
-          <div class="map_legend-block">
-            <div class="truncate">value</div>
-          </div>
-          <div class="map_legend-block light">
-            <div class="truncate">value</div>
-          </div>
-        </div>
-      </div>
     </div>
-  </div>
-  <div class="print-styling w-embed">
+    <div class="data-mapper">
+        <div class="data-mapper-content narrow-scroll">
+            <div class="data-mapper-content__header">
+                <div class="point-data__header_icon">
+                    <div class="svg-icon w-embed">
+                        <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor"
+                                  d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                        </svg>
+                    </div>
+                </div>
+                <div class="point-data__header_title">
+                    <div>Data Mapper</div>
+                </div>
+            </div>
+            <div class="data-mapper-content__description">
+                <div>Explore data categories available for this location. Click or tap a sub-indicator to show it on the
+                    map.<strong><br></strong></div>
+            </div>
+            <div class="data-mapper-content__loading">
+                <div class="loading">
+                    <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                    <div class="loading__text">
+                        <div>Loading...</div>
+                    </div>
+                </div>
+            </div>
+            <div class="data-mapper-content__no-data hidden">
+                <div class="no-data__icon">
+                    <div class="svg-icon w-embed">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor"
+                                  d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                        </svg>
+                    </div>
+                </div>
+                <div>The Data Mapper cannot be used with this location as it doesn&#x27;t contain any sub-areas which
+                    can be used for mapping
+                </div>
+            </div>
+            <div class="data-mapper-content__list"></div>
+        </div>
+        <div class="data-mapper-toggles">
+            <div data-w-id="82de420b-3451-8ea3-a5a4-f892b059998e" class="panel-toggle rich-data-panel__open">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+                    </svg>
+                </div>
+                <div class="panel-toggle__tooltip">
+                    <div class="panel-toggle__tooltip_text">
+                        <div>Rich Data</div>
+                    </div>
+                    <div class="panel-toggle__tooltip_notch"></div>
+                </div>
+            </div>
+            <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599990" class="panel-toggle point-mapper-panel__open">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                        <path fill="currentColor"
+                              d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                    </svg>
+                </div>
+                <div class="panel-toggle__tooltip">
+                    <div class="panel-toggle__tooltip_text">
+                        <div>Point Mapper</div>
+                    </div>
+                    <div class="panel-toggle__tooltip_notch"></div>
+                </div>
+            </div>
+            <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599992"
+                 class="panel-toggle data-mapper-panel__close cc-active">
+                <div class="svg-icon w-embed">
+                    <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor"
+                              d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                    </svg>
+                </div>
+                <div class="panel-toggle__tooltip">
+                    <div class="panel-toggle__tooltip_text">
+                        <div>Data Mapper</div>
+                    </div>
+                    <div class="panel-toggle__tooltip_notch"></div>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="panel-toggles">
+        <div data-w-id="b8845a6b-d018-3723-9163-c2bb32f2a4ea" class="panel-toggle rich-data-panel__open">
+            <div class="panel-toggle__tooltip">
+                <div class="panel-toggle__tooltip_text">
+                    <div>Rich Data</div>
+                </div>
+                <div class="panel-toggle__tooltip_notch"></div>
+            </div>
+            <div class="svg-icon w-embed">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor"
+                          d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+                </svg>
+            </div>
+        </div>
+        <div data-w-id="cb33504b-ce21-a841-3478-0f9742bd5340" class="panel-toggle point-mapper-panel__open">
+            <div class="panel-toggle__tooltip">
+                <div class="panel-toggle__tooltip_text">
+                    <div>Point Mapper</div>
+                </div>
+                <div class="panel-toggle__tooltip_notch"></div>
+            </div>
+            <div class="svg-icon w-embed">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor"
+                          d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                    <path fill="currentColor"
+                          d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                </svg>
+            </div>
+        </div>
+        <div data-w-id="6207c761-ee3d-87bf-d0fb-b9250b5408ec" class="panel-toggle data-mapper-panel__open">
+            <div class="panel-toggle__tooltip">
+                <div class="panel-toggle__tooltip_text">
+                    <div>Data Mapper</div>
+                </div>
+                <div class="panel-toggle__tooltip_notch"></div>
+            </div>
+            <div class="svg-icon w-embed">
+                <svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor"
+                          d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                </svg>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="styles hidden">
+    <div class="styles__wrapper">
+        <div class="styles__section">
+            <div class="styles__title">
+                <div>General</div>
+            </div>
+            <div class="styles__subsection">
+                <div>Data sources</div>
+            </div>
+            <div class="styles__title">
+                <div>Point Mapper</div>
+            </div>
+            <div class="styles__subsection">
+                <div>Categories</div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div class="point-mapper__h1_trigger point-mapper__h1--default-closed">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                        <div class="point-mapper__h1_trigger-arrow">
+                            <div class="fas fa-angle-up"></div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_content default-state--closed">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-1">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-1">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div class="point-mapper__h1_trigger point-mapper__h1--default-open">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                        <div class="point-mapper__h1_trigger-arrow">
+                            <div class="fas fa-angle-up"></div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_content default-state--open">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-1">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-1">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="e0cdcac6-d5b6-2780-3500-919c8eb3a735" class="point-mapper__h1_trigger">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-1">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-1">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="555868a6-ac7f-4f39-8af1-54b777afa871"
+                         class="point-mapper__h1_trigger theme-1 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-1">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-1 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-1">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="6c86cd6d-a3de-4bf1-d2ef-1b52d687bf4e"
+                         class="point-mapper__h1_trigger theme-2 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-2">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-2 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-2">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="bf6a46d9-86a7-67f0-4a2e-794e9e22a39c"
+                         class="point-mapper__h1_trigger theme-3 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-3">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-3 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-3">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="4cef7f0e-21b5-0f03-d39b-d81f3f762e9b"
+                         class="point-mapper__h1_trigger theme-4 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-4">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-4 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-4">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="7744e72b-62fe-c3cd-e2b1-d418a4c81926"
+                         class="point-mapper__h1_trigger theme-5 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-5">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-5 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-5">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="ac8e408e-8dfd-2bd2-473a-7f80ffe5d8da"
+                         class="point-mapper__h1_trigger theme-6 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-6">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-6 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-6">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="9cf08a1c-eea4-40f7-7584-7a22af1533c0"
+                         class="point-mapper__h1_trigger theme-7 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-7">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-7 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-7">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="c7b0b95d-3477-0e3c-db3a-98e3a48fa33a"
+                         class="point-mapper__h1_trigger theme-8 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-8">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-8 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-8">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="5a41969a-edbe-1d60-39e9-b0079ac64c15"
+                         class="point-mapper__h1_trigger theme-9 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-9">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-9 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div title="test test" class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-9">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__area_block">
+                <div class="point-mapper__h1">
+                    <div data-w-id="9a2d4f34-e296-5da4-f30e-b15ac204c0da"
+                         class="point-mapper__h1_trigger theme-10 active">
+                        <div class="point-data__h1_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="point-data__h1_name">
+                            <div class="truncate">Category Name</div>
+                        </div>
+                    </div>
+                    <div class="point-mapper__h1_checkbox">
+                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label
+                                class="switch">
+                            <input type="checkbox">
+                            <span class="slider round"></span>
+                        </label></div>
+                    </div>
+                    <div style="display:block" class="point-mapper__h1_content">
+                        <div class="point-mapper__h2_wrapper">
+                            <div class="point-mapper__h2 theme-10">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 theme-10 active">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="point-mapper__h2 last theme-10">
+                                <div class="point-mapper__h2_line-h"></div>
+                                <div class="point-mapper__h2_label">
+                                    <div class="point-mapper__h2_name">
+                                        <div class="truncate">Point data name</div>
+                                    </div>
+                                    <div class="point-mapper__h2_source">
+                                        <div class="truncate">Point data source name</div>
+                                    </div>
+                                </div>
+                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                                <div class="point-mapper__h2_load-complete hidden">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                            <path fill="currentColor"
+                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="point-data__h2_line-v"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="styles__section">
+            <div class="styles__title">
+                <div>Map Location</div>
+            </div>
+            <div class="styles__subsection">
+                <div>Location tags</div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <div title="Click to make this your primary search" class="location-tag">
+                    <div class="location-tag__type">
+                        <div>Location type</div>
+                    </div>
+                    <div class="location-tag__name">
+                        <div class="truncate text-center">Location name</div>
+                    </div>
+                    <div class="location-tag__loading-icon"><img src="images/loading.gif" alt=""></div>
+                </div>
+                <div title="Click to make this your primary search" class="location-tag active">
+                    <div class="location-tag__type">
+                        <div>Location type</div>
+                    </div>
+                    <div class="location-tag__name">
+                        <div class="truncate text-center">Location name</div>
+                    </div>
+                    <div class="location-tag__loading-icon hidden"><img src="images/loading.gif" alt=""></div>
+                </div>
+            </div>
+            <div class="styles__subsection">
+                <div>Location tags</div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <div class="location-highlight">
+                    <div class="location-highlight__title">
+                        <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)
+                        </div>
+                    </div>
+                    <div class="location-highlight__value">
+                        <div class="truncate">Value</div>
+                    </div>
+                </div>
+                <div class="location-highlight last">
+                    <div class="location-highlight__title">
+                        <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)
+                        </div>
+                    </div>
+                    <div class="location-highlight__value">
+                        <div class="truncate">Value</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="styles__section">
+            <div class="styles__title">
+                <div>Data Mapper</div>
+            </div>
+            <div class="styles__subsection">
+                <div>Categories</div>
+            </div>
+            <div class="styles__area_block">
+                <div class="data-category">
+                    <div href="#" class="data-category__h1_trigger">
+                        <div class="data-category__h1_header">
+                            <div class="data-category__h1_icon">
+                                <div class="svg-icon w-embed">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor"
+                                              d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                    </svg>
+                                </div>
+                            </div>
+                            <div class="data-category__h1_title">
+                                <div class="truncate">Category</div>
+                            </div>
+                        </div>
+                        <div class="data-category__h1_toggle toggle-icon-v">
+                            <div class="toggle-icon-v--first w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
+                                </svg>
+                            </div>
+                            <div class="toggle-icon-v--last w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="data-category__h1_content">
+                        <div class="data-category__h1_wrapper">
+                            <div class="data-category__h2">
+                                <div href="#" class="data-category__h2_trigger">
+                                    <div class="truncate">Subcategory</div>
+                                </div>
+                                <div class="data-category__h2_content">
+                                    <div class="data-category__h2_wrapper">
+                                        <div class="data-category__h3">
+                                            <div data-w-id="d9dcf788-413f-9049-8723-d6b050277cba"
+                                                 class="data-category__h3_trigger">
+                                                <div class="truncate">Indicator</div>
+                                                <div class="data-category__h3_loading hidden"><img
+                                                        src="images/loading.gif" alt=""></div>
+                                                <div class="data-category__h3_load-complete hidden">
+                                                    <div class="svg-icon w-embed">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                             viewbox="0 0 24 24">
+                                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                                            <path fill="currentColor"
+                                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                        </svg>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div style="height:0PX" class="data-category__h3_content">
+                                                <div class="data-category__h3_wrapper">
+                                                    <div class="data-category__h4_line-v"></div>
+                                                    <a href="#" class="data-category__h4 w-inline-block">
+                                                        <div class="data-category__h4_line-h"></div>
+                                                        <div class="truncate">Subindicator</div>
+                                                        <div class="data-category__h4_loading hidden"><img
+                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_load-complete hidden">
+                                                            <div class="svg-icon w-embed">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                     height="24" viewbox="0 0 24 24">
+                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                    <path fill="currentColor"
+                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                    <a href="#" class="data-category__h4 w-inline-block">
+                                                        <div class="data-category__h4_line-h"></div>
+                                                        <div class="truncate">Subindicator</div>
+                                                        <div class="data-category__h4_loading"><img
+                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_load-complete hidden">
+                                                            <div class="svg-icon w-embed">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                     height="24" viewbox="0 0 24 24">
+                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                    <path fill="currentColor"
+                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                    <a href="#" class="data-category__h4 active w-inline-block">
+                                                        <div class="data-category__h4_line-h"></div>
+                                                        <div class="truncate">Subindicator</div>
+                                                        <div class="data-category__h4_loading hidden"><img
+                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_load-complete">
+                                                            <div class="svg-icon w-embed">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                     height="24" viewbox="0 0 24 24">
+                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                    <path fill="currentColor"
+                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="data-category__h3">
+                                            <div data-w-id="1e35aa5d-6794-7eaf-27f0-84b06b77495c"
+                                                 class="data-category__h3_trigger">
+                                                <div class="truncate">Indicator</div>
+                                                <div class="data-category__h3_loading"><img src="images/loading.gif"
+                                                                                            alt=""></div>
+                                                <div class="data-category__h3_load-complete hidden">
+                                                    <div class="svg-icon w-embed">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                             viewbox="0 0 24 24">
+                                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                                            <path fill="currentColor"
+                                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                        </svg>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="data-category__h3_content hidden">
+                                                <div class="data-category__h3_wrapper">
+                                                    <div class="data-category__h4_line-v"></div>
+                                                    <a href="#" class="data-category__h4 w-inline-block">
+                                                        <div class="data-category__h4_line-h"></div>
+                                                        <div class="truncate">Subindicator</div>
+                                                        <div class="data-category__h4_loading hidden"><img
+                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_load-complete hidden">
+                                                            <div class="svg-icon w-embed">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                     height="24" viewbox="0 0 24 24">
+                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                    <path fill="currentColor"
+                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                    <a href="#" class="data-category__h4 w-inline-block">
+                                                        <div class="data-category__h4_line-h"></div>
+                                                        <div class="truncate">Subindicator</div>
+                                                        <div class="data-category__h4_loading"><img
+                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_load-complete hidden">
+                                                            <div class="svg-icon w-embed">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                     height="24" viewbox="0 0 24 24">
+                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                    <path fill="currentColor"
+                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                    <a href="#" class="data-category__h4 active w-inline-block">
+                                                        <div class="data-category__h4_line-h"></div>
+                                                        <div class="truncate">Subindicator</div>
+                                                        <div class="data-category__h4_loading hidden"><img
+                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_load-complete">
+                                                            <div class="svg-icon w-embed">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                     height="24" viewbox="0 0 24 24">
+                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                    <path fill="currentColor"
+                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="data-category__h3">
+                                            <div data-w-id="5cc4d99e-ac57-fc58-7a13-748080bb6e5e"
+                                                 class="data-category__h3_trigger active">
+                                                <div class="truncate">Indicator</div>
+                                                <div class="data-category__h3_loading hidden"><img
+                                                        src="images/loading.gif" alt=""></div>
+                                                <div class="data-category__h3_load-complete">
+                                                    <div class="svg-icon w-embed">
+                                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                             viewbox="0 0 24 24">
+                                                            <path d="M0 0h24v24H0z" fill="none"></path>
+                                                            <path fill="currentColor"
+                                                                  d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                        </svg>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="data-category__h3_content hidden">
+                                                <div class="data-category__h3_wrapper">
+                                                    <div class="data-category__h4_line-v"></div>
+                                                    <a href="#" class="data-category__h4 w-inline-block">
+                                                        <div class="data-category__h4_line-h"></div>
+                                                        <div class="truncate">Subindicator</div>
+                                                        <div class="data-category__h4_loading hidden"><img
+                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_load-complete hidden">
+                                                            <div class="svg-icon w-embed">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                     height="24" viewbox="0 0 24 24">
+                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                    <path fill="currentColor"
+                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                    <a href="#" class="data-category__h4 w-inline-block">
+                                                        <div class="data-category__h4_line-h"></div>
+                                                        <div class="truncate">Subindicator</div>
+                                                        <div class="data-category__h4_loading"><img
+                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_load-complete hidden">
+                                                            <div class="svg-icon w-embed">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                     height="24" viewbox="0 0 24 24">
+                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                    <path fill="currentColor"
+                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                    <a href="#" class="data-category__h4 active w-inline-block">
+                                                        <div class="data-category__h4_line-h"></div>
+                                                        <div class="truncate">Subindicator</div>
+                                                        <div class="data-category__h4_loading hidden"><img
+                                                                src="images/loading.gif" alt=""></div>
+                                                        <div class="data-category__h4_load-complete">
+                                                            <div class="svg-icon w-embed">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="24"
+                                                                     height="24" viewbox="0 0 24 24">
+                                                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                                                    <path fill="currentColor"
+                                                                          d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                                                </svg>
+                                                            </div>
+                                                        </div>
+                                                    </a>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="styles__section">
+            <div class="styles__title">
+                <div>Rich Data Header</div>
+            </div>
+            <div class="styles__subsection">
+                <div>Rich data nav item</div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <a href="#top" class="rich-data-nav__item w-inline-block">
+                    <div class="rich-data-nav__item-text">
+                        <div class="truncate">Section title</div>
+                    </div>
+                    <div class="rich-data-nav__item-icon">
+                        <div class="svg-icon w-embed">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor"
+                                      d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
+                            </svg>
+                        </div>
+                    </div>
+                </a>
+            </div>
+            <div class="styles__subsection">
+                <div>Location breadcrumbs</div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <div class="breadcrumb">
+                    <div class="truncate">Parent geography</div>
+                </div>
+            </div>
+            <div class="styles__subsection">
+                <div>Location facilities</div>
+            </div>
+            <div class="styles__area_block wide">
+                <div class="location__facilities">
+                    <div class="location__facilities_header--loading">
+                        <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                        <div class="location__facilities_title_loading">
+                            <div>Loading facilities...</div>
+                        </div>
+                    </div>
+                    <div class="location__facilities_header hidden">
+                        <div class="location__facilities_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                                    <path fill="currentColor"
+                                          d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="location__facilities_title">
+                            <div>This <span class="location__facilities_geo-type">location</span> has <span
+                                    class="location__facilities_facilities-value"><strong>0000</strong></span><strong>
+                                facilities</strong> in <span
+                                    class="location__facilities_categories-value"><strong>0000</strong></span><strong>
+                                categories</strong>.
+                            </div>
+                        </div>
+                    </div>
+                    <div class="location__facilities_trigger hidden">
+                        <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d4" style="display:flex"
+                             class="location__facilities_expand">
+                            <div>Show facilities</div>
+                        </div>
+                        <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d7" style="display:none"
+                             class="location__facilities_contract">
+                            <div>Hide facilities</div>
+                        </div>
+                    </div>
+                    <div style="height:0PX" class="location__facilities_content">
+                        <div class="location__facilities_content-wrapper">
+                            <div class="location__facilities_loading hidden">
+                                <div class="loading">
+                                    <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                                    <div class="loading__text">
+                                        <div>Loading...</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="location__facilities_no-data hidden">
+                                <div class="no-data">
+                                    <div class="no-data__icon">
+                                        <div class="svg-icon w-embed">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                 viewbox="0 0 24 24">
+                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                <path fill="currentColor"
+                                                      d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                                            </svg>
+                                        </div>
+                                    </div>
+                                    <div class="no-data__text">
+                                        <div>No facilities for this location</div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="location-facility">
+                                <div class="location-facility__card">
+                                    <div class="location-facility__category">
+                                        <div class="location-facility__header">
+                                            <div class="location-facility__icon">
+                                                <div class="svg-icon w-embed">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="100%" height=""
+                                                         viewbox="0 0 24 24">
+                                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                                        <path fill="currentColor"
+                                                              d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                                    </svg>
+                                                </div>
+                                            </div>
+                                            <div class="location-facility__name">
+                                                <div>Point data category</div>
+                                            </div>
+                                        </div>
+                                        <div class="location-facility__value">
+                                            <div>0000</div>
+                                        </div>
+                                    </div>
+                                    <div class="location-facility__list">
+                                        <a href="#" class="location-facility__list_item w-inline-block">
+                                            <div class="location-facility__item_name">
+                                                <div class="truncate">Point data item</div>
+                                            </div>
+                                            <div class="location-facility__item_value">
+                                                <div>0000</div>
+                                            </div>
+                                            <div id="w-node-a4312e607bde-e148319d"
+                                                 class="location-facility__item_download">
+                                                <div class="svg-icon small w-embed">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                         viewbox="0 0 24 24">
+                                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                                        <path fill="currentColor"
+                                                              d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                                                    </svg>
+                                                </div>
+                                            </div>
+                                        </a>
+                                        <a href="#" class="location-facility__list_item last w-inline-block">
+                                            <div class="location-facility__item_name">
+                                                <div class="truncate">Point data item</div>
+                                            </div>
+                                            <div class="location-facility__item_value">
+                                                <div>0000</div>
+                                            </div>
+                                            <div id="w-node-a4312e607be7-e148319d"
+                                                 class="location-facility__item_download">
+                                                <div class="svg-icon small w-embed">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                         viewbox="0 0 24 24">
+                                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                                        <path fill="currentColor"
+                                                              d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                                                    </svg>
+                                                </div>
+                                            </div>
+                                        </a>
+                                    </div>
+                                    <div class="location-facility__description">
+                                        <div>Description text that describes this point data category in relation to
+                                            surrounding locations
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="location__facilities_sources">
+                                <div class="label">
+                                    <div>Sources:</div>
+                                </div>
+                                <div class="location__sources_loading">
+                                    <div class="loading">
+                                        <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                                        <div class="loading__text">
+                                            <div>Loading...</div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="location__sources_no-data hidden">
+                                    <div class="no-data">
+                                        <div class="no-data__text">
+                                            <div>No source data available</div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="styles__section">
+            <div class="styles__title">
+                <div>Navigation search</div>
+            </div>
+            <div class="styles__subsection">
+                <div>Search dropdown list items</div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <div class="facility-tooltip">
+                    <div class="facility-tooltip__header">
+                        <div class="facility-tooltip__header_icon">
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
+                        </div>
+                        <div class="facility-tooltip__header_name">Loading...</div>
+                    </div>
+                    <div class="facility-tooltip__scroll-wrapper">
+                        <div class="facility-tooltip__items">
+                            <div class="facility-tooltip__item last">
+                                <div class="tooltip__facility-item_label">Loading...</div>
+                                <div class="tooltip__facility-item_value">...</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="facility-tooltip__open-modal">More info</div>
+                    <div class="facility-tooltip__close">
+                        <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                            <path d="M0 0h24v24H0z" fill="none"></path>
+                            <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                        </svg></div>
+                    </div>
+                    <div class="tooltip__notch"></div>
+                </div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <div data-w-id="8d9eb87a-805a-ef6a-0ef3-bca9e2f0f208" class="search__dropdown_list-item active">
+                    <div class="search__list-item_location-name">
+                        <div class="truncate">Location name</div>
+                    </div>
+                    <div class="search__list-item_location-parent">
+                        <div class="truncate">Parent</div>
+                    </div>
+                    <div id="w-node-bca9e2f0f20f-e148319d" class="search__list-item_location-type">
+                        <div class="truncate">Location Type</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="styles__section">
+            <div class="styles__title">
+                <div>Rich Data Indicator</div>
+            </div>
+            <div class="styles__subsection">
+                <div>Rich data section title</div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <div class="category-header">
+                    <div class="category-header__content">
+                        <div class="category-header__title">
+                            <div class="category-header__icon">
+                                <div class="svg-icon large w-embed">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                        <path fill="currentColor"
+                                              d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                    </svg>
+                                </div>
+                            </div>
+                            <div class="category-header__text">
+                                <h2 class="cc-clear">Category title</h2>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="category-header__description">
+                        <p>Category description. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__subsection">
+                <div>Rich data indicator header</div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <div class="sub-category-header first">
+                    <div class="sub-category-header__title">
+                        <div class="indicator__title_wrapper">
+                            <h3 class="cc-clear">Indicator title</h3>
+                            <div class="h3__line-v"></div>
+                        </div>
+                    </div>
+                    <div class="sub-category-header__description">
+                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros
+                            elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut
+                            commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem
+                            imperdiet. Nunc ut sem vitae risus tristique posuere.</p>
+                    </div>
+                    <div class="sub-category-header__key-metrics">
+                        <div class="sub-category-header__key-metrics_title">
+                            <div>KEY METRICS for this indicator</div>
+                        </div>
+                        <div class="sub-category-header__key-metrics_wrap">
+                            <div class="key-metric">
+                                <div class="key-metric__card">
+                                    <div class="key-metric__value">
+                                        <div class="truncate">00</div>
+                                    </div>
+                                    <div class="key-metric__title">
+                                        <div>Metric title</div>
+                                    </div>
+                                    <div class="key-metric__description">
+                                        <div>Description text that describes this metric in relation to surrounding
+                                            locations
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="key-metric">
+                                <div class="key-metric__card">
+                                    <div class="key-metric__value">
+                                        <div class="truncate">00</div>
+                                    </div>
+                                    <div class="key-metric__title">
+                                        <div>Metric title</div>
+                                    </div>
+                                    <div class="key-metric__description">
+                                        <div>Description text that describes this metric in relation to surrounding
+                                            locations
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="key-metric">
+                                <div class="key-metric__card">
+                                    <div class="key-metric__value">
+                                        <div class="truncate">00</div>
+                                    </div>
+                                    <div class="key-metric__title">
+                                        <div>Metric title</div>
+                                    </div>
+                                    <div class="key-metric__description">
+                                        <div>Description text that describes this metric in relation to surrounding
+                                            locations
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="key-metric">
+                                <div class="key-metric__card">
+                                    <div class="key-metric__value">
+                                        <div class="truncate">00</div>
+                                    </div>
+                                    <div class="key-metric__title">
+                                        <div>Metric title</div>
+                                    </div>
+                                    <div class="key-metric__description">
+                                        <div>Description text that describes this metric in relation to surrounding
+                                            locations
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="styles__subsection">
+                <div>Rich data sub-indicator</div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <div class="profile-indicator last">
+                    <div class="profile-indicator__header">
+                        <div class="profile-indicator__title">
+                            <h4>Indicator chart title</h4>
+                        </div>
+                        <div class="profile-indicator__options">
+                            <div class="hover-menu">
+                                <div class="hover-menu__icon">
+                                    <div class="svg-icon w-embed">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                             viewbox="0 0 24 24">
+                                            <path fill="currentColor"
+                                                  d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
+                                        </svg>
+                                    </div>
+                                </div>
+                                <div class="hover-menu__content">
+                                    <div class="hover-menu__content_wrapper">
+                                        <a href="#" class="hover-menu__content_item w-inline-block">
+                                            <div class="icon--small"><img
+                                                    src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c397204ee09f13_image-24px.svg"
+                                                    alt=""></div>
+                                            <div class="content__item_title">
+                                                <div>Save as image</div>
+                                            </div>
+                                        </a>
+                                        <div class="hover-menu__content_item--no-link">
+                                            <div class="icon--small">
+                                                <div class="svg-icon small w-embed">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                         viewbox="0 0 24 24">
+                                                        <path d="M0 0h24v24H0z" fill="none"></path>
+                                                        <path fill="currentColor"
+                                                              d="M21 6H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v8z"></path>
+                                                    </svg>
+                                                </div>
+                                            </div>
+                                            <div class="content__item_title">
+                                                <div>Chart values as:</div>
+                                            </div>
+                                        </div>
+                                        <div class="hover-menu__content_list">
+                                            <a href="#" class="hover-menu__content_list-item active w-inline-block">
+                                                <div>Percentage</div>
+                                            </a>
+                                            <a href="#" class="hover-menu__content_list-item--last w-inline-block">
+                                                <div>Value</div>
+                                            </a>
+                                        </div>
+                                        <div class="hover-menu__content_item--no-link">
+                                            <div class="icon--small"><img
+                                                    src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c3974bdbe09f2e_download-24px.svg"
+                                                    alt=""></div>
+                                            <div class="content__item_title">
+                                                <div>Click to download data:</div>
+                                            </div>
+                                        </div>
+                                        <div class="hover-menu__content_list--last">
+                                            <a href="#" class="hover-menu__content_list-item w-inline-block">
+                                                <div>CSV</div>
+                                            </a>
+                                            <a href="#" class="hover-menu__content_list-item w-inline-block">
+                                                <div>Excel</div>
+                                            </a>
+                                            <a href="#" class="hover-menu__content_list-item w-inline-block">
+                                                <div>JSON</div>
+                                            </a>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="profile-indicator__filters">
+                        <div class="filter__dropdown_wrap">
+                            <div class="dropdown-menu__label">
+                                <div>Select a value:</div>
+                            </div>
+                            <div class="dropdown-menu">
+                                <div class="dropdown-menu__trigger">
+                                    <div class="dropdown-menu__selected-item">
+                                        <div class="truncate">All values</div>
+                                    </div>
+                                    <div class="dropdown-menu__icon">
+                                        <div class="svg-icon w-embed">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                 viewbox="0 0 24 24">
+                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                <path fill="currentColor"
+                                                      d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                                            </svg>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="dropdown-menu__content scroll-element">
+                                    <div class="dropdown__list_item selected">
+                                        <div class="truncate">All values</div>
+                                    </div>
+                                    <div class="dropdown__list_item">
+                                        <div class="truncate">Value name</div>
+                                    </div>
+                                    <div class="dropdown__list_item">
+                                        <div class="truncate">Value name</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="filter__dropdown_wrap disabled">
+                            <div class="dropdown-menu__label">
+                                <div>FILTER BY:</div>
+                            </div>
+                            <div class="dropdown-menu">
+                                <div class="dropdown-menu__trigger">
+                                    <div class="dropdown-menu__selected-item">
+                                        <div class="truncate">All values</div>
+                                    </div>
+                                    <div class="dropdown-menu__icon">
+                                        <div class="svg-icon w-embed">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"
+                                                 viewbox="0 0 24 24">
+                                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                                <path fill="currentColor"
+                                                      d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                                            </svg>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="dropdown-menu__content scroll-element">
+                                    <div class="dropdown__list_item selected">
+                                        <div class="truncate">All filters</div>
+                                    </div>
+                                    <div class="dropdown__list_item">
+                                        <div class="truncate">Filter name</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="profile-indicator__chart">
+                        <div class="profile-indicator__chart_body">
+                            <div class="indicator__chart full">
+                                <div class="bar-chart">
+                                    <div class="bar-chart__main">
+                                        <div class="bar-chart__labels">
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__label">
+                                                <div class="bar-chart__label_position">
+                                                    <div class="bar-chart__label_value">
+                                                        <div>0%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="bar-chart__rows">
+                                            <div class="bar-chart__row">
+                                                <div class="bar-chart__row_label">
+                                                    <div class="truncate">Truncation of the following sentence</div>
+                                                </div>
+                                                <div class="bar-chart__row-wrapper">
+                                                    <div class="bar-chart__row_bar _1">
+                                                        <div class="bar-chart__row_tooltip">
+                                                            <div class="bar-chart__row_tooltip-card">
+                                                                <div class="bar-chart__tooltip_name">
+                                                                    <div>Long chart label looks like this</div>
+                                                                </div>
+                                                                <div class="bar-chart__tooltip_value">
+                                                                    <div>00%</div>
+                                                                </div>
+                                                                <div class="bar-chart__tooltip_alt-value">
+                                                                    <div>000,000,000</div>
+                                                                </div>
+                                                                <div class="bar-chart__row_tooltip-notch"></div>
+                                                            </div>
+                                                        </div>
+                                                    </div>
+                                                    <div class="bar-chart__row_value">
+                                                        <div class="truncate">00%</div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div class="bar-chart__underline"></div>
+                                        </div>
+                                    </div>
+                                    <div class="bar-chart__x-label">
+                                        <div>Label Goes here</div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="profile-indicator__chart_footer">
+                            <div class="profile-indicator__chart_description">
+                                <p>Sub-indicator chart footnote goes here and helps to describe the data presented</p>
+                            </div>
+                            <div class="profile-indicator__chart_source">
+                                <div class="chart__footer_label">
+                                    <div>Source:</div>
+                                </div>
+                                <div class="data-source">
+                                    <div>Data source name</div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="styles__section">
+            <div class="styles__title">
+                <div>Map</div>
+            </div>
+            <div class="styles__subsection">
+                <div>Map tooltip</div>
+            </div>
+            <div class="styles__area_block test">
+                <div class="map-tooltip">
+                    <div class="map-tooltip__geography-chip">
+                        <div>MUNICIPALITY</div>
+                    </div>
+                    <div class="map-tooltip__name">
+                        <div>Elim</div>
+                    </div>
+                    <div class="map-tooltip__value hidden">
+                        <div class="tooltip__value_label">
+                            <div class="truncate">Language most spoken at home:</div>
+                        </div>
+                        <div class="tooltip__value_wrapper">
+                            <div class="tooltip__value_amount">
+                                <div>24,539</div>
+                            </div>
+                            <div class="tooltip__value_detail">
+                                <div>(24%)</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tooltip__notch"></div>
+                </div>
+            </div>
+            <div class="styles__area_block test">
+                <div class="map-tooltip">
+                    <div class="map-tooltip__geography-chip">
+                        <div>MUNICIPALITY</div>
+                    </div>
+                    <div class="map-tooltip__name">
+                        <div>Elim</div>
+                    </div>
+                    <div class="map-tooltip__value">
+                        <div class="tooltip__value_label">
+                            <div class="truncate">Short label:</div>
+                        </div>
+                        <div class="tooltip__value_wrapper">
+                            <div class="tooltip__value_amount">
+                                <div>24,539</div>
+                            </div>
+                            <div class="tooltip__value_detail">
+                                <div>(24%)</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="map-tooltip__value">
+                        <div class="tooltip__value_label">
+                            <div class="truncate">Short label:</div>
+                        </div>
+                        <div class="tooltip__value_wrapper">
+                            <div class="tooltip__value_amount">
+                                <div>24,539</div>
+                            </div>
+                            <div class="tooltip__value_detail">
+                                <div>(24%)</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="map-tooltip__value">
+                        <div class="tooltip__value_label">
+                            <div class="truncate">Short label:</div>
+                        </div>
+                        <div class="tooltip__value_wrapper">
+                            <div class="tooltip__value_amount">
+                                <div>24,539</div>
+                            </div>
+                            <div class="tooltip__value_detail">
+                                <div>(24%)</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tooltip__notch"></div>
+                </div>
+            </div>
+            <div class="styles__area_block test">
+                <div class="map-tooltip">
+                    <div class="map-tooltip__geography-chip">
+                        <div>MUNICIPALITY</div>
+                    </div>
+                    <div class="map-tooltip__name">
+                        <div>Elim</div>
+                    </div>
+                    <div class="map-tooltip__value">
+                        <div class="tooltip__value_label">
+                            <div class="truncate">Long label that gets truncated outside of the box width:</div>
+                        </div>
+                        <div class="tooltip__value_wrapper">
+                            <div class="tooltip__value_amount">
+                                <div>24,539</div>
+                            </div>
+                            <div class="tooltip__value_detail">
+                                <div>(24%)</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="map-tooltip__value">
+                        <div class="tooltip__value_label">
+                            <div class="truncate">Long label that gets truncated outside of the box width:</div>
+                        </div>
+                        <div class="tooltip__value_wrapper">
+                            <div class="tooltip__value_amount">
+                                <div>24,539</div>
+                            </div>
+                            <div class="tooltip__value_detail">
+                                <div>(24%)</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="map-tooltip__value">
+                        <div class="tooltip__value_label">
+                            <div class="truncate">Long label that gets truncated outside of the box width:</div>
+                        </div>
+                        <div class="tooltip__value_wrapper">
+                            <div class="tooltip__value_amount">
+                                <div>24,539</div>
+                            </div>
+                            <div class="tooltip__value_detail">
+                                <div>(24%)</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="tooltip__notch"></div>
+                </div>
+            </div>
+            <div class="styles__subsection">
+                <div>Facility tooltip</div>
+            </div>
+            <div class="styles__area_block horizontal wide">
+                <div class="facility-tooltip">
+                    <div class="facility-tooltip__header">
+                        <div class="facility-tooltip__header_icon">
+                            <div class="svg-icon w-embed">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor"
+                                          d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                                </svg>
+                            </div>
+                        </div>
+                        <div class="facility-tooltip__header_name">
+                            <div>Elim High School</div>
+                        </div>
+                    </div>
+                    <div class="facility-tooltip__items">
+                        <div class="facility-tooltip__item">
+                            <div class="tooltip__facility-item_label">
+                                <div>Address:</div>
+                            </div>
+                            <div class="tooltip__facility-item_value">
+                                <div>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris aliquet libero
+                                    ullamcorper, blandit felis sit amet, rhoncus eros. Nam sed dolor id quam ullamcorper
+                                    rhoncus.
+                                </div>
+                            </div>
+                        </div>
+                        <div class="facility-tooltip__item">
+                            <div class="tooltip__facility-item_label">
+                                <div>Phone:</div>
+                            </div>
+                            <div class="tooltip__facility-item_value">
+                                <div>09123901293</div>
+                            </div>
+                        </div>
+                        <div class="facility-tooltip__item">
+                            <div class="tooltip__facility-item_label">
+                                <div>Website:</div>
+                            </div>
+                            <div class="tooltip__facility-item_value">
+                                <div>
+                                    <a href="#">www.test.com</a>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="facility-tooltip__item last">
+                            <div class="tooltip__facility-item_label">
+                                <div>Email:</div>
+                            </div>
+                            <div class="tooltip__facility-item_value">
+                                <div>
+                                    <a target="_blank" href="mailto:appletreenat@gmail.com">appletreenat@gmail.com</a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="facility-tooltip__close">
+                        <div class="svg-icon svg-icon--no-size w-embed">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor"
+                                      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                            </svg>
+                        </div>
+                    </div>
+                    <div class="tooltip__notch"></div>
+                </div>
+            </div>
+            <div class="styles__subsection">
+                <div>Map legend</div>
+            </div>
+            <div class="styles__area_block horizontal">
+                <div class="map_legend-block">
+                    <div class="truncate">value</div>
+                </div>
+                <div class="map_legend-block light">
+                    <div class="truncate">value</div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="print-styling w-embed">
     <style>
-@media print {
-/*--padding adjustments--*/
-	.location__description, .location__sources .profile-indicator {
-  	padding-bottom: 0px;
-  }
-  .section {
-  	padding-bottom: 20px;
-  }
-  .sub-category-header__key-metrics {
-  	padding-bottom: 12px;
-  }
-  .profile-indicator__header {
-  	margin-bottom: 0px;
-  }
-	.sub-category-header__title {
-  	margin-bottom: 12px;
-  }
-  .profile-indicator__chart {
-  	margin-top: 0px;
-  }
-/*--hide unwanted elements in print--*/
-  .nav, .login-modal, .category-header__link, .location__header, .profile-indicator__options, .sticky-header, .tutorial-modal, .styles, .map, .point-mapper, .data-mapper, .panel-toggles, .rich-data-nav, .rich-data-bumper, .rich-data-toggles {
-    display: none;
-  }
-/*--avoid page breaks--*/
-	.sub-category-header {
- 		break-inside: avoid;
-	}
-	.profile-indicator {
-  	break-inside: avoid;
-  }
-/*--hide interaction buttons--*/
-.location-facility__list_item {
-	grid-template-columns: 4fr 1fr .0;
-  }
-.location-facility__item_download {
-	display: none;
-  }
-/*--adjust rich-data panel to fill page--*/
-	.rich-data, .rich-data-content {
-  	max-width: 100%;
-    width: 100%;
-	}
-  .rich-data-content {
-  	padding: 0px;
-    filter: grayscale(100%);
-  }
-/*--adjust text size--*/
-  .body {
- 	 font-size: 12px !important;
-  }
-/*--adjust charts--*/
-.bar-chart__row_bar {
-	background-color: #000 !important;
-  }
-}
-</style>
-  </div>
-  <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5ecb7ed6bb713f2f4b48319b" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-  <script src="js/webflow.js" type="text/javascript"></script>
-  <!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
-  <style>
-  #dev-tools {
-    z-index:200;
-  }
-  #map-download-title {
-   position: fixed;
-   top: 80px;
-   z-index: 998;
-   width: 100%;
-   text-align: center;
-   font-size: 30px;
-   font-weight: bold;
-   color: white;
- }
-  #map-download-legend {
-   position: absolute;
-   bottom: 50px;
-   z-index: 998;
-   width: 100%;
-   display: flex;
-   justify-content: center;
- }
-  #map-download-legend .map-options__legend_wrap {
-   background: white;
-   padding: 5px;
-   height: 29px;
-   max-width: 397px;
- }
-</style> <!--  Used for the autocomplete search box  -->
-  <link href="https://code.jquery.com/ui/1.12.0/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css">
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css">
-  <link rel="stylesheet" href="https://openup.org.za/wazimap-ng-ui/wazimap-ng.css">
-  <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
-  <!--  Material design icons  -->
-  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-  <!--  used the the autocomplete search box  -->
-  <script crossorigin="anonymous" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E=" src="https://code.jquery.com/ui/1.12.0/jquery-ui.min.js"></script>
-  <script src="https://bevacqua.github.io/dragula/dist/dragula.js"></script>
-  <script>
-	var drake = dragula({
-  isContainer: function (el) {
-    return el.classList.contains('dragula-container');
-  }
-});
-</script>
-  <script src="js/index.js"></script>
-  <script>
-setTimeout(function(){
-		$('.w-webflow-badge').css({'display':'none !important'});
-}, 2000);
-</script>
-  <style>
-/*------------------------------------- Map attribution hide */
-  .leaflet-control-attribution {
-    display: none !important;
+        @media print {
+            /*--padding adjustments--*/
+            .location__description, .location__sources .profile-indicator {
+                padding-bottom: 0px;
+            }
+
+            .section {
+                padding-bottom: 20px;
+            }
+
+            .sub-category-header__key-metrics {
+                padding-bottom: 12px;
+            }
+
+            .profile-indicator__header {
+                margin-bottom: 0px;
+            }
+
+            .sub-category-header__title {
+                margin-bottom: 12px;
+            }
+
+            .profile-indicator__chart {
+                margin-top: 0px;
+            }
+
+            /*--hide unwanted elements in print--*/
+            .nav, .login-modal, .category-header__link, .location__header, .profile-indicator__options, .sticky-header, .tutorial-modal, .styles, .map, .point-mapper, .data-mapper, .panel-toggles, .rich-data-nav, .rich-data-bumper, .rich-data-toggles {
+                display: none;
+            }
+
+            /*--avoid page breaks--*/
+            .sub-category-header {
+                break-inside: avoid;
+            }
+
+            .profile-indicator {
+                break-inside: avoid;
+            }
+
+            /*--hide interaction buttons--*/
+            .location-facility__list_item {
+                grid-template-columns: 4fr 1fr .0;
+            }
+
+            .location-facility__item_download {
+                display: none;
+            }
+
+            /*--adjust rich-data panel to fill page--*/
+            .rich-data, .rich-data-content {
+                max-width: 100%;
+                width: 100%;
+            }
+
+            .rich-data-content {
+                padding: 0px;
+                filter: grayscale(100%);
+            }
+
+            /*--adjust text size--*/
+            .body {
+                font-size: 12px !important;
+            }
+
+            /*--adjust charts--*/
+            .bar-chart__row_bar {
+                background-color: #000 !important;
+            }
+        }
+    </style>
+</div>
+<script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5ecb7ed6bb713f2f4b48319b"
+        type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0="
+        crossorigin="anonymous"></script>
+<script src="js/webflow.js" type="text/javascript"></script>
+<!-- [if lte IE 9]>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
+<style>
+    #dev-tools {
+        z-index: 200;
     }
-/*------------------------------------- Truncation */
-.truncate {
-	width: 100%;
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	}
-/*------------------------------------- Hidden important */
-.hidden {
-	display: none !important;
-  }
-/*------------------------------------- Hide webflow items on deploy */
-.disabled {
-  pointer-events: none;
-}  
-/*------------------------------------- Hide scrollbar for Chrome, Safari and Opera */
-.no-scroll::-webkit-scrollbar {
-  display: none;
-}
-/*------------------------------------- Hide scrollbar for IE and Edge */
-.no-scroll {
-  -ms-overflow-style: none;
-}
-/*-------- Narrow scroll bar */
-/*width*/
-.narrow-scroll::-webkit-scrollbar {
-  width:4px;
-}
-/*track*/
-.narrow-scroll::-webkit-scrollbar-track {
-  background:rgba(255, 255, 255, 0);
-  border-color:rgb(255, 255, 255);
-}
-/*thumb*/
-.narrow-scroll::-webkit-scrollbar-thumb {
-  background:rgb(98, 98, 98);
-  border-color:rgb(51, 51, 51);
-  border-radius:2px;
-}
-/*-------- Custom slider checkbox */  
-.switch {
-  position: relative;
-  display: inline-block;
-  width: 32px;
-  height: 20px;
-}
-.switch input { 
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-.slider {
-  position: absolute;
-  cursor: pointer;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: #00000030;
-  -webkit-transition: .1s;
-  transition: .1s;
-}
-.slider:before {
-  position: absolute;
-  content: "";
-  height: 12px;
-  width: 12px;
-  left: 4px;
-  bottom: 4px;
-  background-color: white;
-  -webkit-transition: .1s;
-  transition: .1s;
-}
-input:checked + .slider {
-  background-color: #3c3c3c;
-}
-input:checked + .slider:before {
-  -webkit-transform: translateX(26px);
-  -ms-transform: translateX(12px);
-  transform: translateX(12px);
-}
-/* Rounded sliders */
-.slider.round {
-  border-radius: 34px;
-}
-.slider.round:before {
-  border-radius: 50%;
-}
-/*-------- Fixing Chart Lines */  
-.bar-tooltip {
-  z-index: 100;
-}
-line, .grid {
-  stroke: #999;
-}
+
+    #map-download-title {
+        position: fixed;
+        top: 80px;
+        z-index: 998;
+        width: 100%;
+        text-align: center;
+        font-size: 30px;
+        font-weight: bold;
+        color: white;
+    }
+
+    #map-download-legend {
+        position: absolute;
+        bottom: 50px;
+        z-index: 998;
+        width: 100%;
+        display: flex;
+        justify-content: center;
+    }
+
+    #map-download-legend .map-options__legend_wrap {
+        background: white;
+        padding: 5px;
+        height: 29px;
+        max-width: 397px;
+    }
+</style> <!--  Used for the autocomplete search box  -->
+<link href="https://code.jquery.com/ui/1.12.0/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css">
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css">
+<link rel="stylesheet" href="https://openup.org.za/wazimap-ng-ui/wazimap-ng.css">
+<script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
+<!--  Material design icons  -->
+<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+<!--  used the the autocomplete search box  -->
+<script crossorigin="anonymous" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E="
+        src="https://code.jquery.com/ui/1.12.0/jquery-ui.min.js"></script>
+<script src="https://bevacqua.github.io/dragula/dist/dragula.js"></script>
+<script>
+    var drake = dragula({
+        isContainer: function (el) {
+            return el.classList.contains('dragula-container');
+        }
+    });
+</script>
+<script src="js/index.js"></script>
+<script>
+    setTimeout(function () {
+        $('.w-webflow-badge').css({'display': 'none !important'});
+    }, 2000);
+</script>
+<style>
+    /*------------------------------------- Map attribution hide */
+    .leaflet-control-attribution {
+        display: none !important;
+    }
+
+    /*------------------------------------- Truncation */
+    .truncate {
+        width: 100%;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    /*------------------------------------- Hidden important */
+    .hidden {
+        display: none !important;
+    }
+
+    /*------------------------------------- Hide webflow items on deploy */
+    .disabled {
+        pointer-events: none;
+    }
+
+    /*------------------------------------- Hide scrollbar for Chrome, Safari and Opera */
+    .no-scroll::-webkit-scrollbar {
+        display: none;
+    }
+
+    /*------------------------------------- Hide scrollbar for IE and Edge */
+    .no-scroll {
+        -ms-overflow-style: none;
+    }
+
+    /*-------- Narrow scroll bar */
+    /*width*/
+    .narrow-scroll::-webkit-scrollbar {
+        width: 4px;
+    }
+
+    /*track*/
+    .narrow-scroll::-webkit-scrollbar-track {
+        background: rgba(255, 255, 255, 0);
+        border-color: rgb(255, 255, 255);
+    }
+
+    /*thumb*/
+    .narrow-scroll::-webkit-scrollbar-thumb {
+        background: rgb(98, 98, 98);
+        border-color: rgb(51, 51, 51);
+        border-radius: 2px;
+    }
+
+    /*-------- Custom slider checkbox */
+    .switch {
+        position: relative;
+        display: inline-block;
+        width: 32px;
+        height: 20px;
+    }
+
+    .switch input {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+
+    .slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #00000030;
+        -webkit-transition: .1s;
+        transition: .1s;
+    }
+
+    .slider:before {
+        position: absolute;
+        content: "";
+        height: 12px;
+        width: 12px;
+        left: 4px;
+        bottom: 4px;
+        background-color: white;
+        -webkit-transition: .1s;
+        transition: .1s;
+    }
+
+    input:checked + .slider {
+        background-color: #3c3c3c;
+    }
+
+    input:checked + .slider:before {
+        -webkit-transform: translateX(26px);
+        -ms-transform: translateX(12px);
+        transform: translateX(12px);
+    }
+
+    /* Rounded sliders */
+    .slider.round {
+        border-radius: 34px;
+    }
+
+    .slider.round:before {
+        border-radius: 50%;
+    }
+
+    /*-------- Fixing Chart Lines */
+    .bar-tooltip {
+        z-index: 100;
+    }
+
+    line, .grid {
+        stroke: #999;
+    }
 </style>
 </body>
 </html>

--- a/src/index.html
+++ b/src/index.html
@@ -2,22 +2,22 @@
 <!--  Last Published: Tue Dec 08 2020 09:13:20 GMT+0000 (Coordinated Universal Time)  -->
 <html data-wf-page="5ecb7ed6bb713f67e148319d" data-wf-site="5ecb7ed6bb713f2f4b48319b">
 <head>
-    <meta charset="utf-8">
-    <title>Wazimap NG</title>
-    <meta content="width=device-width, initial-scale=1" name="viewport">
-    <meta content="Webflow" name="generator">
-    <link href="css/normalize.css" rel="stylesheet" type="text/css">
-    <link href="css/webflow.css" rel="stylesheet" type="text/css">
-    <link href="css/wazimap-ng-v1.webflow.css" rel="stylesheet" type="text/css">
-    <style>@media (max-width:479px) {html.w-mod-js:not(.w-mod-ix) [data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825"] {-webkit-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);}html.w-mod-js:not(.w-mod-ix) [data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50"] {width:44PX;}html.w-mod-js:not(.w-mod-ix) [data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7"] {-webkit-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);-moz-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);-ms-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);}}</style>
-    <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
-    <script type="text/javascript">WebFont.load({  google: {    families: ["Roboto:300,regular,italic,500,500italic,700,900"]  }});</script>
-    <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
-    <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
-    <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon">
-    <link href="images/webclip.png" rel="apple-touch-icon">
-    <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-93649482-25"></script>
-    <script>
+  <meta charset="utf-8">
+  <title>Wazimap NG</title>
+  <meta content="width=device-width, initial-scale=1" name="viewport">
+  <meta content="Webflow" name="generator">
+  <link href="css/normalize.css" rel="stylesheet" type="text/css">
+  <link href="css/webflow.css" rel="stylesheet" type="text/css">
+  <link href="css/wazimap-ng-v1.webflow.css" rel="stylesheet" type="text/css">
+  <style>@media (max-width:479px) {html.w-mod-js:not(.w-mod-ix) [data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825"] {-webkit-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);}html.w-mod-js:not(.w-mod-ix) [data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50"] {width:44PX;}html.w-mod-js:not(.w-mod-ix) [data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7"] {-webkit-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);-moz-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);-ms-transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);transform:translate3d(0PX, 0, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0DEG) skew(0, 0);}}</style>
+  <script src="https://ajax.googleapis.com/ajax/libs/webfont/1.6.26/webfont.js" type="text/javascript"></script>
+  <script type="text/javascript">WebFont.load({  google: {    families: ["Roboto:300,regular,italic,500,500italic,700,900"]  }});</script>
+  <!-- [if lt IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" type="text/javascript"></script><![endif] -->
+  <script type="text/javascript">!function(o,c){var n=c.documentElement,t=" w-mod-";n.className+=t+"js",("ontouchstart"in o||o.DocumentTouch&&c instanceof DocumentTouch)&&(n.className+=t+"touch")}(window,document);</script>
+  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon">
+  <link href="images/webclip.png" rel="apple-touch-icon">
+  <script async="" src="https://www.googletagmanager.com/gtag/js?id=UA-93649482-25"></script>
+  <script>
         window.dataLayer = window.dataLayer || [];
         function gtag() {
             dataLayer.push(arguments);
@@ -30,3118 +30,3118 @@
         });
         window.gtag = gtag;
     </script>
-    <script src="https://kit.fontawesome.com/95e41092af.js" crossorigin="anonymous"></script>
+  <script src="https://kit.fontawesome.com/95e41092af.js" crossorigin="anonymous"></script>
 </head>
 <body class="body no-scroll">
-<div class="login-modal hidden">
+  <div class="login-modal hidden">
     <div class="login">
-        <div id="w-node-11a67e6ccd44-e148319d" class="login__title">
-            <h1 class="clear">Login Required</h1>
+      <div id="w-node-11a67e6ccd44-e148319d" class="login__title">
+        <h1 class="clear">Login Required</h1>
+      </div>
+      <div id="w-node-31f6ef2aede4-e148319d" data-w-id="138f8096-55b2-2cf7-756a-31f6ef2aede4" class="login__close">
+        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+            <path d="M0 0h24v24H0z" fill="none"></path>
+            <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+          </svg></div>
+      </div>
+      <div id="w-node-09c3cf7a9fe2-e148319d" class="login__description">
+        <div>This is private instance of Wazimap and requires you to be an authorized user to access it.</div>
+      </div>
+      <div id="w-node-222d0aaebade-e148319d" class="login__form">
+        <div class="form-block w-form">
+          <form id="wf-form-Login-Form" name="wf-form-Login-Form" data-name="Login Form"><label for="Email">Username</label><input type="email" class="text-field w-input" maxlength="256" name="Email" data-name="Email" placeholder="" id="Email" required=""><label for="Password">Password</label><input type="password" class="text-field w-input" maxlength="256" name="Password" data-name="Password" id="Password" required="">
+            <div class="login-form__actions"><label id="w-node-fefcf113a3cc-e148319d" class="w-checkbox login-form__checkbox">
+                <div class="w-checkbox-input w-checkbox-input--inputType-custom custom-checkbox"></div><input type="checkbox" id="checkbox-2" name="checkbox-2" data-name="Checkbox 2" style="opacity:0;position:absolute;z-index:-1"><span class="checkbox-label w-form-label">Remember me</span>
+              </label><input type="submit" value="Login" data-wait="Please wait..." id="w-node-fceb1157e41b-e148319d" class="button w-button">
+              <a id="w-node-25fe1e234621-e148319d" href="#">Forgot your password?</a>
+            </div>
+          </form>
+          <div class="w-form-done">
+            <div>Thank you! Your submission has been received!</div>
+          </div>
+          <div class="w-form-fail">
+            <div>Oops! Something went wrong while submitting the form.</div>
+          </div>
         </div>
-        <div id="w-node-31f6ef2aede4-e148319d" data-w-id="138f8096-55b2-2cf7-756a-31f6ef2aede4" class="login__close">
-            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                <path d="M0 0h24v24H0z" fill="none"></path>
-                <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+      </div>
+    </div>
+  </div>
+  <div class="tutorial-modal">
+    <div class="tutorial">
+      <div class="tutorial__header">
+        <div class="tutorial__title">
+          <h1 class="clear">How to use</h1>
+        </div>
+        <div data-w-id="6ca2d157-b860-d2c0-78da-11837bc90d1d" data-testid="tutorial-close" class="tutorial__close">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
             </svg></div>
         </div>
-        <div id="w-node-09c3cf7a9fe2-e148319d" class="login__description">
-            <div>This is private instance of Wazimap and requires you to be an authorized user to access it.</div>
-        </div>
-        <div id="w-node-222d0aaebade-e148319d" class="login__form">
-            <div class="form-block w-form">
-                <form id="wf-form-Login-Form" name="wf-form-Login-Form" data-name="Login Form"><label for="Email">Username</label><input type="email" class="text-field w-input" maxlength="256" name="Email" data-name="Email" placeholder="" id="Email" required=""><label for="Password">Password</label><input type="password" class="text-field w-input" maxlength="256" name="Password" data-name="Password" id="Password" required="">
-                    <div class="login-form__actions"><label id="w-node-fefcf113a3cc-e148319d" class="w-checkbox login-form__checkbox">
-                        <div class="w-checkbox-input w-checkbox-input--inputType-custom custom-checkbox"></div><input type="checkbox" id="checkbox-2" name="checkbox-2" data-name="Checkbox 2" style="opacity:0;position:absolute;z-index:-1"><span class="checkbox-label w-form-label">Remember me</span>
-                    </label><input type="submit" value="Login" data-wait="Please wait..." id="w-node-fceb1157e41b-e148319d" class="button w-button">
-                        <a id="w-node-25fe1e234621-e148319d" href="#">Forgot your password?</a>
-                    </div>
-                </form>
-                <div class="w-form-done">
-                    <div>Thank you! Your submission has been received!</div>
+      </div>
+      <div data-animation="cross" data-nav-spacing="4" data-duration="500" id="w-node-d1064d900402-e148319d" class="tutorial__slider w-slider">
+        <div class="mask w-slider-mask">
+          <div class="slide w-slide">
+            <div class="tutorial__slide-content">
+              <div class="tutorial__slide-info">
+                <div><span class="slide-info__title">Introduction:</span> <span class="slide-info__introduction">This website was developed to enable you to easily find spatial information related to geographic areas. By clicking on the map or using the search bar, you can navigate to an area of interest and find relevant information about it.</span></div>
+              </div>
+              <div class="tutorial__slide-image _1">
+                <div class="tutorial__slide_gradient bottom"></div>
+                <div class="tutorial__slide-number">
+                  <div>1/8</div>
                 </div>
-                <div class="w-form-fail">
-                    <div>Oops! Something went wrong while submitting the form.</div>
-                </div>
+              </div>
             </div>
+          </div>
+          <div class="slide w-slide">
+            <div class="tutorial__slide-content">
+              <div class="tutorial__slide-info">
+                <div><span class="slide-info__title">Location Search:</span> To get started, first select a location on the map or use the search box to find the location you would like to analyse.</div>
+              </div>
+              <div class="tutorial__slide-image _2">
+                <div class="tutorial__slide-number">
+                  <div>2/8</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="slide w-slide">
+            <div class="tutorial__slide-content">
+              <div class="tutorial__slide-info">
+                <div><span class="slide-info__title">Location Panel:</span> Basic information for your selected location can be found in the Location Panel. Use the buttons to navigate to parent locations.</div>
+              </div>
+              <div class="tutorial__slide-image _2b">
+                <div class="tutorial__slide-number">
+                  <div>3/8</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="slide w-slide">
+            <div class="tutorial__slide-content">
+              <div class="tutorial__slide-info">
+                <div><span class="slide-info__title">Rich Data:</span> To view rich data specific to the location you selected, open the Rich Data panel in the left toolbar.</div>
+              </div>
+              <div class="tutorial__slide-image _3">
+                <div class="tutorial__slide-number">
+                  <div>4/8</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="slide w-slide">
+            <div class="tutorial__slide-content">
+              <div class="tutorial__slide-info">
+                <div><span class="slide-info__title">Point Mapper:</span> To add point data to the map, use the Point Mapper to show different facilities in that area.</div>
+              </div>
+              <div class="tutorial__slide-image _4">
+                <div class="tutorial__slide-number">
+                  <div>5/8</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="slide w-slide">
+            <div class="tutorial__slide-content">
+              <div class="tutorial__slide-info">
+                <div><span class="slide-info__title">Data Mapper:</span> To overlay compatible datasets onto your location, open the Data Mapper and choose from the available indicators.</div>
+              </div>
+              <div class="tutorial__slide-image _5">
+                <div class="tutorial__slide-number">
+                  <div>6/8</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="slide w-slide">
+            <div class="tutorial__slide-content">
+              <div class="tutorial__slide-info">
+                <div><span class="slide-info__title">Data Filtering:</span> Once you&#x27;ve mapped a data-set (eg. gender), use the Data Filter to select a sub-indicator for that data-set (eg. male)</div>
+              </div>
+              <div class="tutorial__slide-image _7">
+                <div class="tutorial__slide-number">
+                  <div>7/8</div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div class="slide w-slide">
+            <div class="tutorial__slide-content">
+              <div class="tutorial__slide-info">
+                <div><span class="slide-info__title">Learn more:</span> For more information on how to use specific features, look out for tutorial icons. For an in-depth guide on using this site, please see our <a href="https://openup.gitbook.io/wazimap-ng-user-guide/" target="_blank">user manual</a>.</div>
+              </div>
+              <div class="tutorial__slide-image _7">
+                <div class="tutorial__slide-number">
+                  <div>8/8</div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
+        <div class="left-arrow w-slider-arrow-left">
+          <div class="tutorial__slide_button previous">
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path>
+              </svg></div>
+          </div>
+        </div>
+        <div class="right-arrow w-slider-arrow-right">
+          <div class="tutorial__slide_button next">
+            <div class="text-block">Next</div>
+          </div>
+        </div>
+        <div class="slide-nav w-slider-nav w-slider-nav-invert w-round"></div>
+      </div>
     </div>
-</div>
-<div class="tutorial-modal">
-    <div class="tutorial">
-        <div class="tutorial__header">
-            <div class="tutorial__title">
-                <h1 class="clear">How to use</h1>
+  </div>
+  <div class="warning-modal hidden">
+    <div class="warning">
+      <div class="warning__header">
+        <div class="warning-title">
+          <h1 class="clear">Map boundary change</h1>
+        </div>
+      </div>
+      <div class="warning__content">
+        <div class="w-richtext">
+          <p>Changing your boundary type might deselect your current geography or adjust your view of the map.</p>
+          <p><strong>Are you sure you would like to proceed?</strong></p>
+        </div>
+      </div>
+      <div id="w-node-0df91218fa5c-e148319d" class="warning__actions">
+        <div id="w-node-0df91218fa5d-e148319d" class="dismiss__no-show">
+          <div class="html-embed w-embed">
+            <p><input type="checkbox" class="custom-checkbox" name="dismiss__no-show" id="no-show"></p>
+          </div>
+          <div class="checkbox-label">Don&#x27;t show again</div>
+        </div>
+        <div id="w-node-0df91218fa61-e148319d" class="button-wrapper">
+          <a href="#" class="button button--margin-right button--grey w-button">Cancel</a>
+          <a id="warning-proceed" href="#" class="button button--margin-right w-button">Proceed</a>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="main">
+    <div class="nav">
+      <div data-w-id="66ee4f1f-99f3-8310-c69c-b5d00bdac74c" style="opacity:1;display:none" class="nav__search-deselect"></div>
+      <div class="nav__shadow"></div>
+      <div class="nav__content">
+        <a id="w-node-926b3e9c855a-e148319d" href="#" class="nav__content_title w-inline-block">
+          <div class="nav__profile-logo"><img src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg" alt="" class="profile-logo"></div>
+        </a>
+        <div id="w-node-926b3e9c8568-e148319d" class="nav__content_search">
+          <div class="nav__search_input">
+            <div data-w-id="2331a044-806f-907c-13ce-926b3e9c8576" class="search__input w-form">
+              <form id="email-form" name="email-form" data-name="Email Form" method="post" class="form"><input type="text" class="location__search_input w-input" autocomplete="off" maxlength="256" name="Location" data-name="Location" placeholder="Search for a location..." id="Location">
+                <div class="location__search_loading hidden"><img src="images/loading.gif" alt=""></div>
+              </form>
+              <div class="w-form-done">
+                <div>Thank you! Your submission has been received!</div>
+              </div>
+              <div class="w-form-fail">
+                <div>Oops! Something went wrong while submitting the form.</div>
+              </div>
             </div>
-            <div data-w-id="6ca2d157-b860-d2c0-78da-11837bc90d1d" data-testid="tutorial-close" class="tutorial__close">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+            <div class="nav__search_button">
+              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none"></path>
+                  <path fill="currentColor" d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
                 </svg></div>
             </div>
+          </div>
+          <div style="display:none;opacity:0" class="nav__search_dropdown">
+            <div class="search__dropdown_plate">
+              <div class="search__dropdown_scroll narrow-scroll">
+                <div class="search__dropdown_content">
+                  <div class="search__dropdown_results-label">
+                    <div>Results (<span class="search__dropdown_results-value">0</span>):</div>
+                  </div>
+                  <div class="search__dropdown_list">
+                    <div class="search__dropdown_no-data">
+                      <div class="no-data">
+                        <div class="no-data__icon">
+                          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                              <path d="M0 0h24v24H0z" fill="none"></path>
+                              <path fill="currentColor" d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"></path>
+                            </svg></div>
+                        </div>
+                        <div class="no-data__text">
+                          <div>Start typing to begin...</div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
-        <div data-animation="cross" data-nav-spacing="4" data-duration="500" id="w-node-d1064d900402-e148319d" class="tutorial__slider w-slider">
-            <div class="mask w-slider-mask">
-                <div class="slide w-slide">
-                    <div class="tutorial__slide-content">
-                        <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Introduction:</span> <span class="slide-info__introduction">This website was developed to enable you to easily find spatial information related to geographic areas. By clicking on the map or using the search bar, you can navigate to an area of interest and find relevant information about it.</span></div>
-                        </div>
-                        <div class="tutorial__slide-image _1">
-                            <div class="tutorial__slide_gradient bottom"></div>
-                            <div class="tutorial__slide-number">
-                                <div>1/8</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="slide w-slide">
-                    <div class="tutorial__slide-content">
-                        <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Location Search:</span> To get started, first select a location on the map or use the search box to find the location you would like to analyse.</div>
-                        </div>
-                        <div class="tutorial__slide-image _2">
-                            <div class="tutorial__slide-number">
-                                <div>2/8</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="slide w-slide">
-                    <div class="tutorial__slide-content">
-                        <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Location Panel:</span> Basic information for your selected location can be found in the Location Panel. Use the buttons to navigate to parent locations.</div>
-                        </div>
-                        <div class="tutorial__slide-image _2b">
-                            <div class="tutorial__slide-number">
-                                <div>3/8</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="slide w-slide">
-                    <div class="tutorial__slide-content">
-                        <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Rich Data:</span> To view rich data specific to the location you selected, open the Rich Data panel in the left toolbar.</div>
-                        </div>
-                        <div class="tutorial__slide-image _3">
-                            <div class="tutorial__slide-number">
-                                <div>4/8</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="slide w-slide">
-                    <div class="tutorial__slide-content">
-                        <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Point Mapper:</span> To add point data to the map, use the Point Mapper to show different facilities in that area.</div>
-                        </div>
-                        <div class="tutorial__slide-image _4">
-                            <div class="tutorial__slide-number">
-                                <div>5/8</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="slide w-slide">
-                    <div class="tutorial__slide-content">
-                        <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Data Mapper:</span> To overlay compatible datasets onto your location, open the Data Mapper and choose from the available indicators.</div>
-                        </div>
-                        <div class="tutorial__slide-image _5">
-                            <div class="tutorial__slide-number">
-                                <div>6/8</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="slide w-slide">
-                    <div class="tutorial__slide-content">
-                        <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Data Filtering:</span> Once you&#x27;ve mapped a data-set (eg. gender), use the Data Filter to select a sub-indicator for that data-set (eg. male)</div>
-                        </div>
-                        <div class="tutorial__slide-image _7">
-                            <div class="tutorial__slide-number">
-                                <div>7/8</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="slide w-slide">
-                    <div class="tutorial__slide-content">
-                        <div class="tutorial__slide-info">
-                            <div><span class="slide-info__title">Learn more:</span> For more information on how to use specific features, look out for tutorial icons. For an in-depth guide on using this site, please see our <a href="https://openup.gitbook.io/wazimap-ng-user-guide/" target="_blank">user manual</a>.</div>
-                        </div>
-                        <div class="tutorial__slide-image _7">
-                            <div class="tutorial__slide-number">
-                                <div>8/8</div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="left-arrow w-slider-arrow-left">
-                <div class="tutorial__slide_button previous">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M15.41 7.41L14 6l-6 6 6 6 1.41-1.41L10.83 12z"></path>
-                    </svg></div>
-                </div>
-            </div>
-            <div class="right-arrow w-slider-arrow-right">
-                <div class="tutorial__slide_button next">
-                    <div class="text-block">Next</div>
-                </div>
-            </div>
-            <div class="slide-nav w-slider-nav w-slider-nav-invert w-round"></div>
-        </div>
-    </div>
-</div>
-<div class="warning-modal hidden">
-    <div class="warning">
-        <div class="warning__header">
-            <div class="warning-title">
-                <h1 class="clear">Map boundary change</h1>
-            </div>
-        </div>
-        <div class="warning__content">
-            <div class="w-richtext">
-                <p>Changing your boundary type might deselect your current geography or adjust your view of the map.</p>
-                <p><strong>Are you sure you would like to proceed?</strong></p>
-            </div>
-        </div>
-        <div id="w-node-0df91218fa5c-e148319d" class="warning__actions">
-            <div id="w-node-0df91218fa5d-e148319d" class="dismiss__no-show">
-                <div class="html-embed w-embed">
-                    <p><input type="checkbox" class="custom-checkbox" name="dismiss__no-show" id="no-show"></p>
-                </div>
-                <div class="checkbox-label">Don&#x27;t show again</div>
-            </div>
-            <div id="w-node-0df91218fa61-e148319d" class="button-wrapper">
-                <a href="#" class="button button--margin-right button--grey w-button">Cancel</a>
-                <a id="warning-proceed" href="#" class="button button--margin-right w-button">Proceed</a>
-            </div>
-        </div>
-    </div>
-</div>
-<div class="main">
-    <div class="nav">
-        <div data-w-id="66ee4f1f-99f3-8310-c69c-b5d00bdac74c" style="opacity:1;display:none" class="nav__search-deselect"></div>
-        <div class="nav__shadow"></div>
-        <div class="nav__content">
-            <a id="w-node-926b3e9c855a-e148319d" href="#" class="nav__content_title w-inline-block">
-                <div class="nav__profile-logo"><img src="https://d3e54v103j8qbb.cloudfront.net/plugins/Basic/assets/placeholder.60f9b1840c.svg" alt="" class="profile-logo"></div>
+        <div id="w-node-926b3e9c85a0-e148319d" class="nav__content_menu">
+          <div class="nav__link-wrap">
+            <a data-w-id="2331a044-806f-907c-13ce-926b3e9c8565" href="#" class="nav__link tutorial__open w-inline-block">
+              <div class="nav__link_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+                  </svg></div>
+              </div>
+              <div class="nav__link_text">
+                <div>Tutorial</div>
+              </div>
             </a>
-            <div id="w-node-926b3e9c8568-e148319d" class="nav__content_search">
-                <div class="nav__search_input">
-                    <div data-w-id="2331a044-806f-907c-13ce-926b3e9c8576" class="search__input w-form">
-                        <form id="email-form" name="email-form" data-name="Email Form" method="post" class="form"><input type="text" class="location__search_input w-input" autocomplete="off" maxlength="256" name="Location" data-name="Location" placeholder="Search for a location..." id="Location">
-                            <div class="location__search_loading hidden"><img src="images/loading.gif" alt=""></div>
-                        </form>
-                        <div class="w-form-done">
-                            <div>Thank you! Your submission has been received!</div>
-                        </div>
-                        <div class="w-form-fail">
-                            <div>Oops! Something went wrong while submitting the form.</div>
-                        </div>
-                    </div>
-                    <div class="nav__search_button">
-                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"></path>
-                        </svg></div>
-                    </div>
-                </div>
-                <div style="display:none;opacity:0" class="nav__search_dropdown">
-                    <div class="search__dropdown_plate">
-                        <div class="search__dropdown_scroll narrow-scroll">
-                            <div class="search__dropdown_content">
-                                <div class="search__dropdown_results-label">
-                                    <div>Results (<span class="search__dropdown_results-value">0</span>):</div>
-                                </div>
-                                <div class="search__dropdown_list">
-                                    <div class="search__dropdown_no-data">
-                                        <div class="no-data">
-                                            <div class="no-data__icon">
-                                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                    <path fill="currentColor" d="M20 5H4c-1.1 0-1.99.9-1.99 2L2 17c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm-9 3h2v2h-2V8zm0 3h2v2h-2v-2zM8 8h2v2H8V8zm0 3h2v2H8v-2zm-1 2H5v-2h2v2zm0-3H5V8h2v2zm9 7H8v-2h8v2zm0-4h-2v-2h2v2zm0-3h-2V8h2v2zm3 3h-2v-2h2v2zm0-3h-2V8h2v2z"></path>
-                                                </svg></div>
-                                            </div>
-                                            <div class="no-data__text">
-                                                <div>Start typing to begin...</div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div id="w-node-926b3e9c85a0-e148319d" class="nav__content_menu">
-                <div class="nav__link-wrap">
-                    <a data-w-id="2331a044-806f-907c-13ce-926b3e9c8565" href="#" class="nav__link tutorial__open w-inline-block">
-                        <div class="nav__link_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="nav__link_text">
-                            <div>Tutorial</div>
-                        </div>
-                    </a>
-                    <a data-w-id="9ed47308-e332-9825-644e-4ad6bb204fab" href="#" class="nav__link hidden w-inline-block">
-                        <div class="nav__link_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5c-1.11 0-2 .9-2 2v4h2V5h14v14H5v-4H3v4c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="nav__link_text">
-                            <div>Login</div>
-                        </div>
-                    </a>
-                </div>
-                <div class="nav__menu-trigger hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
-                    </svg></div>
-                </div>
-            </div>
+            <a data-w-id="9ed47308-e332-9825-644e-4ad6bb204fab" href="#" class="nav__link hidden w-inline-block">
+              <div class="nav__link_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M10.09 15.59L11.5 17l5-5-5-5-1.41 1.41L12.67 11H3v2h9.67l-2.58 2.59zM19 3H5c-1.11 0-2 .9-2 2v4h2V5h14v14H5v-4H3v4c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2z"></path>
+                  </svg></div>
+              </div>
+              <div class="nav__link_text">
+                <div>Login</div>
+              </div>
+            </a>
+          </div>
+          <div class="nav__menu-trigger hidden">
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
+              </svg></div>
+          </div>
         </div>
+      </div>
     </div>
     <div class="map">
-        <div class="map-about hidden">
-            <div class="map-about__icon">
-                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
-                </svg></div>
-            </div>
-            <div class="map-about__profile-name">
-                <div>Profile name</div>
-            </div>
-            <div>. <a href="#">Learn more</a>
-                <a href="#"></a>
-            </div>
-        </div>
-        <div class="map-location">
-            <div class="map-location__tags">
-                <div title="Click to make this your primary search" class="location-tag__loading">
-                    <div class="location-tag__type">
-                        <div>LOCATION TYPE</div>
-                    </div>
-                    <div class="location-tag__name">
-                        <div class="truncate text-center">Loading...</div>
-                    </div>
-                    <div class="location-tag__loading-icon"><img src="images/loading.gif" width="10" alt=""></div>
-                </div>
-            </div>
-            <div class="map-location__info"></div>
-        </div>
-        <div class="map-options hidden">
-            <div class="map-options__filters">
-                <div class="map-options__filters_header">
-                    <div class="filter__header_sub-indicator">
-                        <div class="filters__header_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="filters__header_name">
-                            <div class="truncate">indicator name</div>
-                        </div>
-                    </div>
-                    <div data-w-id="a0a0a80b-723d-9f06-08f8-22ecf4a4bddb" class="filters__header_toggle">
-                        <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="toggle-icon-v--first w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
-                        </svg></div>
-                        <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="toggle-icon-v--last w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
-                        </svg></div>
-                    </div>
-                    <div data-w-id="f7f05345-5dc5-101e-109a-a0291cc7b897" class="filters__header_close">
-                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                        </svg></div>
-                    </div>
-                </div>
-                <div style="display:flex" class="map-options__filters_content">
-                    <div class="mapping-options__filter">
-                        <div class="mapping-options__filter_label">
-                            <div>Select a value:</div>
-                        </div>
-                        <div data-w-id="c3edb6cb-8fc8-3508-f112-94613483dd79" class="mapping-options__filter_menu">
-                            <div class="dropdown-menu__trigger narrow">
-                                <div class="dropdown-menu__selected-item">
-                                    <div class="truncate">All values</div>
-                                </div>
-                                <div class="dropdown-menu__icon">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="dropdown-menu__content position-top scroll-element">
-                                <div class="dropdown__list_item selected">
-                                    <div class="truncate">All values</div>
-                                </div>
-                                <div class="dropdown__list_item">
-                                    <div class="truncate">Value</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="mapping-options__filter disabled">
-                        <div class="mapping-options__filter_label">
-                            <div>FILTER BY:</div>
-                        </div>
-                        <div data-w-id="fd26a4e0-f0f7-aaf0-9eee-32c6e9fb2e19" class="mapping-options__filter_menu">
-                            <div class="dropdown-menu__trigger narrow">
-                                <div class="dropdown-menu__selected-item">
-                                    <div class="truncate">All filters</div>
-                                </div>
-                                <div class="dropdown-menu__icon">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="dropdown-menu__content position-top scroll-element">
-                                <div class="dropdown__list_item selected">
-                                    <div class="truncate">All Filters</div>
-                                </div>
-                                <div class="dropdown__list_item">
-                                    <div class="truncate">Filter</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="map-options__legend">
-                <div class="map-options__legend_label">
-                    <div>LEGEND:</div>
-                </div>
-                <div class="map-options__legend_wrap">
-                    <div class="map-options__legend_loading">
-                        <div class="truncate">Loading...</div>
-                        <div class="legend-block__loading-icon"><img src="images/loading.gif" alt=""></div>
-                    </div>
-                </div>
-            </div>
-            <div style="display:flex" class="map-options__context">
-                <div class="map-option__context_text">
-                    <div>Indicator context</div>
-                </div>
-                <div data-w-id="dfcf026d-123b-ec2d-3d1f-5646d4025e7b" class="map-options__context_tooltip">
-                    <div style="display:none" class="tooltip">
-                        <div class="tooltip-card dark">
-                            <div class="tooltip-text">
-                                <div>Tooltip text</div>
-                            </div>
-                            <div class="tooltip-notch dark"></div>
-                        </div>
-                    </div>
-                    <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
-                    </svg></div>
-                </div>
-            </div>
-        </div>
-        <div class="map-geo-select hidden">
-            <div class="mag-geo__dropdown_wrap">
-                <div class="dropdown-menu__label">
-                    <div>BOUNDARY type select:</div>
-                </div>
-                <div class="dropdown-menu">
-                    <div class="dropdown-menu__trigger">
-                        <div class="dropdown-menu__selected-item">
-                            <div class="truncate">Loading...</div>
-                        </div>
-                        <div class="dropdown-menu__icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                            </svg></div>
-                        </div>
-                    </div>
-                    <div class="dropdown-menu__content dropdown-menu__content--top scroll-element">
-                        <div class="dropdown__list_item selected">
-                            <div class="truncate">Loading...</div>
-                        </div>
-                        <div class="dropdown__list_item">
-                            <div class="truncate">Loading...</div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div title="Download map" class="map-download">
-            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                <path d="M0 0h24v24H0z" fill="none"></path>
-                <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+      <div class="map-about hidden">
+        <div class="map-about__icon">
+          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
             </svg></div>
         </div>
-        <div id="main-map" class="map-area"></div>
+        <div class="map-about__profile-name">
+          <div>Profile name</div>
+        </div>
+        <div>. <a href="#">Learn more</a>
+          <a href="#"></a>
+        </div>
+      </div>
+      <div class="map-location">
+        <div class="map-location__tags">
+          <div title="Click to make this your primary search" class="location-tag__loading">
+            <div class="location-tag__type">
+              <div>LOCATION TYPE</div>
+            </div>
+            <div class="location-tag__name">
+              <div class="truncate text-center">Loading...</div>
+            </div>
+            <div class="location-tag__loading-icon"><img src="images/loading.gif" width="10" alt=""></div>
+          </div>
+        </div>
+        <div class="map-location__info"></div>
+      </div>
+      <div class="map-options hidden">
+        <div class="map-options__filters">
+          <div class="map-options__filters_header">
+            <div class="filter__header_sub-indicator">
+              <div class="filters__header_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+                  </svg></div>
+              </div>
+              <div class="filters__header_name">
+                <div class="truncate">indicator name</div>
+              </div>
+            </div>
+            <div data-w-id="a0a0a80b-723d-9f06-08f8-22ecf4a4bddb" class="filters__header_toggle">
+              <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="toggle-icon-v--first w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none"></path>
+                  <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
+                </svg></div>
+              <div style="-webkit-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, 0PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="toggle-icon-v--last w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none"></path>
+                  <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
+                </svg></div>
+            </div>
+            <div data-w-id="f7f05345-5dc5-101e-109a-a0291cc7b897" class="filters__header_close">
+              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none"></path>
+                  <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                </svg></div>
+            </div>
+          </div>
+          <div style="display:flex" class="map-options__filters_content">
+            <div class="mapping-options__filter">
+              <div class="mapping-options__filter_label">
+                <div>Select a value:</div>
+              </div>
+              <div data-w-id="c3edb6cb-8fc8-3508-f112-94613483dd79" class="mapping-options__filter_menu">
+                <div class="dropdown-menu__trigger narrow">
+                  <div class="dropdown-menu__selected-item">
+                    <div class="truncate">All values</div>
+                  </div>
+                  <div class="dropdown-menu__icon">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="dropdown-menu__content position-top scroll-element">
+                  <div class="dropdown__list_item selected">
+                    <div class="truncate">All values</div>
+                  </div>
+                  <div class="dropdown__list_item">
+                    <div class="truncate">Value</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="mapping-options__filter disabled">
+              <div class="mapping-options__filter_label">
+                <div>FILTER BY:</div>
+              </div>
+              <div data-w-id="fd26a4e0-f0f7-aaf0-9eee-32c6e9fb2e19" class="mapping-options__filter_menu">
+                <div class="dropdown-menu__trigger narrow">
+                  <div class="dropdown-menu__selected-item">
+                    <div class="truncate">All filters</div>
+                  </div>
+                  <div class="dropdown-menu__icon">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="dropdown-menu__content position-top scroll-element">
+                  <div class="dropdown__list_item selected">
+                    <div class="truncate">All Filters</div>
+                  </div>
+                  <div class="dropdown__list_item">
+                    <div class="truncate">Filter</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="map-options__legend">
+          <div class="map-options__legend_label">
+            <div>LEGEND:</div>
+          </div>
+          <div class="map-options__legend_wrap">
+            <div class="map-options__legend_loading">
+              <div class="truncate">Loading...</div>
+              <div class="legend-block__loading-icon"><img src="images/loading.gif" alt=""></div>
+            </div>
+          </div>
+        </div>
+        <div style="display:flex" class="map-options__context">
+          <div class="map-option__context_text">
+            <div>Indicator context</div>
+          </div>
+          <div data-w-id="dfcf026d-123b-ec2d-3d1f-5646d4025e7b" class="map-options__context_tooltip">
+            <div style="display:none" class="tooltip">
+              <div class="tooltip-card dark">
+                <div class="tooltip-text">
+                  <div>Tooltip text</div>
+                </div>
+                <div class="tooltip-notch dark"></div>
+              </div>
+            </div>
+            <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-6h2v6zm0-8h-2V7h2v2z"></path>
+              </svg></div>
+          </div>
+        </div>
+      </div>
+      <div class="map-geo-select hidden">
+        <div class="mag-geo__dropdown_wrap">
+          <div class="dropdown-menu__label">
+            <div>BOUNDARY type select:</div>
+          </div>
+          <div class="dropdown-menu">
+            <div class="dropdown-menu__trigger">
+              <div class="dropdown-menu__selected-item">
+                <div class="truncate">Loading...</div>
+              </div>
+              <div class="dropdown-menu__icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                  </svg></div>
+              </div>
+            </div>
+            <div class="dropdown-menu__content dropdown-menu__content--top scroll-element">
+              <div class="dropdown__list_item selected">
+                <div class="truncate">Loading...</div>
+              </div>
+              <div class="dropdown__list_item">
+                <div class="truncate">Loading...</div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div title="Download map" class="map-download">
+        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+            <path d="M0 0h24v24H0z" fill="none"></path>
+            <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+          </svg></div>
+      </div>
+      <div id="main-map" class="map-area"></div>
     </div>
     <div class="rich-data">
-        <div data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825" class="rich-data-nav">
-            <div data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7" class="rich-data-nav__toggle">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M3 18h13v-2H3v2zm0-5h10v-2H3v2zm0-7v2h13V6H3zm18 9.59L17.42 12 21 8.41 19.59 7l-5 5 5 5L21 15.59z"></path>
-                </svg></div>
-            </div>
-            <div class="rich-data-nav__list">
-                <a href="#top" class="rich-data-nav__item w-inline-block">
-                    <div class="rich-data-nav__item-text">
-                        <div class="truncate">Summary</div>
-                    </div>
-                    <div class="rich-data-nav__item-icon">
-                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
-                        </svg></div>
-                    </div>
-                </a>
-            </div>
-        </div>
-        <div data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50" class="rich-data-bumper"></div>
-        <div class="rich-data-content">
-            <div class="rich-data__shadow"></div>
-            <div style="-webkit-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="sticky-header">
-                <div title="Click to make this your primary search" class="sticky-header__current-location">
-                    <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                    <div class="loading__text">
-                        <div class="truncate">Loading... </div>
-                    </div>
-                </div>
-                <div class="sticky-header__tutorial hidden">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-                    </svg></div>
-                </div>
-            </div>
-            <section class="section header">
-                <div id="top" class="section-link"></div>
-                <div class="location__header">
-                    <div class="location__breadcrumbs hidden">
-                        <div class="label">
-                            <div>Navigate to:</div>
-                        </div>
-                        <div class="breadcrumb">
-                            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                            <div class="loading__text">
-                                <div>Loading... </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="location__tutorial hidden">
-                        <div class="location__tutorial_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
-                            </svg></div>
-                        </div>
-                        <div>Quick tutorial</div>
-                    </div>
-                </div>
-                <div data-w-id="a462ef20-a798-735c-f166-106a34080855" class="location__title">
-                    <div class="loading">
-                        <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                        <div class="loading__text">
-                            <div>Loading... </div>
-                        </div>
-                    </div>
-                </div>
-                <div class="location__description hidden">
-                    <div>A <span class="location-type">Location type</span> in <span class="parent-geography">parent geography</span></div>
-                </div>
-                <div class="location__facilities">
-                    <div class="location__facilities_no-data hidden">
-                        <div class="no-data">
-                            <div class="no-data__icon">
-                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                                </svg></div>
-                            </div>
-                            <div class="no-data__text">
-                                <div>No facilities for this location</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="location__facilities_loading">
-                        <div class="loading">
-                            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                            <div class="loading__text">
-                                <div>Loading... </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="location__facilities_header hidden">
-                        <div class="location__facilities_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                                <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="location__facilities_title">
-                            <div>This <span class="location__facilities_geo-type">location</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> facilities</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
-                        </div>
-                    </div>
-                    <div class="location__facilities_trigger hidden">
-                        <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6ad" style="display:flex" class="location__facilities_expand">
-                            <div>Show facilities</div>
-                        </div>
-                        <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6b0" style="display:none" class="location__facilities_contract">
-                            <div>Hide facilities</div>
-                        </div>
-                    </div>
-                    <div style="height:0PX" class="location__facilities_content">
-                        <div class="location__facilities_content-wrapper">
-                            <div class="location__facilities_sources">
-                                <div class="label">
-                                    <div>Sources:</div>
-                                </div>
-                                <div class="location__sources_loading">
-                                    <div class="loading">
-                                        <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                                        <div class="loading__text">
-                                            <div>Loading... </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="location__sources_no-data hidden">
-                                    <div class="no-data">
-                                        <div class="no-data__text">
-                                            <div>No source data available</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </section>
-            <div class="section">
-                <div class="section-link"></div>
-            </div>
-        </div>
-        <div class="rich-data-toggles">
-            <div data-w-id="1b738c3c-f509-9ebc-f15d-d66894a02164" class="panel-toggle rich-data-panel__close cc-active">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-                </svg></div>
-                <div class="panel-toggle__tooltip">
-                    <div class="panel-toggle__tooltip_text">
-                        <div>Rich Data</div>
-                    </div>
-                    <div class="panel-toggle__tooltip_notch"></div>
-                </div>
-            </div>
-            <div data-w-id="1260faa6-080e-87e0-2b01-fe2eba016dcb" class="panel-toggle point-mapper-panel__open">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                </svg></div>
-                <div class="panel-toggle__tooltip">
-                    <div class="panel-toggle__tooltip_text">
-                        <div>Point Mapper</div>
-                    </div>
-                    <div class="panel-toggle__tooltip_notch"></div>
-                </div>
-            </div>
-            <div data-w-id="ef6902f7-5288-a426-a2e6-ee2a693e86d7" class="panel-toggle data-mapper-panel__open">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                </svg></div>
-                <div class="panel-toggle__tooltip">
-                    <div class="panel-toggle__tooltip_text">
-                        <div>Data Mapper</div>
-                    </div>
-                    <div class="panel-toggle__tooltip_notch"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="facility-info">
-        <div class="facility-info__header">
-            <h3 class="facility-info__title">Loading...</h3>
-            <div title="Download information (.pdf)" class="facility-info__download">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-                </svg></div>
-            </div>
-            <div title="Close" class="facility-info__close">
-                <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-                </svg></div>
-            </div>
-        </div>
-        <div class="facility-info__content">
-            <div class="facility-info__items">
-                <div class="facility-info__item last">
-                    <div class="facility-info__item_label">Loading...</div>
-                    <div class="facility-info__item_value">...</div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="point-mapper">
-        <div class="point-mapper-content narrow-scroll">
-            <div class="point-mapper-content__header">
-                <div class="point-data__header_icon">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                        <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                    </svg></div>
-                </div>
-                <div class="point-data__header_title">
-                    <div>Point Mapper </div>
-                </div>
-            </div>
-            <div class="point-mapper-content__description">
-                <div>Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong></div>
-            </div>
-            <div class="point-mapper-content__loading">
-                <div class="loading">
-                    <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                    <div class="loading__text">
-                        <div>Loading... </div>
-                    </div>
-                </div>
-            </div>
-            <div class="point-mapper-content__no-data hidden">
-                <div class="no-data">
-                    <div class="no-data__icon">
-                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                        </svg></div>
-                    </div>
-                    <div class="no-data__text">
-                        <div>No points available for this location</div>
-                    </div>
-                </div>
-            </div>
-            <div class="point-mapper-content__list"></div>
-        </div>
-        <div class="point-mapper-toggles">
-            <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de47" class="panel-toggle rich-data-panel__open">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-                </svg></div>
-                <div class="panel-toggle__tooltip">
-                    <div class="panel-toggle__tooltip_text">
-                        <div>Rich Data</div>
-                    </div>
-                    <div class="panel-toggle__tooltip_notch"></div>
-                </div>
-            </div>
-            <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de4a" class="panel-toggle point-mapper-panel__close cc-active">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                </svg></div>
-                <div class="panel-toggle__tooltip">
-                    <div class="panel-toggle__tooltip_text">
-                        <div>Point Mapper</div>
-                    </div>
-                    <div class="panel-toggle__tooltip_notch"></div>
-                </div>
-            </div>
-            <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de49" class="panel-toggle data-mapper-panel__open">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                </svg></div>
-                <div class="panel-toggle__tooltip">
-                    <div class="panel-toggle__tooltip_text">
-                        <div>Data Mapper</div>
-                    </div>
-                    <div class="panel-toggle__tooltip_notch"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="data-mapper">
-        <div class="data-mapper-content narrow-scroll">
-            <div class="data-mapper-content__header">
-                <div class="point-data__header_icon">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                    </svg></div>
-                </div>
-                <div class="point-data__header_title">
-                    <div>Data Mapper</div>
-                </div>
-            </div>
-            <div class="data-mapper-content__description">
-                <div>Explore data categories available for this location. Click or tap a sub-indicator to show it on the map.<strong><br></strong></div>
-            </div>
-            <div class="data-mapper-content__loading">
-                <div class="loading">
-                    <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                    <div class="loading__text">
-                        <div>Loading... </div>
-                    </div>
-                </div>
-            </div>
-            <div class="data-mapper-content__no-data hidden">
-                <div class="no-data__icon">
-                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                        <path d="M0 0h24v24H0z" fill="none"></path>
-                        <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                    </svg></div>
-                </div>
-                <div>The Data Mapper cannot be used with this location as it doesn&#x27;t contain any sub-areas which can be used for mapping</div>
-            </div>
-            <div class="data-mapper-content__list"></div>
-        </div>
-        <div class="data-mapper-toggles">
-            <div data-w-id="82de420b-3451-8ea3-a5a4-f892b059998e" class="panel-toggle rich-data-panel__open">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
-                </svg></div>
-                <div class="panel-toggle__tooltip">
-                    <div class="panel-toggle__tooltip_text">
-                        <div>Rich Data</div>
-                    </div>
-                    <div class="panel-toggle__tooltip_notch"></div>
-                </div>
-            </div>
-            <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599990" class="panel-toggle point-mapper-panel__open">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                </svg></div>
-                <div class="panel-toggle__tooltip">
-                    <div class="panel-toggle__tooltip_text">
-                        <div>Point Mapper</div>
-                    </div>
-                    <div class="panel-toggle__tooltip_notch"></div>
-                </div>
-            </div>
-            <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599992" class="panel-toggle data-mapper-panel__close cc-active">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
-                </svg></div>
-                <div class="panel-toggle__tooltip">
-                    <div class="panel-toggle__tooltip_text">
-                        <div>Data Mapper</div>
-                    </div>
-                    <div class="panel-toggle__tooltip_notch"></div>
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="panel-toggles">
-        <div data-w-id="b8845a6b-d018-3723-9163-c2bb32f2a4ea" class="panel-toggle rich-data-panel__open">
-            <div class="panel-toggle__tooltip">
-                <div class="panel-toggle__tooltip_text">
-                    <div>Rich Data</div>
-                </div>
-                <div class="panel-toggle__tooltip_notch"></div>
-            </div>
-            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                <path d="M0 0h24v24H0z" fill="none"></path>
-                <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+      <div data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825" class="rich-data-nav">
+        <div data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7" class="rich-data-nav__toggle">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M3 18h13v-2H3v2zm0-5h10v-2H3v2zm0-7v2h13V6H3zm18 9.59L17.42 12 21 8.41 19.59 7l-5 5 5 5L21 15.59z"></path>
             </svg></div>
         </div>
-        <div data-w-id="cb33504b-ce21-a841-3478-0f9742bd5340" class="panel-toggle point-mapper-panel__open">
-            <div class="panel-toggle__tooltip">
-                <div class="panel-toggle__tooltip_text">
-                    <div>Point Mapper</div>
-                </div>
-                <div class="panel-toggle__tooltip_notch"></div>
+        <div class="rich-data-nav__list">
+          <a href="#top" class="rich-data-nav__item w-inline-block">
+            <div class="rich-data-nav__item-text">
+              <div class="truncate">Summary</div>
             </div>
+            <div class="rich-data-nav__item-icon">
+              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none"></path>
+                  <path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
+                </svg></div>
+            </div>
+          </a>
+        </div>
+      </div>
+      <div data-w-id="5c312e8d-57e5-7c96-7f71-b6b8b8f96a50" class="rich-data-bumper"></div>
+      <div class="rich-data-content">
+        <div class="rich-data__shadow"></div>
+        <div style="-webkit-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-moz-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);-ms-transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0);transform:translate3d(0, -72PX, 0) scale3d(1, 1, 1) rotateX(0) rotateY(0) rotateZ(0) skew(0, 0)" class="sticky-header">
+          <div title="Click to make this your primary search" class="sticky-header__current-location">
+            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+            <div class="loading__text">
+              <div class="truncate">Loading... </div>
+            </div>
+          </div>
+          <div class="sticky-header__tutorial hidden">
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+              </svg></div>
+          </div>
+        </div>
+        <section class="section header">
+          <div id="top" class="section-link"></div>
+          <div class="location__header">
+            <div class="location__breadcrumbs hidden">
+              <div class="label">
+                <div>Navigate to:</div>
+              </div>
+              <div class="breadcrumb">
+                <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                <div class="loading__text">
+                  <div>Loading... </div>
+                </div>
+              </div>
+            </div>
+            <div class="location__tutorial hidden">
+              <div class="location__tutorial_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 17h-2v-2h2v2zm2.07-7.75l-.9.92C13.45 12.9 13 13.5 13 15h-2v-.5c0-1.1.45-2.1 1.17-2.83l1.24-1.26c.37-.36.59-.86.59-1.41 0-1.1-.9-2-2-2s-2 .9-2 2H8c0-2.21 1.79-4 4-4s4 1.79 4 4c0 .88-.36 1.68-.93 2.25z"></path>
+                  </svg></div>
+              </div>
+              <div>Quick tutorial</div>
+            </div>
+          </div>
+          <div data-w-id="a462ef20-a798-735c-f166-106a34080855" class="location__title">
+            <div class="loading">
+              <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+              <div class="loading__text">
+                <div>Loading... </div>
+              </div>
+            </div>
+          </div>
+          <div class="location__description hidden">
+            <div>A <span class="location-type">Location type</span> in <span class="parent-geography">parent geography</span></div>
+          </div>
+          <div class="location__facilities">
+            <div class="location__facilities_no-data hidden">
+              <div class="no-data">
+                <div class="no-data__icon">
+                  <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                    </svg></div>
+                </div>
+                <div class="no-data__text">
+                  <div>No facilities for this location</div>
+                </div>
+              </div>
+            </div>
+            <div class="location__facilities_loading">
+              <div class="loading">
+                <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                <div class="loading__text">
+                  <div>Loading... </div>
+                </div>
+              </div>
+            </div>
+            <div class="location__facilities_header hidden">
+              <div class="location__facilities_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                  </svg></div>
+              </div>
+              <div class="location__facilities_title">
+                <div>This <span class="location__facilities_geo-type">location</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> facilities</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
+              </div>
+            </div>
+            <div class="location__facilities_trigger hidden">
+              <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6ad" style="display:flex" class="location__facilities_expand">
+                <div>Show facilities</div>
+              </div>
+              <div data-w-id="d2df92af-c619-a615-ada8-5aae86e9c6b0" style="display:none" class="location__facilities_contract">
+                <div>Hide facilities</div>
+              </div>
+            </div>
+            <div style="height:0PX" class="location__facilities_content">
+              <div class="location__facilities_content-wrapper">
+                <div class="location__facilities_sources">
+                  <div class="label">
+                    <div>Sources:</div>
+                  </div>
+                  <div class="location__sources_loading">
+                    <div class="loading">
+                      <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                      <div class="loading__text">
+                        <div>Loading... </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="location__sources_no-data hidden">
+                    <div class="no-data">
+                      <div class="no-data__text">
+                        <div>No source data available</div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+        <div class="section">
+          <div class="section-link"></div>
+        </div>
+      </div>
+      <div class="rich-data-toggles">
+        <div data-w-id="1b738c3c-f509-9ebc-f15d-d66894a02164" class="panel-toggle rich-data-panel__close cc-active">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+            </svg></div>
+          <div class="panel-toggle__tooltip">
+            <div class="panel-toggle__tooltip_text">
+              <div>Rich Data</div>
+            </div>
+            <div class="panel-toggle__tooltip_notch"></div>
+          </div>
+        </div>
+        <div data-w-id="1260faa6-080e-87e0-2b01-fe2eba016dcb" class="panel-toggle point-mapper-panel__open">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+              <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+            </svg></div>
+          <div class="panel-toggle__tooltip">
+            <div class="panel-toggle__tooltip_text">
+              <div>Point Mapper</div>
+            </div>
+            <div class="panel-toggle__tooltip_notch"></div>
+          </div>
+        </div>
+        <div data-w-id="ef6902f7-5288-a426-a2e6-ee2a693e86d7" class="panel-toggle data-mapper-panel__open">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+            </svg></div>
+          <div class="panel-toggle__tooltip">
+            <div class="panel-toggle__tooltip_text">
+              <div>Data Mapper</div>
+            </div>
+            <div class="panel-toggle__tooltip_notch"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="facility-info">
+      <div class="facility-info__header">
+        <h3 class="facility-info__title">Loading...</h3>
+        <div title="Download information (.pdf)" class="facility-info__download">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+            </svg></div>
+        </div>
+        <div title="Close" class="facility-info__close">
+          <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+            </svg></div>
+        </div>
+      </div>
+      <div class="facility-info__content">
+        <div class="facility-info__items">
+          <div class="facility-info__item last">
+            <div class="facility-info__item_label">Loading...</div>
+            <div class="facility-info__item_value">...</div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="point-mapper">
+      <div class="point-mapper-content narrow-scroll">
+        <div class="point-mapper-content__header">
+          <div class="point-data__header_icon">
             <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
                 <path d="M0 0h24v24H0z" fill="none"></path>
                 <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
                 <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-            </svg></div>
+              </svg></div>
+          </div>
+          <div class="point-data__header_title">
+            <div>Point Mapper </div>
+          </div>
         </div>
-        <div data-w-id="6207c761-ee3d-87bf-d0fb-b9250b5408ec" class="panel-toggle data-mapper-panel__open">
-            <div class="panel-toggle__tooltip">
-                <div class="panel-toggle__tooltip_text">
-                    <div>Data Mapper</div>
-                </div>
-                <div class="panel-toggle__tooltip_notch"></div>
+        <div class="point-mapper-content__description">
+          <div>Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong></div>
+        </div>
+        <div class="point-mapper-content__loading">
+          <div class="loading">
+            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+            <div class="loading__text">
+              <div>Loading... </div>
             </div>
+          </div>
+        </div>
+        <div class="point-mapper-content__no-data hidden">
+          <div class="no-data">
+            <div class="no-data__icon">
+              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none"></path>
+                  <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+                </svg></div>
+            </div>
+            <div class="no-data__text">
+              <div>No points available for this location</div>
+            </div>
+          </div>
+        </div>
+        <div class="point-mapper-content__list"></div>
+      </div>
+      <div class="point-mapper-toggles">
+        <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de47" class="panel-toggle rich-data-panel__open">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+            </svg></div>
+          <div class="panel-toggle__tooltip">
+            <div class="panel-toggle__tooltip_text">
+              <div>Rich Data</div>
+            </div>
+            <div class="panel-toggle__tooltip_notch"></div>
+          </div>
+        </div>
+        <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de4a" class="panel-toggle point-mapper-panel__close cc-active">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+              <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+            </svg></div>
+          <div class="panel-toggle__tooltip">
+            <div class="panel-toggle__tooltip_text">
+              <div>Point Mapper</div>
+            </div>
+            <div class="panel-toggle__tooltip_notch"></div>
+          </div>
+        </div>
+        <div data-w-id="6854cf7e-365a-2139-68ee-c7a45970de49" class="panel-toggle data-mapper-panel__open">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+            </svg></div>
+          <div class="panel-toggle__tooltip">
+            <div class="panel-toggle__tooltip_text">
+              <div>Data Mapper</div>
+            </div>
+            <div class="panel-toggle__tooltip_notch"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div class="data-mapper">
+      <div class="data-mapper-content narrow-scroll">
+        <div class="data-mapper-content__header">
+          <div class="point-data__header_icon">
             <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
                 <path d="M0 0h24v24H0z" fill="none"></path>
                 <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+              </svg></div>
+          </div>
+          <div class="point-data__header_title">
+            <div>Data Mapper</div>
+          </div>
+        </div>
+        <div class="data-mapper-content__description">
+          <div>Explore data categories available for this location. Click or tap a sub-indicator to show it on the map.<strong><br></strong></div>
+        </div>
+        <div class="data-mapper-content__loading">
+          <div class="loading">
+            <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+            <div class="loading__text">
+              <div>Loading... </div>
+            </div>
+          </div>
+        </div>
+        <div class="data-mapper-content__no-data hidden">
+          <div class="no-data__icon">
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+              </svg></div>
+          </div>
+          <div>The Data Mapper cannot be used with this location as it doesn&#x27;t contain any sub-areas which can be used for mapping</div>
+        </div>
+        <div class="data-mapper-content__list"></div>
+      </div>
+      <div class="data-mapper-toggles">
+        <div data-w-id="82de420b-3451-8ea3-a5a4-f892b059998e" class="panel-toggle rich-data-panel__open">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
             </svg></div>
+          <div class="panel-toggle__tooltip">
+            <div class="panel-toggle__tooltip_text">
+              <div>Rich Data</div>
+            </div>
+            <div class="panel-toggle__tooltip_notch"></div>
+          </div>
         </div>
+        <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599990" class="panel-toggle point-mapper-panel__open">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+              <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+            </svg></div>
+          <div class="panel-toggle__tooltip">
+            <div class="panel-toggle__tooltip_text">
+              <div>Point Mapper</div>
+            </div>
+            <div class="panel-toggle__tooltip_notch"></div>
+          </div>
+        </div>
+        <div data-w-id="82de420b-3451-8ea3-a5a4-f892b0599992" class="panel-toggle data-mapper-panel__close cc-active">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+            </svg></div>
+          <div class="panel-toggle__tooltip">
+            <div class="panel-toggle__tooltip_text">
+              <div>Data Mapper</div>
+            </div>
+            <div class="panel-toggle__tooltip_notch"></div>
+          </div>
+        </div>
+      </div>
     </div>
-</div>
-<div class="styles hidden">
+    <div class="panel-toggles">
+      <div data-w-id="b8845a6b-d018-3723-9163-c2bb32f2a4ea" class="panel-toggle rich-data-panel__open">
+        <div class="panel-toggle__tooltip">
+          <div class="panel-toggle__tooltip_text">
+            <div>Rich Data</div>
+          </div>
+          <div class="panel-toggle__tooltip_notch"></div>
+        </div>
+        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+            <path d="M0 0h24v24H0z" fill="none"></path>
+            <path fill="currentColor" d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zM9 17H7v-7h2v7zm4 0h-2V7h2v10zm4 0h-2v-4h2v4z"></path>
+          </svg></div>
+      </div>
+      <div data-w-id="cb33504b-ce21-a841-3478-0f9742bd5340" class="panel-toggle point-mapper-panel__open">
+        <div class="panel-toggle__tooltip">
+          <div class="panel-toggle__tooltip_text">
+            <div>Point Mapper</div>
+          </div>
+          <div class="panel-toggle__tooltip_notch"></div>
+        </div>
+        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+            <path d="M0 0h24v24H0z" fill="none"></path>
+            <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+            <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+          </svg></div>
+      </div>
+      <div data-w-id="6207c761-ee3d-87bf-d0fb-b9250b5408ec" class="panel-toggle data-mapper-panel__open">
+        <div class="panel-toggle__tooltip">
+          <div class="panel-toggle__tooltip_text">
+            <div>Data Mapper</div>
+          </div>
+          <div class="panel-toggle__tooltip_notch"></div>
+        </div>
+        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+            <path d="M0 0h24v24H0z" fill="none"></path>
+            <path fill="currentColor" d="M1.13,13.11,3.42,18a1.23,1.23,0,0,1-.28,1.52L3,19.66a.72.72,0,0,0-.08.85l.28.44.28.45a3.23,3.23,0,0,0,3.55,1.51l5.17-1.29a11.68,11.68,0,0,0,5.84-3.55l3.06-3.4a7.41,7.41,0,0,0,1.74-3.52l0-.16A1,1,0,0,0,22,9.81h-.27A.68.68,0,0,1,21,9.07l.06-.76a.67.67,0,0,1,.37-.58h0a1.46,1.46,0,0,0,.73-1.59l-.53-2.55a2.53,2.53,0,0,0-2.57-2.07h0a3,3,0,0,0-2.28,1.3l-2.6,4.6A1.56,1.56,0,0,1,12.29,8l-.46-.19c-.75-.31-1.6,1.56-2.09,2.23l-.42.58c-.33.46-.88.24-1.15-.25S7.27,7,7,6.39a.74.74,0,0,0-.63-.52H6a.67.67,0,0,0-.65.64l.12,4.12A1.67,1.67,0,0,1,3,12.05l-.39-.24a.62.62,0,0,0-.75.07l-.51.45A.73.73,0,0,0,1.13,13.11Z"></path>
+          </svg></div>
+      </div>
+    </div>
+  </div>
+  <div class="styles hidden">
     <div class="styles__wrapper">
-        <div class="styles__section">
-            <div class="styles__title">
-                <div>General</div>
-            </div>
-            <div class="styles__subsection">
-                <div>Data sources</div>
-            </div>
-            <div class="styles__title">
-                <div>Point Mapper</div>
-            </div>
-            <div class="styles__subsection">
-                <div>Categories</div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div class="point-mapper__h1_trigger point-mapper__h1--default-closed">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                        <div class="point-mapper__h1_trigger-arrow">
-                            <div class="fas fa-angle-up"></div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_content default-state--closed">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-1">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-1">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div class="point-mapper__h1_trigger point-mapper__h1--default-open">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                        <div class="point-mapper__h1_trigger-arrow">
-                            <div class="fas fa-angle-up"></div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_content default-state--open">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-1">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-1">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="e0cdcac6-d5b6-2780-3500-919c8eb3a735" class="point-mapper__h1_trigger">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-1">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-1">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="555868a6-ac7f-4f39-8af1-54b777afa871" class="point-mapper__h1_trigger theme-1 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-1">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-1 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-1">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="6c86cd6d-a3de-4bf1-d2ef-1b52d687bf4e" class="point-mapper__h1_trigger theme-2 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-2">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-2 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-2">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="bf6a46d9-86a7-67f0-4a2e-794e9e22a39c" class="point-mapper__h1_trigger theme-3 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-3">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-3 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-3">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="4cef7f0e-21b5-0f03-d39b-d81f3f762e9b" class="point-mapper__h1_trigger theme-4 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-4">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-4 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-4">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="7744e72b-62fe-c3cd-e2b1-d418a4c81926" class="point-mapper__h1_trigger theme-5 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-5">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-5 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-5">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="ac8e408e-8dfd-2bd2-473a-7f80ffe5d8da" class="point-mapper__h1_trigger theme-6 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-6">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-6 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-6">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="9cf08a1c-eea4-40f7-7584-7a22af1533c0" class="point-mapper__h1_trigger theme-7 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-7">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-7 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-7">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="c7b0b95d-3477-0e3c-db3a-98e3a48fa33a" class="point-mapper__h1_trigger theme-8 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-8">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-8 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-8">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="5a41969a-edbe-1d60-39e9-b0079ac64c15" class="point-mapper__h1_trigger theme-9 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-9">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-9 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div title="test test" class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-9">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block">
-                <div class="point-mapper__h1">
-                    <div data-w-id="9a2d4f34-e296-5da4-f30e-b15ac204c0da" class="point-mapper__h1_trigger theme-10 active">
-                        <div class="point-data__h1_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
-                        </div>
-                        <div class="point-data__h1_name">
-                            <div class="truncate">Category Name</div>
-                        </div>
-                    </div>
-                    <div class="point-mapper__h1_checkbox">
-                        <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
-                            <input type="checkbox">
-                            <span class="slider round"></span>
-                        </label></div>
-                    </div>
-                    <div style="display:block" class="point-mapper__h1_content">
-                        <div class="point-mapper__h2_wrapper">
-                            <div class="point-mapper__h2 theme-10">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 theme-10 active">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                            <div class="point-mapper__h2 last theme-10">
-                                <div class="point-mapper__h2_line-h"></div>
-                                <div class="point-mapper__h2_label">
-                                    <div class="point-mapper__h2_name">
-                                        <div class="truncate">Point data name</div>
-                                    </div>
-                                    <div class="point-mapper__h2_source">
-                                        <div class="truncate">Point data source name</div>
-                                    </div>
-                                </div>
-                                <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
-                                <div class="point-mapper__h2_load-complete hidden">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                    </svg></div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="point-data__h2_line-v"></div>
-                    </div>
-                </div>
-            </div>
+      <div class="styles__section">
+        <div class="styles__title">
+          <div>General</div>
         </div>
-        <div class="styles__section">
-            <div class="styles__title">
-                <div>Map Location</div>
-            </div>
-            <div class="styles__subsection">
-                <div>Location tags</div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <div title="Click to make this your primary search" class="location-tag">
-                    <div class="location-tag__type">
-                        <div>Location type</div>
-                    </div>
-                    <div class="location-tag__name">
-                        <div class="truncate text-center">Location name</div>
-                    </div>
-                    <div class="location-tag__loading-icon"><img src="images/loading.gif" alt=""></div>
-                </div>
-                <div title="Click to make this your primary search" class="location-tag active">
-                    <div class="location-tag__type">
-                        <div>Location type</div>
-                    </div>
-                    <div class="location-tag__name">
-                        <div class="truncate text-center">Location name</div>
-                    </div>
-                    <div class="location-tag__loading-icon hidden"><img src="images/loading.gif" alt=""></div>
-                </div>
-            </div>
-            <div class="styles__subsection">
-                <div>Location tags</div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <div class="location-highlight">
-                    <div class="location-highlight__title">
-                        <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)</div>
-                    </div>
-                    <div class="location-highlight__value">
-                        <div class="truncate">Value</div>
-                    </div>
-                </div>
-                <div class="location-highlight last">
-                    <div class="location-highlight__title">
-                        <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)</div>
-                    </div>
-                    <div class="location-highlight__value">
-                        <div class="truncate">Value</div>
-                    </div>
-                </div>
-            </div>
+        <div class="styles__subsection">
+          <div>Data sources</div>
         </div>
-        <div class="styles__section">
-            <div class="styles__title">
-                <div>Data Mapper</div>
+        <div class="styles__title">
+          <div>Point Mapper</div>
+        </div>
+        <div class="styles__subsection">
+          <div>Categories</div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div class="point-mapper__h1_trigger point-mapper__h1--default-closed">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+              <div class="point-mapper__h1_trigger-arrow">
+                <div class="fas fa-angle-up"></div>
+              </div>
             </div>
-            <div class="styles__subsection">
-                <div>Categories</div>
+            <div class="point-mapper__h1_content default-state--closed">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-1">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-1">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
             </div>
-            <div class="styles__area_block">
-                <div class="data-category">
-                    <div href="#" class="data-category__h1_trigger">
-                        <div class="data-category__h1_header">
-                            <div class="data-category__h1_icon">
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div class="point-mapper__h1_trigger point-mapper__h1--default-open">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+              <div class="point-mapper__h1_trigger-arrow">
+                <div class="fas fa-angle-up"></div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_content default-state--open">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-1">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-1">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="e0cdcac6-d5b6-2780-3500-919c8eb3a735" class="point-mapper__h1_trigger">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-1">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-1">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="555868a6-ac7f-4f39-8af1-54b777afa871" class="point-mapper__h1_trigger theme-1 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-1">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-1 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-1">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="6c86cd6d-a3de-4bf1-d2ef-1b52d687bf4e" class="point-mapper__h1_trigger theme-2 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-2">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-2 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-2">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="bf6a46d9-86a7-67f0-4a2e-794e9e22a39c" class="point-mapper__h1_trigger theme-3 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-3">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-3 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-3">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="4cef7f0e-21b5-0f03-d39b-d81f3f762e9b" class="point-mapper__h1_trigger theme-4 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-4">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-4 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-4">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="7744e72b-62fe-c3cd-e2b1-d418a4c81926" class="point-mapper__h1_trigger theme-5 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-5">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-5 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-5">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="ac8e408e-8dfd-2bd2-473a-7f80ffe5d8da" class="point-mapper__h1_trigger theme-6 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-6">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-6 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-6">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="9cf08a1c-eea4-40f7-7584-7a22af1533c0" class="point-mapper__h1_trigger theme-7 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-7">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-7 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-7">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="c7b0b95d-3477-0e3c-db3a-98e3a48fa33a" class="point-mapper__h1_trigger theme-8 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-8">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-8 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-8">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="5a41969a-edbe-1d60-39e9-b0079ac64c15" class="point-mapper__h1_trigger theme-9 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-9">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-9 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div title="test test" class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-9">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block">
+          <div class="point-mapper__h1">
+            <div data-w-id="9a2d4f34-e296-5da4-f30e-b15ac204c0da" class="point-mapper__h1_trigger theme-10 active">
+              <div class="point-data__h1_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="point-data__h1_name">
+                <div class="truncate">Category Name</div>
+              </div>
+            </div>
+            <div class="point-mapper__h1_checkbox">
+              <div title="Toggle entire category" class="custom-checkbox point-data-toggle w-embed"><label class="switch">
+                  <input type="checkbox">
+                  <span class="slider round"></span>
+                </label></div>
+            </div>
+            <div style="display:block" class="point-mapper__h1_content">
+              <div class="point-mapper__h2_wrapper">
+                <div class="point-mapper__h2 theme-10">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading hidden"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 theme-10 active">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+                <div class="point-mapper__h2 last theme-10">
+                  <div class="point-mapper__h2_line-h"></div>
+                  <div class="point-mapper__h2_label">
+                    <div class="point-mapper__h2_name">
+                      <div class="truncate">Point data name</div>
+                    </div>
+                    <div class="point-mapper__h2_source">
+                      <div class="truncate">Point data source name</div>
+                    </div>
+                  </div>
+                  <div class="point-mapper__h2_loading"><img src="images/loading.gif" alt=""></div>
+                  <div class="point-mapper__h2_load-complete hidden">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path d="M0 0h24v24H0z" fill="none"></path>
+                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                      </svg></div>
+                  </div>
+                </div>
+              </div>
+              <div class="point-data__h2_line-v"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="styles__section">
+        <div class="styles__title">
+          <div>Map Location</div>
+        </div>
+        <div class="styles__subsection">
+          <div>Location tags</div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <div title="Click to make this your primary search" class="location-tag">
+            <div class="location-tag__type">
+              <div>Location type</div>
+            </div>
+            <div class="location-tag__name">
+              <div class="truncate text-center">Location name</div>
+            </div>
+            <div class="location-tag__loading-icon"><img src="images/loading.gif" alt=""></div>
+          </div>
+          <div title="Click to make this your primary search" class="location-tag active">
+            <div class="location-tag__type">
+              <div>Location type</div>
+            </div>
+            <div class="location-tag__name">
+              <div class="truncate text-center">Location name</div>
+            </div>
+            <div class="location-tag__loading-icon hidden"><img src="images/loading.gif" alt=""></div>
+          </div>
+        </div>
+        <div class="styles__subsection">
+          <div>Location tags</div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <div class="location-highlight">
+            <div class="location-highlight__title">
+              <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)</div>
+            </div>
+            <div class="location-highlight__value">
+              <div class="truncate">Value</div>
+            </div>
+          </div>
+          <div class="location-highlight last">
+            <div class="location-highlight__title">
+              <div class="truncate">Profile highlight (<span class="location-info__metric_unit">unit</span>)</div>
+            </div>
+            <div class="location-highlight__value">
+              <div class="truncate">Value</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="styles__section">
+        <div class="styles__title">
+          <div>Data Mapper</div>
+        </div>
+        <div class="styles__subsection">
+          <div>Categories</div>
+        </div>
+        <div class="styles__area_block">
+          <div class="data-category">
+            <div href="#" class="data-category__h1_trigger">
+              <div class="data-category__h1_header">
+                <div class="data-category__h1_icon">
+                  <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                    </svg></div>
+                </div>
+                <div class="data-category__h1_title">
+                  <div class="truncate">Category</div>
+                </div>
+              </div>
+              <div class="data-category__h1_toggle toggle-icon-v">
+                <div class="toggle-icon-v--first w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
+                  </svg></div>
+                <div class="toggle-icon-v--last w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
+                  </svg></div>
+              </div>
+            </div>
+            <div class="data-category__h1_content">
+              <div class="data-category__h1_wrapper">
+                <div class="data-category__h2">
+                  <div href="#" class="data-category__h2_trigger">
+                    <div class="truncate">Subcategory</div>
+                  </div>
+                  <div class="data-category__h2_content">
+                    <div class="data-category__h2_wrapper">
+                      <div class="data-category__h3">
+                        <div data-w-id="d9dcf788-413f-9049-8723-d6b050277cba" class="data-category__h3_trigger">
+                          <div class="truncate">Indicator</div>
+                          <div class="data-category__h3_loading hidden"><img src="images/loading.gif" alt=""></div>
+                          <div class="data-category__h3_load-complete hidden">
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                              </svg></div>
+                          </div>
+                        </div>
+                        <div style="height:0PX" class="data-category__h3_content">
+                          <div class="data-category__h3_wrapper">
+                            <div class="data-category__h4_line-v"></div>
+                            <a href="#" class="data-category__h4 w-inline-block">
+                              <div class="data-category__h4_line-h"></div>
+                              <div class="truncate">Subindicator</div>
+                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
+                              <div class="data-category__h4_load-complete hidden">
                                 <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
                                     <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg></div>
-                            </div>
-                            <div class="data-category__h1_title">
-                                <div class="truncate">Category</div>
-                            </div>
+                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                  </svg></div>
+                              </div>
+                            </a>
+                            <a href="#" class="data-category__h4 w-inline-block">
+                              <div class="data-category__h4_line-h"></div>
+                              <div class="truncate">Subindicator</div>
+                              <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
+                              <div class="data-category__h4_load-complete hidden">
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                  </svg></div>
+                              </div>
+                            </a>
+                            <a href="#" class="data-category__h4 active w-inline-block">
+                              <div class="data-category__h4_line-h"></div>
+                              <div class="truncate">Subindicator</div>
+                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
+                              <div class="data-category__h4_load-complete">
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                  </svg></div>
+                              </div>
+                            </a>
+                          </div>
                         </div>
-                        <div class="data-category__h1_toggle toggle-icon-v">
-                            <div class="toggle-icon-v--first w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M7 10l5 5 5-5z"></path>
-                            </svg></div>
-                            <div class="toggle-icon-v--last w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M17,14l-5-5l-5,5H17z"></path>
-                            </svg></div>
-                        </div>
-                    </div>
-                    <div class="data-category__h1_content">
-                        <div class="data-category__h1_wrapper">
-                            <div class="data-category__h2">
-                                <div href="#" class="data-category__h2_trigger">
-                                    <div class="truncate">Subcategory</div>
-                                </div>
-                                <div class="data-category__h2_content">
-                                    <div class="data-category__h2_wrapper">
-                                        <div class="data-category__h3">
-                                            <div data-w-id="d9dcf788-413f-9049-8723-d6b050277cba" class="data-category__h3_trigger">
-                                                <div class="truncate">Indicator</div>
-                                                <div class="data-category__h3_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                                <div class="data-category__h3_load-complete hidden">
-                                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                    </svg></div>
-                                                </div>
-                                            </div>
-                                            <div style="height:0PX" class="data-category__h3_content">
-                                                <div class="data-category__h3_wrapper">
-                                                    <div class="data-category__h4_line-v"></div>
-                                                    <a href="#" class="data-category__h4 w-inline-block">
-                                                        <div class="data-category__h4_line-h"></div>
-                                                        <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                                        <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                            </svg></div>
-                                                        </div>
-                                                    </a>
-                                                    <a href="#" class="data-category__h4 w-inline-block">
-                                                        <div class="data-category__h4_line-h"></div>
-                                                        <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
-                                                        <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                            </svg></div>
-                                                        </div>
-                                                    </a>
-                                                    <a href="#" class="data-category__h4 active w-inline-block">
-                                                        <div class="data-category__h4_line-h"></div>
-                                                        <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                                        <div class="data-category__h4_load-complete">
-                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                            </svg></div>
-                                                        </div>
-                                                    </a>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="data-category__h3">
-                                            <div data-w-id="1e35aa5d-6794-7eaf-27f0-84b06b77495c" class="data-category__h3_trigger">
-                                                <div class="truncate">Indicator</div>
-                                                <div class="data-category__h3_loading"><img src="images/loading.gif" alt=""></div>
-                                                <div class="data-category__h3_load-complete hidden">
-                                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                    </svg></div>
-                                                </div>
-                                            </div>
-                                            <div class="data-category__h3_content hidden">
-                                                <div class="data-category__h3_wrapper">
-                                                    <div class="data-category__h4_line-v"></div>
-                                                    <a href="#" class="data-category__h4 w-inline-block">
-                                                        <div class="data-category__h4_line-h"></div>
-                                                        <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                                        <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                            </svg></div>
-                                                        </div>
-                                                    </a>
-                                                    <a href="#" class="data-category__h4 w-inline-block">
-                                                        <div class="data-category__h4_line-h"></div>
-                                                        <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
-                                                        <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                            </svg></div>
-                                                        </div>
-                                                    </a>
-                                                    <a href="#" class="data-category__h4 active w-inline-block">
-                                                        <div class="data-category__h4_line-h"></div>
-                                                        <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                                        <div class="data-category__h4_load-complete">
-                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                            </svg></div>
-                                                        </div>
-                                                    </a>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="data-category__h3">
-                                            <div data-w-id="5cc4d99e-ac57-fc58-7a13-748080bb6e5e" class="data-category__h3_trigger active">
-                                                <div class="truncate">Indicator</div>
-                                                <div class="data-category__h3_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                                <div class="data-category__h3_load-complete">
-                                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                        <path d="M0 0h24v24H0z" fill="none"></path>
-                                                        <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                    </svg></div>
-                                                </div>
-                                            </div>
-                                            <div class="data-category__h3_content hidden">
-                                                <div class="data-category__h3_wrapper">
-                                                    <div class="data-category__h4_line-v"></div>
-                                                    <a href="#" class="data-category__h4 w-inline-block">
-                                                        <div class="data-category__h4_line-h"></div>
-                                                        <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                                        <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                            </svg></div>
-                                                        </div>
-                                                    </a>
-                                                    <a href="#" class="data-category__h4 w-inline-block">
-                                                        <div class="data-category__h4_line-h"></div>
-                                                        <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
-                                                        <div class="data-category__h4_load-complete hidden">
-                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                            </svg></div>
-                                                        </div>
-                                                    </a>
-                                                    <a href="#" class="data-category__h4 active w-inline-block">
-                                                        <div class="data-category__h4_line-h"></div>
-                                                        <div class="truncate">Subindicator</div>
-                                                        <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
-                                                        <div class="data-category__h4_load-complete">
-                                                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                                <path d="M0 0h24v24H0z" fill="none"></path>
-                                                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
-                                                            </svg></div>
-                                                        </div>
-                                                    </a>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="styles__section">
-            <div class="styles__title">
-                <div>Rich Data Header</div>
-            </div>
-            <div class="styles__subsection">
-                <div>Rich data nav item</div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <a href="#top" class="rich-data-nav__item w-inline-block">
-                    <div class="rich-data-nav__item-text">
-                        <div class="truncate">Section title</div>
-                    </div>
-                    <div class="rich-data-nav__item-icon">
-                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
-                        </svg></div>
-                    </div>
-                </a>
-            </div>
-            <div class="styles__subsection">
-                <div>Location breadcrumbs</div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <div class="breadcrumb">
-                    <div class="truncate">Parent geography</div>
-                </div>
-            </div>
-            <div class="styles__subsection">
-                <div>Location facilities</div>
-            </div>
-            <div class="styles__area_block wide">
-                <div class="location__facilities">
-                    <div class="location__facilities_header--loading">
-                        <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                        <div class="location__facilities_title_loading">
-                            <div>Loading facilities...</div>
-                        </div>
-                    </div>
-                    <div class="location__facilities_header hidden">
-                        <div class="location__facilities_icon">
+                      </div>
+                      <div class="data-category__h3">
+                        <div data-w-id="1e35aa5d-6794-7eaf-27f0-84b06b77495c" class="data-category__h3_trigger">
+                          <div class="truncate">Indicator</div>
+                          <div class="data-category__h3_loading"><img src="images/loading.gif" alt=""></div>
+                          <div class="data-category__h3_load-complete hidden">
                             <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
                                 <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                                <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                            </svg></div>
+                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                              </svg></div>
+                          </div>
                         </div>
-                        <div class="location__facilities_title">
-                            <div>This <span class="location__facilities_geo-type">location</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> facilities</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
-                        </div>
-                    </div>
-                    <div class="location__facilities_trigger hidden">
-                        <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d4" style="display:flex" class="location__facilities_expand">
-                            <div>Show facilities</div>
-                        </div>
-                        <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d7" style="display:none" class="location__facilities_contract">
-                            <div>Hide facilities</div>
-                        </div>
-                    </div>
-                    <div style="height:0PX" class="location__facilities_content">
-                        <div class="location__facilities_content-wrapper">
-                            <div class="location__facilities_loading hidden">
-                                <div class="loading">
-                                    <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                                    <div class="loading__text">
-                                        <div>Loading... </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="location__facilities_no-data hidden">
-                                <div class="no-data">
-                                    <div class="no-data__icon">
-                                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
-                                        </svg></div>
-                                    </div>
-                                    <div class="no-data__text">
-                                        <div>No facilities for this location</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="location-facility">
-                                <div class="location-facility__card">
-                                    <div class="location-facility__category">
-                                        <div class="location-facility__header">
-                                            <div class="location-facility__icon">
-                                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
-                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                                </svg></div>
-                                            </div>
-                                            <div class="location-facility__name">
-                                                <div>Point data category</div>
-                                            </div>
-                                        </div>
-                                        <div class="location-facility__value">
-                                            <div>0000</div>
-                                        </div>
-                                    </div>
-                                    <div class="location-facility__list">
-                                        <a href="#" class="location-facility__list_item w-inline-block">
-                                            <div class="location-facility__item_name">
-                                                <div class="truncate">Point data item</div>
-                                            </div>
-                                            <div class="location-facility__item_value">
-                                                <div>0000</div>
-                                            </div>
-                                            <div id="w-node-a4312e607bde-e148319d" class="location-facility__item_download">
-                                                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-                                                </svg></div>
-                                            </div>
-                                        </a>
-                                        <a href="#" class="location-facility__list_item last w-inline-block">
-                                            <div class="location-facility__item_name">
-                                                <div class="truncate">Point data item</div>
-                                            </div>
-                                            <div class="location-facility__item_value">
-                                                <div>0000</div>
-                                            </div>
-                                            <div id="w-node-a4312e607be7-e148319d" class="location-facility__item_download">
-                                                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-                                                </svg></div>
-                                            </div>
-                                        </a>
-                                    </div>
-                                    <div class="location-facility__description">
-                                        <div>Description text that describes this point data category in relation to surrounding locations</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="location__facilities_sources">
-                                <div class="label">
-                                    <div>Sources:</div>
-                                </div>
-                                <div class="location__sources_loading">
-                                    <div class="loading">
-                                        <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
-                                        <div class="loading__text">
-                                            <div>Loading... </div>
-                                        </div>
-                                    </div>
-                                </div>
-                                <div class="location__sources_no-data hidden">
-                                    <div class="no-data">
-                                        <div class="no-data__text">
-                                            <div>No source data available</div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="styles__section">
-            <div class="styles__title">
-                <div>Navigation search</div>
-            </div>
-            <div class="styles__subsection">
-                <div>Search dropdown list items</div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <div data-w-id="0cc195d0-8237-0a5c-88c5-6bd36b98a8c1" class="search__dropdown_list-item">
-                    <div class="search__list-item_location-name">
-                        <div class="truncate">Location name</div>
-                    </div>
-                    <div class="search__list-item_location-parent">
-                        <div class="truncate">Parent </div>
-                    </div>
-                    <div id="w-node-6bd36b98a8c8-e148319d" class="search__list-item_location-type">
-                        <div class="truncate">Location Type</div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <div data-w-id="8d9eb87a-805a-ef6a-0ef3-bca9e2f0f208" class="search__dropdown_list-item active">
-                    <div class="search__list-item_location-name">
-                        <div class="truncate">Location name</div>
-                    </div>
-                    <div class="search__list-item_location-parent">
-                        <div class="truncate">Parent </div>
-                    </div>
-                    <div id="w-node-bca9e2f0f20f-e148319d" class="search__list-item_location-type">
-                        <div class="truncate">Location Type</div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="styles__section">
-            <div class="styles__title">
-                <div>Rich Data Indicator</div>
-            </div>
-            <div class="styles__subsection">
-                <div>Rich data section title</div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <div class="category-header">
-                    <div class="category-header__content">
-                        <div class="category-header__title">
-                            <div class="category-header__icon">
-                                <div class="svg-icon large w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                        <div class="data-category__h3_content hidden">
+                          <div class="data-category__h3_wrapper">
+                            <div class="data-category__h4_line-v"></div>
+                            <a href="#" class="data-category__h4 w-inline-block">
+                              <div class="data-category__h4_line-h"></div>
+                              <div class="truncate">Subindicator</div>
+                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
+                              <div class="data-category__h4_load-complete hidden">
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
                                     <path d="M0 0h24v24H0z" fill="none"></path>
-                                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                                </svg></div>
-                            </div>
-                            <div class="category-header__text">
-                                <h2 class="cc-clear">Category title</h2>
-                            </div>
+                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                  </svg></div>
+                              </div>
+                            </a>
+                            <a href="#" class="data-category__h4 w-inline-block">
+                              <div class="data-category__h4_line-h"></div>
+                              <div class="truncate">Subindicator</div>
+                              <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
+                              <div class="data-category__h4_load-complete hidden">
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                  </svg></div>
+                              </div>
+                            </a>
+                            <a href="#" class="data-category__h4 active w-inline-block">
+                              <div class="data-category__h4_line-h"></div>
+                              <div class="truncate">Subindicator</div>
+                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
+                              <div class="data-category__h4_load-complete">
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                  </svg></div>
+                              </div>
+                            </a>
+                          </div>
                         </div>
-                    </div>
-                    <div class="category-header__description">
-                        <p>Category description. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__subsection">
-                <div>Rich data indicator header</div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <div class="sub-category-header first">
-                    <div class="sub-category-header__title">
-                        <div class="indicator__title_wrapper">
-                            <h3 class="cc-clear">Indicator title</h3>
-                            <div class="h3__line-v"></div>
-                        </div>
-                    </div>
-                    <div class="sub-category-header__description">
-                        <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. Nunc ut sem vitae risus tristique posuere.</p>
-                    </div>
-                    <div class="sub-category-header__key-metrics">
-                        <div class="sub-category-header__key-metrics_title">
-                            <div>KEY METRICS for this indicator</div>
-                        </div>
-                        <div class="sub-category-header__key-metrics_wrap">
-                            <div class="key-metric">
-                                <div class="key-metric__card">
-                                    <div class="key-metric__value">
-                                        <div class="truncate">00</div>
-                                    </div>
-                                    <div class="key-metric__title">
-                                        <div>Metric title</div>
-                                    </div>
-                                    <div class="key-metric__description">
-                                        <div>Description text that describes this metric in relation to surrounding locations</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="key-metric">
-                                <div class="key-metric__card">
-                                    <div class="key-metric__value">
-                                        <div class="truncate">00</div>
-                                    </div>
-                                    <div class="key-metric__title">
-                                        <div>Metric title</div>
-                                    </div>
-                                    <div class="key-metric__description">
-                                        <div>Description text that describes this metric in relation to surrounding locations</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="key-metric">
-                                <div class="key-metric__card">
-                                    <div class="key-metric__value">
-                                        <div class="truncate">00</div>
-                                    </div>
-                                    <div class="key-metric__title">
-                                        <div>Metric title</div>
-                                    </div>
-                                    <div class="key-metric__description">
-                                        <div>Description text that describes this metric in relation to surrounding locations</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="key-metric">
-                                <div class="key-metric__card">
-                                    <div class="key-metric__value">
-                                        <div class="truncate">00</div>
-                                    </div>
-                                    <div class="key-metric__title">
-                                        <div>Metric title</div>
-                                    </div>
-                                    <div class="key-metric__description">
-                                        <div>Description text that describes this metric in relation to surrounding locations</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            <div class="styles__subsection">
-                <div>Rich data sub-indicator</div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <div class="profile-indicator last">
-                    <div class="profile-indicator__header">
-                        <div class="profile-indicator__title">
-                            <h4>Indicator chart title</h4>
-                        </div>
-                        <div class="profile-indicator__options">
-                            <div class="hover-menu">
-                                <div class="hover-menu__icon">
-                                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                        <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
-                                    </svg></div>
-                                </div>
-                                <div class="hover-menu__content">
-                                    <div class="hover-menu__content_wrapper">
-                                        <a href="#" class="hover-menu__content_item w-inline-block">
-                                            <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c397204ee09f13_image-24px.svg" alt=""></div>
-                                            <div class="content__item_title">
-                                                <div>Save as image</div>
-                                            </div>
-                                        </a>
-                                        <div class="hover-menu__content_item--no-link">
-                                            <div class="icon--small">
-                                                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                                    <path d="M0 0h24v24H0z" fill="none"></path>
-                                                    <path fill="currentColor" d="M21 6H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v8z"></path>
-                                                </svg></div>
-                                            </div>
-                                            <div class="content__item_title">
-                                                <div>Chart values as:</div>
-                                            </div>
-                                        </div>
-                                        <div class="hover-menu__content_list">
-                                            <a href="#" class="hover-menu__content_list-item active w-inline-block">
-                                                <div>Percentage</div>
-                                            </a>
-                                            <a href="#" class="hover-menu__content_list-item--last w-inline-block">
-                                                <div>Value</div>
-                                            </a>
-                                        </div>
-                                        <div class="hover-menu__content_item--no-link">
-                                            <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c3974bdbe09f2e_download-24px.svg" alt=""></div>
-                                            <div class="content__item_title">
-                                                <div>Click to download data:</div>
-                                            </div>
-                                        </div>
-                                        <div class="hover-menu__content_list--last">
-                                            <a href="#" class="hover-menu__content_list-item w-inline-block">
-                                                <div>CSV</div>
-                                            </a>
-                                            <a href="#" class="hover-menu__content_list-item w-inline-block">
-                                                <div>Excel</div>
-                                            </a>
-                                            <a href="#" class="hover-menu__content_list-item w-inline-block">
-                                                <div>JSON</div>
-                                            </a>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="profile-indicator__filters">
-                        <div class="filter__dropdown_wrap">
-                            <div class="dropdown-menu__label">
-                                <div>Select a value:</div>
-                            </div>
-                            <div class="dropdown-menu">
-                                <div class="dropdown-menu__trigger">
-                                    <div class="dropdown-menu__selected-item">
-                                        <div class="truncate">All values</div>
-                                    </div>
-                                    <div class="dropdown-menu__icon">
-                                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                                        </svg></div>
-                                    </div>
-                                </div>
-                                <div class="dropdown-menu__content scroll-element">
-                                    <div class="dropdown__list_item selected">
-                                        <div class="truncate">All values</div>
-                                    </div>
-                                    <div class="dropdown__list_item">
-                                        <div class="truncate">Value name</div>
-                                    </div>
-                                    <div class="dropdown__list_item">
-                                        <div class="truncate">Value name</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="filter__dropdown_wrap disabled">
-                            <div class="dropdown-menu__label">
-                                <div>FILTER BY:</div>
-                            </div>
-                            <div class="dropdown-menu">
-                                <div class="dropdown-menu__trigger">
-                                    <div class="dropdown-menu__selected-item">
-                                        <div class="truncate">All values</div>
-                                    </div>
-                                    <div class="dropdown-menu__icon">
-                                        <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                                            <path d="M0 0h24v24H0z" fill="none"></path>
-                                            <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
-                                        </svg></div>
-                                    </div>
-                                </div>
-                                <div class="dropdown-menu__content scroll-element">
-                                    <div class="dropdown__list_item selected">
-                                        <div class="truncate">All filters</div>
-                                    </div>
-                                    <div class="dropdown__list_item">
-                                        <div class="truncate">Filter name</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="profile-indicator__chart">
-                        <div class="profile-indicator__chart_body">
-                            <div class="indicator__chart full">
-                                <div class="bar-chart">
-                                    <div class="bar-chart__main">
-                                        <div class="bar-chart__labels">
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__label">
-                                                <div class="bar-chart__label_position">
-                                                    <div class="bar-chart__label_value">
-                                                        <div>0%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="bar-chart__rows">
-                                            <div class="bar-chart__row">
-                                                <div class="bar-chart__row_label">
-                                                    <div class="truncate">Truncation of the following sentence</div>
-                                                </div>
-                                                <div class="bar-chart__row-wrapper">
-                                                    <div class="bar-chart__row_bar _1">
-                                                        <div class="bar-chart__row_tooltip">
-                                                            <div class="bar-chart__row_tooltip-card">
-                                                                <div class="bar-chart__tooltip_name">
-                                                                    <div>Long chart label looks like this</div>
-                                                                </div>
-                                                                <div class="bar-chart__tooltip_value">
-                                                                    <div>00%</div>
-                                                                </div>
-                                                                <div class="bar-chart__tooltip_alt-value">
-                                                                    <div>000,000,000</div>
-                                                                </div>
-                                                                <div class="bar-chart__row_tooltip-notch"></div>
-                                                            </div>
-                                                        </div>
-                                                    </div>
-                                                    <div class="bar-chart__row_value">
-                                                        <div class="truncate">00%</div>
-                                                    </div>
-                                                </div>
-                                            </div>
-                                            <div class="bar-chart__underline"></div>
-                                        </div>
-                                    </div>
-                                    <div class="bar-chart__x-label">
-                                        <div>Label Goes here</div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="profile-indicator__chart_footer">
-                            <div class="profile-indicator__chart_description">
-                                <p>Sub-indicator chart footnote goes here and helps to describe the data presented</p>
-                            </div>
-                            <div class="profile-indicator__chart_source">
-                                <div class="chart__footer_label">
-                                    <div>Source:</div>
-                                </div>
-                                <div class="data-source">
-                                    <div>Data source name</div>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="styles__section">
-            <div class="styles__title">
-                <div>Map</div>
-            </div>
-            <div class="styles__subsection">
-                <div>Map tooltip</div>
-            </div>
-            <div class="styles__area_block test">
-                <div class="map-tooltip">
-                    <div class="map-tooltip__geography-chip">
-                        <div>MUNICIPALITY</div>
-                    </div>
-                    <div class="map-tooltip__name">
-                        <div>Elim</div>
-                    </div>
-                    <div class="map-tooltip__value hidden">
-                        <div class="tooltip__value_label">
-                            <div class="truncate">Language most spoken at home:</div>
-                        </div>
-                        <div class="tooltip__value_wrapper">
-                            <div class="tooltip__value_amount">
-                                <div>24,539</div>
-                            </div>
-                            <div class="tooltip__value_detail">
-                                <div>(24%)</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="tooltip__notch"></div>
-                </div>
-            </div>
-            <div class="styles__area_block test">
-                <div class="map-tooltip">
-                    <div class="map-tooltip__geography-chip">
-                        <div>MUNICIPALITY</div>
-                    </div>
-                    <div class="map-tooltip__name">
-                        <div>Elim</div>
-                    </div>
-                    <div class="map-tooltip__value">
-                        <div class="tooltip__value_label">
-                            <div class="truncate">Short label:</div>
-                        </div>
-                        <div class="tooltip__value_wrapper">
-                            <div class="tooltip__value_amount">
-                                <div>24,539</div>
-                            </div>
-                            <div class="tooltip__value_detail">
-                                <div>(24%)</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="map-tooltip__value">
-                        <div class="tooltip__value_label">
-                            <div class="truncate">Short label:</div>
-                        </div>
-                        <div class="tooltip__value_wrapper">
-                            <div class="tooltip__value_amount">
-                                <div>24,539</div>
-                            </div>
-                            <div class="tooltip__value_detail">
-                                <div>(24%)</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="map-tooltip__value">
-                        <div class="tooltip__value_label">
-                            <div class="truncate">Short label:</div>
-                        </div>
-                        <div class="tooltip__value_wrapper">
-                            <div class="tooltip__value_amount">
-                                <div>24,539</div>
-                            </div>
-                            <div class="tooltip__value_detail">
-                                <div>(24%)</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="tooltip__notch"></div>
-                </div>
-            </div>
-            <div class="styles__area_block test">
-                <div class="map-tooltip">
-                    <div class="map-tooltip__geography-chip">
-                        <div>MUNICIPALITY</div>
-                    </div>
-                    <div class="map-tooltip__name">
-                        <div>Elim</div>
-                    </div>
-                    <div class="map-tooltip__value">
-                        <div class="tooltip__value_label">
-                            <div class="truncate">Long label that gets truncated outside of the box width:</div>
-                        </div>
-                        <div class="tooltip__value_wrapper">
-                            <div class="tooltip__value_amount">
-                                <div>24,539</div>
-                            </div>
-                            <div class="tooltip__value_detail">
-                                <div>(24%)</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="map-tooltip__value">
-                        <div class="tooltip__value_label">
-                            <div class="truncate">Long label that gets truncated outside of the box width:</div>
-                        </div>
-                        <div class="tooltip__value_wrapper">
-                            <div class="tooltip__value_amount">
-                                <div>24,539</div>
-                            </div>
-                            <div class="tooltip__value_detail">
-                                <div>(24%)</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="map-tooltip__value">
-                        <div class="tooltip__value_label">
-                            <div class="truncate">Long label that gets truncated outside of the box width:</div>
-                        </div>
-                        <div class="tooltip__value_wrapper">
-                            <div class="tooltip__value_amount">
-                                <div>24,539</div>
-                            </div>
-                            <div class="tooltip__value_detail">
-                                <div>(24%)</div>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="tooltip__notch"></div>
-                </div>
-            </div>
-            <div class="styles__subsection">
-                <div>Facility tooltip</div>
-            </div>
-            <div class="styles__area_block horizontal wide">
-                <div class="facility-tooltip">
-                    <div class="facility-tooltip__header">
-                        <div class="facility-tooltip__header_icon">
-                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                      </div>
+                      <div class="data-category__h3">
+                        <div data-w-id="5cc4d99e-ac57-fc58-7a13-748080bb6e5e" class="data-category__h3_trigger active">
+                          <div class="truncate">Indicator</div>
+                          <div class="data-category__h3_loading hidden"><img src="images/loading.gif" alt=""></div>
+                          <div class="data-category__h3_load-complete">
+                            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
                                 <path d="M0 0h24v24H0z" fill="none"></path>
-                                <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
-                            </svg></div>
+                                <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                              </svg></div>
+                          </div>
                         </div>
-                        <div class="facility-tooltip__header_name">Loading...</div>
-                    </div>
-                    <div class="facility-tooltip__scroll-wrapper">
-                        <div class="facility-tooltip__items">
-                            <div class="facility-tooltip__item last">
-                                <div class="tooltip__facility-item_label">Loading...</div>
-                                <div class="tooltip__facility-item_value">...</div>
-                            </div>
+                        <div class="data-category__h3_content hidden">
+                          <div class="data-category__h3_wrapper">
+                            <div class="data-category__h4_line-v"></div>
+                            <a href="#" class="data-category__h4 w-inline-block">
+                              <div class="data-category__h4_line-h"></div>
+                              <div class="truncate">Subindicator</div>
+                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
+                              <div class="data-category__h4_load-complete hidden">
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                  </svg></div>
+                              </div>
+                            </a>
+                            <a href="#" class="data-category__h4 w-inline-block">
+                              <div class="data-category__h4_line-h"></div>
+                              <div class="truncate">Subindicator</div>
+                              <div class="data-category__h4_loading"><img src="images/loading.gif" alt=""></div>
+                              <div class="data-category__h4_load-complete hidden">
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                  </svg></div>
+                              </div>
+                            </a>
+                            <a href="#" class="data-category__h4 active w-inline-block">
+                              <div class="data-category__h4_line-h"></div>
+                              <div class="truncate">Subindicator</div>
+                              <div class="data-category__h4_loading hidden"><img src="images/loading.gif" alt=""></div>
+                              <div class="data-category__h4_load-complete">
+                                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                    <path d="M0 0h24v24H0z" fill="none"></path>
+                                    <path fill="currentColor" d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41z"></path>
+                                  </svg></div>
+                              </div>
+                            </a>
+                          </div>
                         </div>
+                      </div>
                     </div>
-                    <div class="facility-tooltip__open-modal">More info</div>
-                    <div class="facility-tooltip__close">
-                        <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                            <path d="M0 0h24v24H0z" fill="none"></path>
-                            <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="styles__section">
+        <div class="styles__title">
+          <div>Rich Data Header</div>
+        </div>
+        <div class="styles__subsection">
+          <div>Rich data nav item</div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <a href="#top" class="rich-data-nav__item w-inline-block">
+            <div class="rich-data-nav__item-text">
+              <div class="truncate">Section title</div>
+            </div>
+            <div class="rich-data-nav__item-icon">
+              <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none"></path>
+                  <path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"></path>
+                </svg></div>
+            </div>
+          </a>
+        </div>
+        <div class="styles__subsection">
+          <div>Location breadcrumbs</div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <div class="breadcrumb">
+            <div class="truncate">Parent geography</div>
+          </div>
+        </div>
+        <div class="styles__subsection">
+          <div>Location facilities</div>
+        </div>
+        <div class="styles__area_block wide">
+          <div class="location__facilities">
+            <div class="location__facilities_header--loading">
+              <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+              <div class="location__facilities_title_loading">
+                <div>Loading facilities...</div>
+              </div>
+            </div>
+            <div class="location__facilities_header hidden">
+              <div class="location__facilities_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                  </svg></div>
+              </div>
+              <div class="location__facilities_title">
+                <div>This <span class="location__facilities_geo-type">location</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> facilities</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
+              </div>
+            </div>
+            <div class="location__facilities_trigger hidden">
+              <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d4" style="display:flex" class="location__facilities_expand">
+                <div>Show facilities</div>
+              </div>
+              <div data-w-id="4213bb89-7d31-f409-202f-ae0837f612d7" style="display:none" class="location__facilities_contract">
+                <div>Hide facilities</div>
+              </div>
+            </div>
+            <div style="height:0PX" class="location__facilities_content">
+              <div class="location__facilities_content-wrapper">
+                <div class="location__facilities_loading hidden">
+                  <div class="loading">
+                    <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                    <div class="loading__text">
+                      <div>Loading... </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="location__facilities_no-data hidden">
+                  <div class="no-data">
+                    <div class="no-data__icon">
+                      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                          <path d="M0 0h24v24H0z" fill="none"></path>
+                          <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
                         </svg></div>
                     </div>
-                    <div class="tooltip__notch"></div>
+                    <div class="no-data__text">
+                      <div>No facilities for this location</div>
+                    </div>
+                  </div>
                 </div>
-            </div>
-            <div class="styles__subsection">
-                <div>Map legend</div>
-            </div>
-            <div class="styles__area_block horizontal">
-                <div class="map_legend-block">
-                    <div class="truncate">value</div>
+                <div class="location-facility">
+                  <div class="location-facility__card">
+                    <div class="location-facility__category">
+                      <div class="location-facility__header">
+                        <div class="location-facility__icon">
+                          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                              <path d="M0 0h24v24H0z" fill="none"></path>
+                              <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                            </svg></div>
+                        </div>
+                        <div class="location-facility__name">
+                          <div>Point data category</div>
+                        </div>
+                      </div>
+                      <div class="location-facility__value">
+                        <div>0000</div>
+                      </div>
+                    </div>
+                    <div class="location-facility__list">
+                      <a href="#" class="location-facility__list_item w-inline-block">
+                        <div class="location-facility__item_name">
+                          <div class="truncate">Point data item</div>
+                        </div>
+                        <div class="location-facility__item_value">
+                          <div>0000</div>
+                        </div>
+                        <div id="w-node-a4312e607bde-e148319d" class="location-facility__item_download">
+                          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                              <path d="M0 0h24v24H0z" fill="none"></path>
+                              <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                            </svg></div>
+                        </div>
+                      </a>
+                      <a href="#" class="location-facility__list_item last w-inline-block">
+                        <div class="location-facility__item_name">
+                          <div class="truncate">Point data item</div>
+                        </div>
+                        <div class="location-facility__item_value">
+                          <div>0000</div>
+                        </div>
+                        <div id="w-node-a4312e607be7-e148319d" class="location-facility__item_download">
+                          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                              <path d="M0 0h24v24H0z" fill="none"></path>
+                              <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                            </svg></div>
+                        </div>
+                      </a>
+                    </div>
+                    <div class="location-facility__description">
+                      <div>Description text that describes this point data category in relation to surrounding locations</div>
+                    </div>
+                  </div>
                 </div>
-                <div class="map_legend-block light">
-                    <div class="truncate">value</div>
+                <div class="location__facilities_sources">
+                  <div class="label">
+                    <div>Sources:</div>
+                  </div>
+                  <div class="location__sources_loading">
+                    <div class="loading">
+                      <div class="loading__icon"><img src="images/loading.gif" alt=""></div>
+                      <div class="loading__text">
+                        <div>Loading... </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="location__sources_no-data hidden">
+                    <div class="no-data">
+                      <div class="no-data__text">
+                        <div>No source data available</div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
+              </div>
             </div>
+          </div>
         </div>
+      </div>
+      <div class="styles__section">
+        <div class="styles__title">
+          <div>Navigation search</div>
+        </div>
+        <div class="styles__subsection">
+          <div>Search dropdown list items</div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <div data-w-id="0cc195d0-8237-0a5c-88c5-6bd36b98a8c1" class="search__dropdown_list-item">
+            <div class="search__list-item_location-name">
+              <div class="truncate">Location name</div>
+            </div>
+            <div class="search__list-item_location-parent">
+              <div class="truncate">Parent </div>
+            </div>
+            <div id="w-node-6bd36b98a8c8-e148319d" class="search__list-item_location-type">
+              <div class="truncate">Location Type</div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <div data-w-id="8d9eb87a-805a-ef6a-0ef3-bca9e2f0f208" class="search__dropdown_list-item active">
+            <div class="search__list-item_location-name">
+              <div class="truncate">Location name</div>
+            </div>
+            <div class="search__list-item_location-parent">
+              <div class="truncate">Parent </div>
+            </div>
+            <div id="w-node-bca9e2f0f20f-e148319d" class="search__list-item_location-type">
+              <div class="truncate">Location Type</div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="styles__section">
+        <div class="styles__title">
+          <div>Rich Data Indicator</div>
+        </div>
+        <div class="styles__subsection">
+          <div>Rich data section title</div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <div class="category-header">
+            <div class="category-header__content">
+              <div class="category-header__title">
+                <div class="category-header__icon">
+                  <div class="svg-icon large w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                    </svg></div>
+                </div>
+                <div class="category-header__text">
+                  <h2 class="cc-clear">Category title</h2>
+                </div>
+              </div>
+            </div>
+            <div class="category-header__description">
+              <p>Category description. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+            </div>
+          </div>
+        </div>
+        <div class="styles__subsection">
+          <div>Rich data indicator header</div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <div class="sub-category-header first">
+            <div class="sub-category-header__title">
+              <div class="indicator__title_wrapper">
+                <h3 class="cc-clear">Indicator title</h3>
+                <div class="h3__line-v"></div>
+              </div>
+            </div>
+            <div class="sub-category-header__description">
+              <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Suspendisse varius enim in eros elementum tristique. Duis cursus, mi quis viverra ornare, eros dolor interdum nulla, ut commodo diam libero vitae erat. Aenean faucibus nibh et justo cursus id rutrum lorem imperdiet. Nunc ut sem vitae risus tristique posuere.</p>
+            </div>
+            <div class="sub-category-header__key-metrics">
+              <div class="sub-category-header__key-metrics_title">
+                <div>KEY METRICS for this indicator</div>
+              </div>
+              <div class="sub-category-header__key-metrics_wrap">
+                <div class="key-metric">
+                  <div class="key-metric__card">
+                    <div class="key-metric__value">
+                      <div class="truncate">00</div>
+                    </div>
+                    <div class="key-metric__title">
+                      <div>Metric title</div>
+                    </div>
+                    <div class="key-metric__description">
+                      <div>Description text that describes this metric in relation to surrounding locations</div>
+                    </div>
+                  </div>
+                </div>
+                <div class="key-metric">
+                  <div class="key-metric__card">
+                    <div class="key-metric__value">
+                      <div class="truncate">00</div>
+                    </div>
+                    <div class="key-metric__title">
+                      <div>Metric title</div>
+                    </div>
+                    <div class="key-metric__description">
+                      <div>Description text that describes this metric in relation to surrounding locations</div>
+                    </div>
+                  </div>
+                </div>
+                <div class="key-metric">
+                  <div class="key-metric__card">
+                    <div class="key-metric__value">
+                      <div class="truncate">00</div>
+                    </div>
+                    <div class="key-metric__title">
+                      <div>Metric title</div>
+                    </div>
+                    <div class="key-metric__description">
+                      <div>Description text that describes this metric in relation to surrounding locations</div>
+                    </div>
+                  </div>
+                </div>
+                <div class="key-metric">
+                  <div class="key-metric__card">
+                    <div class="key-metric__value">
+                      <div class="truncate">00</div>
+                    </div>
+                    <div class="key-metric__title">
+                      <div>Metric title</div>
+                    </div>
+                    <div class="key-metric__description">
+                      <div>Description text that describes this metric in relation to surrounding locations</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div class="styles__subsection">
+          <div>Rich data sub-indicator</div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <div class="profile-indicator last">
+            <div class="profile-indicator__header">
+              <div class="profile-indicator__title">
+                <h4>Indicator chart title</h4>
+              </div>
+              <div class="profile-indicator__options">
+                <div class="hover-menu">
+                  <div class="hover-menu__icon">
+                    <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                        <path fill="currentColor" d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"></path>
+                      </svg></div>
+                  </div>
+                  <div class="hover-menu__content">
+                    <div class="hover-menu__content_wrapper">
+                      <a href="#" class="hover-menu__content_item w-inline-block">
+                        <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c397204ee09f13_image-24px.svg" alt=""></div>
+                        <div class="content__item_title">
+                          <div>Save as image</div>
+                        </div>
+                      </a>
+                      <div class="hover-menu__content_item--no-link">
+                        <div class="icon--small">
+                          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                              <path d="M0 0h24v24H0z" fill="none"></path>
+                              <path fill="currentColor" d="M21 6H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v8z"></path>
+                            </svg></div>
+                        </div>
+                        <div class="content__item_title">
+                          <div>Chart values as:</div>
+                        </div>
+                      </div>
+                      <div class="hover-menu__content_list">
+                        <a href="#" class="hover-menu__content_list-item active w-inline-block">
+                          <div>Percentage</div>
+                        </a>
+                        <a href="#" class="hover-menu__content_list-item--last w-inline-block">
+                          <div>Value</div>
+                        </a>
+                      </div>
+                      <div class="hover-menu__content_item--no-link">
+                        <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c3974bdbe09f2e_download-24px.svg" alt=""></div>
+                        <div class="content__item_title">
+                          <div>Click to download data:</div>
+                        </div>
+                      </div>
+                      <div class="hover-menu__content_list--last">
+                        <a href="#" class="hover-menu__content_list-item w-inline-block">
+                          <div>CSV</div>
+                        </a>
+                        <a href="#" class="hover-menu__content_list-item w-inline-block">
+                          <div>Excel</div>
+                        </a>
+                        <a href="#" class="hover-menu__content_list-item w-inline-block">
+                          <div>JSON</div>
+                        </a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="profile-indicator__filters">
+              <div class="filter__dropdown_wrap">
+                <div class="dropdown-menu__label">
+                  <div>Select a value:</div>
+                </div>
+                <div class="dropdown-menu">
+                  <div class="dropdown-menu__trigger">
+                    <div class="dropdown-menu__selected-item">
+                      <div class="truncate">All values</div>
+                    </div>
+                    <div class="dropdown-menu__icon">
+                      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                          <path d="M0 0h24v24H0z" fill="none"></path>
+                          <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                        </svg></div>
+                    </div>
+                  </div>
+                  <div class="dropdown-menu__content scroll-element">
+                    <div class="dropdown__list_item selected">
+                      <div class="truncate">All values</div>
+                    </div>
+                    <div class="dropdown__list_item">
+                      <div class="truncate">Value name</div>
+                    </div>
+                    <div class="dropdown__list_item">
+                      <div class="truncate">Value name</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="filter__dropdown_wrap disabled">
+                <div class="dropdown-menu__label">
+                  <div>FILTER BY:</div>
+                </div>
+                <div class="dropdown-menu">
+                  <div class="dropdown-menu__trigger">
+                    <div class="dropdown-menu__selected-item">
+                      <div class="truncate">All values</div>
+                    </div>
+                    <div class="dropdown-menu__icon">
+                      <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                          <path d="M0 0h24v24H0z" fill="none"></path>
+                          <path fill="currentColor" d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"></path>
+                        </svg></div>
+                    </div>
+                  </div>
+                  <div class="dropdown-menu__content scroll-element">
+                    <div class="dropdown__list_item selected">
+                      <div class="truncate">All filters</div>
+                    </div>
+                    <div class="dropdown__list_item">
+                      <div class="truncate">Filter name</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div class="profile-indicator__chart">
+              <div class="profile-indicator__chart_body">
+                <div class="indicator__chart full">
+                  <div class="bar-chart">
+                    <div class="bar-chart__main">
+                      <div class="bar-chart__labels">
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__label">
+                          <div class="bar-chart__label_position">
+                            <div class="bar-chart__label_value">
+                              <div>0%</div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                      <div class="bar-chart__rows">
+                        <div class="bar-chart__row">
+                          <div class="bar-chart__row_label">
+                            <div class="truncate">Truncation of the following sentence</div>
+                          </div>
+                          <div class="bar-chart__row-wrapper">
+                            <div class="bar-chart__row_bar _1">
+                              <div class="bar-chart__row_tooltip">
+                                <div class="bar-chart__row_tooltip-card">
+                                  <div class="bar-chart__tooltip_name">
+                                    <div>Long chart label looks like this</div>
+                                  </div>
+                                  <div class="bar-chart__tooltip_value">
+                                    <div>00%</div>
+                                  </div>
+                                  <div class="bar-chart__tooltip_alt-value">
+                                    <div>000,000,000</div>
+                                  </div>
+                                  <div class="bar-chart__row_tooltip-notch"></div>
+                                </div>
+                              </div>
+                            </div>
+                            <div class="bar-chart__row_value">
+                              <div class="truncate">00%</div>
+                            </div>
+                          </div>
+                        </div>
+                        <div class="bar-chart__underline"></div>
+                      </div>
+                    </div>
+                    <div class="bar-chart__x-label">
+                      <div>Label Goes here</div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div class="profile-indicator__chart_footer">
+                <div class="profile-indicator__chart_description">
+                  <p>Sub-indicator chart footnote goes here and helps to describe the data presented</p>
+                </div>
+                <div class="profile-indicator__chart_source">
+                  <div class="chart__footer_label">
+                    <div>Source:</div>
+                  </div>
+                  <div class="data-source">
+                    <div>Data source name</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="styles__section">
+        <div class="styles__title">
+          <div>Map</div>
+        </div>
+        <div class="styles__subsection">
+          <div>Map tooltip</div>
+        </div>
+        <div class="styles__area_block test">
+          <div class="map-tooltip">
+            <div class="map-tooltip__geography-chip">
+              <div>MUNICIPALITY</div>
+            </div>
+            <div class="map-tooltip__name">
+              <div>Elim</div>
+            </div>
+            <div class="map-tooltip__value hidden">
+              <div class="tooltip__value_label">
+                <div class="truncate">Language most spoken at home:</div>
+              </div>
+              <div class="tooltip__value_wrapper">
+                <div class="tooltip__value_amount">
+                  <div>24,539</div>
+                </div>
+                <div class="tooltip__value_detail">
+                  <div>(24%)</div>
+                </div>
+              </div>
+            </div>
+            <div class="tooltip__notch"></div>
+          </div>
+        </div>
+        <div class="styles__area_block test">
+          <div class="map-tooltip">
+            <div class="map-tooltip__geography-chip">
+              <div>MUNICIPALITY</div>
+            </div>
+            <div class="map-tooltip__name">
+              <div>Elim</div>
+            </div>
+            <div class="map-tooltip__value">
+              <div class="tooltip__value_label">
+                <div class="truncate">Short label:</div>
+              </div>
+              <div class="tooltip__value_wrapper">
+                <div class="tooltip__value_amount">
+                  <div>24,539</div>
+                </div>
+                <div class="tooltip__value_detail">
+                  <div>(24%)</div>
+                </div>
+              </div>
+            </div>
+            <div class="map-tooltip__value">
+              <div class="tooltip__value_label">
+                <div class="truncate">Short label:</div>
+              </div>
+              <div class="tooltip__value_wrapper">
+                <div class="tooltip__value_amount">
+                  <div>24,539</div>
+                </div>
+                <div class="tooltip__value_detail">
+                  <div>(24%)</div>
+                </div>
+              </div>
+            </div>
+            <div class="map-tooltip__value">
+              <div class="tooltip__value_label">
+                <div class="truncate">Short label:</div>
+              </div>
+              <div class="tooltip__value_wrapper">
+                <div class="tooltip__value_amount">
+                  <div>24,539</div>
+                </div>
+                <div class="tooltip__value_detail">
+                  <div>(24%)</div>
+                </div>
+              </div>
+            </div>
+            <div class="tooltip__notch"></div>
+          </div>
+        </div>
+        <div class="styles__area_block test">
+          <div class="map-tooltip">
+            <div class="map-tooltip__geography-chip">
+              <div>MUNICIPALITY</div>
+            </div>
+            <div class="map-tooltip__name">
+              <div>Elim</div>
+            </div>
+            <div class="map-tooltip__value">
+              <div class="tooltip__value_label">
+                <div class="truncate">Long label that gets truncated outside of the box width:</div>
+              </div>
+              <div class="tooltip__value_wrapper">
+                <div class="tooltip__value_amount">
+                  <div>24,539</div>
+                </div>
+                <div class="tooltip__value_detail">
+                  <div>(24%)</div>
+                </div>
+              </div>
+            </div>
+            <div class="map-tooltip__value">
+              <div class="tooltip__value_label">
+                <div class="truncate">Long label that gets truncated outside of the box width:</div>
+              </div>
+              <div class="tooltip__value_wrapper">
+                <div class="tooltip__value_amount">
+                  <div>24,539</div>
+                </div>
+                <div class="tooltip__value_detail">
+                  <div>(24%)</div>
+                </div>
+              </div>
+            </div>
+            <div class="map-tooltip__value">
+              <div class="tooltip__value_label">
+                <div class="truncate">Long label that gets truncated outside of the box width:</div>
+              </div>
+              <div class="tooltip__value_wrapper">
+                <div class="tooltip__value_amount">
+                  <div>24,539</div>
+                </div>
+                <div class="tooltip__value_detail">
+                  <div>(24%)</div>
+                </div>
+              </div>
+            </div>
+            <div class="tooltip__notch"></div>
+          </div>
+        </div>
+        <div class="styles__subsection">
+          <div>Facility tooltip</div>
+        </div>
+        <div class="styles__area_block horizontal wide">
+          <div class="facility-tooltip">
+            <div class="facility-tooltip__header">
+              <div class="facility-tooltip__header_icon">
+                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="100%" height="" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M5 13.18v4L12 21l7-3.82v-4L12 17l-7-3.82zM12 3L1 9l11 6 9-4.91V17h2V9L12 3z"></path>
+                  </svg></div>
+              </div>
+              <div class="facility-tooltip__header_name">Loading...</div>
+            </div>
+            <div class="facility-tooltip__scroll-wrapper">
+              <div class="facility-tooltip__items">
+                <div class="facility-tooltip__item last">
+                  <div class="tooltip__facility-item_label">Loading...</div>
+                  <div class="tooltip__facility-item_value">...</div>
+                </div>
+              </div>
+            </div>
+            <div class="facility-tooltip__open-modal">More info</div>
+            <div class="facility-tooltip__close">
+              <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                  <path d="M0 0h24v24H0z" fill="none"></path>
+                  <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+                </svg></div>
+            </div>
+            <div class="tooltip__notch"></div>
+          </div>
+        </div>
+        <div class="styles__subsection">
+          <div>Map legend</div>
+        </div>
+        <div class="styles__area_block horizontal">
+          <div class="map_legend-block">
+            <div class="truncate">value</div>
+          </div>
+          <div class="map_legend-block light">
+            <div class="truncate">value</div>
+          </div>
+        </div>
+      </div>
     </div>
-</div>
-<div class="print-styling w-embed">
+  </div>
+  <div class="print-styling w-embed">
     <style>
-        @media print {
-            /*--padding adjustments--*/
-            .location__description, .location__sources .profile-indicator {
-                padding-bottom: 0px;
-            }
-            .section {
-                padding-bottom: 20px;
-            }
-            .sub-category-header__key-metrics {
-                padding-bottom: 12px;
-            }
-            .profile-indicator__header {
-                margin-bottom: 0px;
-            }
-            .sub-category-header__title {
-                margin-bottom: 12px;
-            }
-            .profile-indicator__chart {
-                margin-top: 0px;
-            }
-            /*--hide unwanted elements in print--*/
-            .nav, .login-modal, .category-header__link, .location__header, .profile-indicator__options, .sticky-header, .tutorial-modal, .styles, .map, .point-mapper, .data-mapper, .panel-toggles, .rich-data-nav, .rich-data-bumper, .rich-data-toggles {
-                display: none;
-            }
-            /*--avoid page breaks--*/
-            .sub-category-header {
-                break-inside: avoid;
-            }
-            .profile-indicator {
-                break-inside: avoid;
-            }
-            /*--hide interaction buttons--*/
-            .location-facility__list_item {
-                grid-template-columns: 4fr 1fr .0;
-            }
-            .location-facility__item_download {
-                display: none;
-            }
-            /*--adjust rich-data panel to fill page--*/
-            .rich-data, .rich-data-content {
-                max-width: 100%;
-                width: 100%;
-            }
-            .rich-data-content {
-                padding: 0px;
-                filter: grayscale(100%);
-            }
-            /*--adjust text size--*/
-            .body {
-                font-size: 12px !important;
-            }
-            /*--adjust charts--*/
-            .bar-chart__row_bar {
-                background-color: #000 !important;
-            }
-        }
-    </style>
-</div>
-<script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5ecb7ed6bb713f2f4b48319b" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
-<script src="js/webflow.js" type="text/javascript"></script>
-<!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
-<style>
-    #dev-tools {
-        z-index:200;
-    }
-    #map-download-title {
-        position: fixed;
-        top: 80px;
-        z-index: 998;
-        width: 100%;
-        text-align: center;
-        font-size: 30px;
-        font-weight: bold;
-        color: white;
-    }
-    #map-download-legend {
-        position: absolute;
-        bottom: 50px;
-        z-index: 998;
-        width: 100%;
-        display: flex;
-        justify-content: center;
-    }
-    #map-download-legend .map-options__legend_wrap {
-        background: white;
-        padding: 5px;
-        height: 29px;
-        max-width: 397px;
-    }
+@media print {
+/*--padding adjustments--*/
+	.location__description, .location__sources .profile-indicator {
+  	padding-bottom: 0px;
+  }
+  .section {
+  	padding-bottom: 20px;
+  }
+  .sub-category-header__key-metrics {
+  	padding-bottom: 12px;
+  }
+  .profile-indicator__header {
+  	margin-bottom: 0px;
+  }
+	.sub-category-header__title {
+  	margin-bottom: 12px;
+  }
+  .profile-indicator__chart {
+  	margin-top: 0px;
+  }
+/*--hide unwanted elements in print--*/
+  .nav, .login-modal, .category-header__link, .location__header, .profile-indicator__options, .sticky-header, .tutorial-modal, .styles, .map, .point-mapper, .data-mapper, .panel-toggles, .rich-data-nav, .rich-data-bumper, .rich-data-toggles {
+    display: none;
+  }
+/*--avoid page breaks--*/
+	.sub-category-header {
+ 		break-inside: avoid;
+	}
+	.profile-indicator {
+  	break-inside: avoid;
+  }
+/*--hide interaction buttons--*/
+.location-facility__list_item {
+	grid-template-columns: 4fr 1fr .0;
+  }
+.location-facility__item_download {
+	display: none;
+  }
+/*--adjust rich-data panel to fill page--*/
+	.rich-data, .rich-data-content {
+  	max-width: 100%;
+    width: 100%;
+	}
+  .rich-data-content {
+  	padding: 0px;
+    filter: grayscale(100%);
+  }
+/*--adjust text size--*/
+  .body {
+ 	 font-size: 12px !important;
+  }
+/*--adjust charts--*/
+.bar-chart__row_bar {
+	background-color: #000 !important;
+  }
+}
+</style>
+  </div>
+  <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=5ecb7ed6bb713f2f4b48319b" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+  <script src="js/webflow.js" type="text/javascript"></script>
+  <!-- [if lte IE 9]><script src="https://cdnjs.cloudflare.com/ajax/libs/placeholders/3.0.2/placeholders.min.js"></script><![endif] -->
+  <style>
+  #dev-tools {
+    z-index:200;
+  }
+  #map-download-title {
+   position: fixed;
+   top: 80px;
+   z-index: 998;
+   width: 100%;
+   text-align: center;
+   font-size: 30px;
+   font-weight: bold;
+   color: white;
+ }
+  #map-download-legend {
+   position: absolute;
+   bottom: 50px;
+   z-index: 998;
+   width: 100%;
+   display: flex;
+   justify-content: center;
+ }
+  #map-download-legend .map-options__legend_wrap {
+   background: white;
+   padding: 5px;
+   height: 29px;
+   max-width: 397px;
+ }
 </style> <!--  Used for the autocomplete search box  -->
-<link href="https://code.jquery.com/ui/1.12.0/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css">
-<link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css">
-<link rel="stylesheet" href="https://openup.org.za/wazimap-ng-ui/wazimap-ng.css">
-<script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
-<!--  Material design icons  -->
-<link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
-<!--  used the the autocomplete search box  -->
-<script crossorigin="anonymous" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E=" src="https://code.jquery.com/ui/1.12.0/jquery-ui.min.js"></script>
-<script src="https://bevacqua.github.io/dragula/dist/dragula.js"></script>
-<script>
-    var drake = dragula({
-        isContainer: function (el) {
-            return el.classList.contains('dragula-container');
-        }
-    });
+  <link href="https://code.jquery.com/ui/1.12.0/themes/smoothness/jquery-ui.css" rel="stylesheet" type="text/css">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css">
+  <link rel="stylesheet" href="https://openup.org.za/wazimap-ng-ui/wazimap-ng.css">
+  <script src="https://unpkg.com/leaflet@1.6.0/dist/leaflet.js"></script>
+  <!--  Material design icons  -->
+  <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
+  <!--  used the the autocomplete search box  -->
+  <script crossorigin="anonymous" integrity="sha256-eGE6blurk5sHj+rmkfsGYeKyZx3M4bG+ZlFyA7Kns7E=" src="https://code.jquery.com/ui/1.12.0/jquery-ui.min.js"></script>
+  <script src="https://bevacqua.github.io/dragula/dist/dragula.js"></script>
+  <script>
+	var drake = dragula({
+  isContainer: function (el) {
+    return el.classList.contains('dragula-container');
+  }
+});
 </script>
-<script src="js/index.js"></script>
-<script>
-    setTimeout(function(){
-        $('.w-webflow-badge').css({'display':'none !important'});
-    }, 2000);
+  <script src="js/index.js"></script>
+  <script>
+setTimeout(function(){
+		$('.w-webflow-badge').css({'display':'none !important'});
+}, 2000);
 </script>
-<style>
-    /*------------------------------------- Map attribution hide */
-    .leaflet-control-attribution {
-        display: none !important;
+  <style>
+/*------------------------------------- Map attribution hide */
+  .leaflet-control-attribution {
+    display: none !important;
     }
-    /*------------------------------------- Truncation */
-    .truncate {
-        width: 100%;
-        white-space: nowrap;
-        overflow: hidden;
-        text-overflow: ellipsis;
-    }
-    /*------------------------------------- Hidden important */
-    .hidden {
-        display: none !important;
-    }
-    /*------------------------------------- Hide webflow items on deploy */
-    .disabled {
-        pointer-events: none;
-    }
-    /*------------------------------------- Hide scrollbar for Chrome, Safari and Opera */
-    .no-scroll::-webkit-scrollbar {
-        display: none;
-    }
-    /*------------------------------------- Hide scrollbar for IE and Edge */
-    .no-scroll {
-        -ms-overflow-style: none;
-    }
-    /*-------- Narrow scroll bar */
-    /*width*/
-    .narrow-scroll::-webkit-scrollbar {
-        width:4px;
-    }
-    /*track*/
-    .narrow-scroll::-webkit-scrollbar-track {
-        background:rgba(255, 255, 255, 0);
-        border-color:rgb(255, 255, 255);
-    }
-    /*thumb*/
-    .narrow-scroll::-webkit-scrollbar-thumb {
-        background:rgb(98, 98, 98);
-        border-color:rgb(51, 51, 51);
-        border-radius:2px;
-    }
-    /*-------- Custom slider checkbox */
-    .switch {
-        position: relative;
-        display: inline-block;
-        width: 32px;
-        height: 20px;
-    }
-    .switch input {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    .slider {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: #00000030;
-        -webkit-transition: .1s;
-        transition: .1s;
-    }
-    .slider:before {
-        position: absolute;
-        content: "";
-        height: 12px;
-        width: 12px;
-        left: 4px;
-        bottom: 4px;
-        background-color: white;
-        -webkit-transition: .1s;
-        transition: .1s;
-    }
-    input:checked + .slider {
-        background-color: #3c3c3c;
-    }
-    input:checked + .slider:before {
-        -webkit-transform: translateX(26px);
-        -ms-transform: translateX(12px);
-        transform: translateX(12px);
-    }
-    /* Rounded sliders */
-    .slider.round {
-        border-radius: 34px;
-    }
-    .slider.round:before {
-        border-radius: 50%;
-    }
-    /*-------- Fixing Chart Lines */
-    .bar-tooltip {
-        z-index: 100;
-    }
-    line, .grid {
-        stroke: #999;
-    }
+/*------------------------------------- Truncation */
+.truncate {
+	width: 100%;
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	}
+/*------------------------------------- Hidden important */
+.hidden {
+	display: none !important;
+  }
+/*------------------------------------- Hide webflow items on deploy */
+.disabled {
+  pointer-events: none;
+}  
+/*------------------------------------- Hide scrollbar for Chrome, Safari and Opera */
+.no-scroll::-webkit-scrollbar {
+  display: none;
+}
+/*------------------------------------- Hide scrollbar for IE and Edge */
+.no-scroll {
+  -ms-overflow-style: none;
+}
+/*-------- Narrow scroll bar */
+/*width*/
+.narrow-scroll::-webkit-scrollbar {
+  width:4px;
+}
+/*track*/
+.narrow-scroll::-webkit-scrollbar-track {
+  background:rgba(255, 255, 255, 0);
+  border-color:rgb(255, 255, 255);
+}
+/*thumb*/
+.narrow-scroll::-webkit-scrollbar-thumb {
+  background:rgb(98, 98, 98);
+  border-color:rgb(51, 51, 51);
+  border-radius:2px;
+}
+/*-------- Custom slider checkbox */  
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 32px;
+  height: 20px;
+}
+.switch input { 
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #00000030;
+  -webkit-transition: .1s;
+  transition: .1s;
+}
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 12px;
+  width: 12px;
+  left: 4px;
+  bottom: 4px;
+  background-color: white;
+  -webkit-transition: .1s;
+  transition: .1s;
+}
+input:checked + .slider {
+  background-color: #3c3c3c;
+}
+input:checked + .slider:before {
+  -webkit-transform: translateX(26px);
+  -ms-transform: translateX(12px);
+  transform: translateX(12px);
+}
+/* Rounded sliders */
+.slider.round {
+  border-radius: 34px;
+}
+.slider.round:before {
+  border-radius: 50%;
+}
+/*-------- Fixing Chart Lines */  
+.bar-tooltip {
+  z-index: 100;
+}
+line, .grid {
+  stroke: #999;
+}
 </style>
 </body>
 </html>

--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -23,6 +23,8 @@ let facilityRowItem = null;
 let activeMarkers = [];
 let activePoints = [];  //the visible points on the map
 
+const POPUP_OFFSET= [20, 0];
+
 /**
  * this class creates the point data dialog
  */
@@ -179,7 +181,7 @@ export class PointData extends Observable {
         let popup = L.popup({
             autoPan: false,
             autoClose: !isClicked,
-            offset: [20, 0],
+            offset: POPUP_OFFSET,
             closeButton: isClicked
         })
 
@@ -221,7 +223,6 @@ export class PointData extends Observable {
 
         $('.' + tooltipItemsClsName, item).html('');
 
-        this.appendPointData(point, item, tooltipRowItem, tooltipItemsClsName, 'tooltip__facility-item_label', 'tooltip__facility-item_value');
         if (point.image != null)
             $('.' + tooltipItemsClsName, item).append(`<img src="${point.image}"/>`);
 

--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -10,8 +10,16 @@ const tooltipClsName = 'facility-tooltip';
 const tooltipRowClsName = 'facility-tooltip__item';
 const tooltipItemsClsName = 'facility-tooltip__items';
 
+const facilityClsName = 'facility-info';
+const facilityRowClsName = 'facility-info__item';
+const facilityItemsClsName = 'facility-info__items';
+
 let tooltipItem = null;
 let tooltipRowItem = null;
+
+let facilityItem = null;
+let facilityRowItem = null;
+
 let activeMarkers = [];
 let activePoints = [];  //the visible points on the map
 
@@ -35,6 +43,9 @@ export class PointData extends Observable {
     prepareDomElements = () => {
         tooltipItem = $('.' + tooltipClsName)[0].cloneNode(true);
         tooltipRowItem = $('.' + tooltipRowClsName)[0].cloneNode(true);
+        facilityRowItem = $('.' + facilityRowClsName)[0].cloneNode(true);
+        facilityItem = $('.' + facilityClsName);
+        $('.facility-info__close').on('click', () => this.hideFacilityModal());
     }
 
     genLayer() {
@@ -168,7 +179,7 @@ export class PointData extends Observable {
         let popup = L.popup({
             autoPan: false,
             autoClose: !isClicked,
-            offset: [9, 0],
+            offset: [20, 0],
             closeButton: isClicked
         })
 
@@ -201,7 +212,7 @@ export class PointData extends Observable {
 
         $(item).find('.tooltip__notch').remove();   //leafletjs already creates this
 
-        const nameContainer = $('.facility-tooltip__header_name div', item);
+        const nameContainer = $('.facility-tooltip__header_name', item);
         if (point.url != null)
             nameContainer.html(`<a href="${point.url}" target="_blank">${point.name}</a>`)
         else
@@ -210,22 +221,44 @@ export class PointData extends Observable {
 
         $('.' + tooltipItemsClsName, item).html('');
 
+        this.appendPointData(point, item, tooltipRowItem, tooltipItemsClsName, 'tooltip__facility-item_label', 'tooltip__facility-item_value');
+        if (point.image != null)
+            $('.' + tooltipItemsClsName, item).append(`<img src="${point.image}"/>`);
+
+
+        $('.facility-tooltip__open-modal', item).on('click', () => {
+            this.showFacilityModal(point);
+        })
+
+        return item;
+    }
+
+    showFacilityModal = (point) => {
+        $('.facility-info__title').text(point.name);
+        this.appendPointData(point, facilityItem, facilityRowItem, facilityItemsClsName, 'facility-info__item_label', 'facility-info__item_value');
+
+        $('.facility-info').css('display', 'flex');
+    }
+
+    appendPointData = (point, item, rowItem, itemsClsName, labelClsName, valueClsName) => {
+        $('.' + itemsClsName, item).empty();
         point.data.forEach((a, i) => {
             if (Object.prototype.toString.call(a.value) == '[object String]') {
-                let itemRow = tooltipRowItem.cloneNode(true);
-                $('.tooltip__facility-item_label div', itemRow).text(a.key);
-                $('.tooltip__facility-item_value div', itemRow).text(a.value);
+                let itemRow = rowItem.cloneNode(true);
+                $(itemRow).removeClass('last');
+                $('.' + labelClsName, itemRow).text(a.key);
+                $('.' + valueClsName, itemRow).text(a.value);
                 if (i === point.data.length - 1) {
                     $(itemRow).addClass('last')
                 }
 
-                $('.' + tooltipItemsClsName, item).append(itemRow);
+                $('.' + itemsClsName, item).append(itemRow);
             }
         })
-        if (point.image != null)
-            $('.' + tooltipItemsClsName, item).append(`<img src="${point.image}"/>`);
+    }
 
-        return $(item).html();
+    hideFacilityModal = () => {
+        $('.facility-info').hide();
     }
 
     onMapZoomed(map) {

--- a/src/js/map/popup.js
+++ b/src/js/map/popup.js
@@ -25,7 +25,7 @@ export class Popup extends Observable {
 
         this.map.map_variables.popup = L.popup({
             autoPan: false,
-            offset: [-10, 0],
+            offset: [20, 0],
             closeButton: false
         })
 
@@ -67,7 +67,7 @@ export class Popup extends Observable {
 
         $(item).find('.tooltip__notch').remove();   //leafletjs already creates this
 
-        return $(item).html();
+        return item;
     }
 
     setTooltipThemes = (item, areaCode) => {

--- a/src/js/map/popup.js
+++ b/src/js/map/popup.js
@@ -3,6 +3,7 @@ import {format as d3format} from "d3-format/src/defaultLocale";
 
 const PERCENTAGE_TYPE = 'Percentage';
 const VALUE_TYPE = 'Value'
+const POPUP_OFFSET= [20, 0];
 
 /**
  * this class creates & manipulates the popup over the map
@@ -25,7 +26,7 @@ export class Popup extends Observable {
 
         this.map.map_variables.popup = L.popup({
             autoPan: false,
-            offset: [20, 0],
+            offset: POPUP_OFFSET,
             closeButton: false
         })
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -62,13 +62,10 @@ export function setPopupStyle(clsName) {
     $('.leaflet-popup-close-button').html($('.facility-tooltip__close').html());
     $('.leaflet-popup-close-button').css('padding', 0);
     $('.facility-tooltip__close').css('display', 'none');
-    $('.leaflet-popup-content-wrapper').css('border-radius', $('.' + clsName).css('border-radius'));
-    $('.leaflet-popup-content-wrapper').css('font-family', $('.' + clsName).css('font-family'));
-    $('.leaflet-popup-content-wrapper').css('font-size', $('.' + clsName).css('font-size'));
-    $('.leaflet-popup-content').css('margin', $('.' + clsName).css('padding'));
-    $('.leaflet-popup-content').css('min-width', $('.' + clsName).css('min-width'));
-    $('.leaflet-popup-content').css('display', 'inline-table');
     $('.map__tooltip_value').css('white-space', 'nowrap');
+    $('.leaflet-popup-content-wrapper').css('padding', 0);
+    $('.leaflet-popup-content').css('margin', 'unset');
+    $('.leaflet-container').css('font', 'unset');
 
     let popupWidth = 0;
     let chipWidth = 0;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1516,8 +1516,8 @@ adler-32@~1.2.0:
     exit-on-epipe "~1.0.1"
     printj "~1.1.0"
 
-ajv-keywords@^3.5.2:
-  version "3.5.2"
+ajv-keywords@^3.5.1:
+  version "3.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.1.tgz#b83ca89c5d42d69031f424cad49aada0236c6957"
 
 ajv@^6.12.3, ajv@^6.12.4:
@@ -8845,9 +8845,10 @@ word@~0.3.0:
   resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
   integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
-wrap-ansi@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"


### PR DESCRIPTION
## Description
Applied design changes related with tooltip. Used the export Matt has created and attached here : 
https://trello.com/c/7hIyV9Lu/633-facility-tooltip-and-facility-modal

Using the `More Info` button on the tooltips, a modal could be viewed.

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/186

## How to test it locally
* On the point mapper window select a category 
* When the points are loaded into the map test if the point tooltips look as designed and if the data shown on them are correct
* Click `More Info` button on any tooltip and test if the modal looks as designed and if the data shown on it is correct

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/105283102-d4626a00-5bc0-11eb-9dd1-4ed0a0be24e5.png)

edit - Jan 22, 2021
![image](https://user-images.githubusercontent.com/53019884/105486182-24275b00-5cbf-11eb-9e07-fd21fc7ba8a3.png)


## Changelog

### Added

### Updated
* utils.js. when we implemented the tooltips initially we had a hard time because of pre-defined leaflet classes. so instead of applying the css classes that Matt has created to tooltips directly, we instead applied those classes' properties to the pre-defined classes. while working on this issue I figured out why pre-defined classes break the design and applied the css classes that Matt has created. `setPopupStyle()` function can be implemented as css too.
* point_data.js to populate facility modal using the data of the selected point, to apply desing changes and utils.js related changes
* popup.js to apply design changes and utils.js related changes

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
