### PR TITLE
hiding empty charts

### DIFF
--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -49,7 +49,7 @@ export class Indicator extends Observable {
         const configuration = detail.indicators[title].chartConfiguration;
         const indicators = detail.indicators;
 
-        let hasValues = this.checkSubindicatorValues(title);
+        let hasValues = this.subindicators.some(function(e) { return e.count > 0 });
 
         if (hasValues) {
             let c = new Chart(configuration, this.subindicators, this.groups, indicators, 'Percentage', indicator, title);
@@ -65,17 +65,5 @@ export class Indicator extends Observable {
 
             wrapper.append(indicator);
         }
-    }
-
-    checkSubindicatorValues(title) {
-        let hasValues = false;
-        for (const [label, subindicator] of Object.entries(this.subindicators)) {
-            if (subindicator.count > 0) {
-                hasValues = true;
-                break;
-            }
-        }
-
-        return hasValues;
     }
 }

--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -49,17 +49,33 @@ export class Indicator extends Observable {
         const configuration = detail.indicators[title].chartConfiguration;
         const indicators = detail.indicators;
 
-        let c = new Chart(configuration, this.subindicators, this.groups, indicators, 'Percentage', indicator, title);
-        this.bubbleEvents(c, [
-            'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
-            'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
-            'point_tray.subindicator_filter.filter'
-        ]);
+        let hasValues = this.checkSubindicatorValues(title);
 
-        if (!isLast) {
-            $(indicator).removeClass('last');
+        if (hasValues) {
+            let c = new Chart(configuration, this.subindicators, this.groups, indicators, 'Percentage', indicator, title);
+            this.bubbleEvents(c, [
+                'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
+                'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
+                'point_tray.subindicator_filter.filter'
+            ]);
+
+            if (!isLast) {
+                $(indicator).removeClass('last');
+            }
+
+            wrapper.append(indicator);
+        }
+    }
+
+    checkSubindicatorValues(title) {
+        let hasValues = false;
+        for (const [label, subindicator] of Object.entries(this.subindicators)) {
+            if (subindicator.count > 0) {
+                hasValues = true;
+                break;
+            }
         }
 
-        wrapper.append(indicator);
+        return hasValues;
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,7 +1517,7 @@ adler-32@~1.2.0:
     printj "~1.1.0"
 
 ajv-keywords@^3.5.2:
-  version "3.5.2"
+  version "3.5.1"
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.1.tgz#b83ca89c5d42d69031f424cad49aada0236c6957"
 
 ajv@^6.12.3, ajv@^6.12.4:
@@ -8845,9 +8845,10 @@ word@~0.3.0:
   resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
   integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
-wrap-ansi@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-5.1.0.tgz#1fd1f67235d5b6d0fee781056001bfb694c03b09"
+wrap-ansi@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-3.0.1.tgz#288a04d87eda5c286e060dfe8f135ce8d007f8ba"
+  integrity sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
   dependencies:
     string-width "^2.1.1"
     strip-ansi "^4.0.0"


### PR DESCRIPTION
## Description
Hiding a chart if all the values are 0 on rich data panel

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/226

## How to test it locally
* on the rich data panel confirm that there are no empty charts but also they are visible when they values > 0. as an example, on `staging` `Medical Aid` chart has no values for country level so it must not be visible. But on `/#geo:GT` `Medical Aid` chart has values so it must be visible


## Screenshots
Before : 
![image](https://user-images.githubusercontent.com/53019884/105488873-65ba0500-5cc3-11eb-8451-3f15fd5024db.png)

After : 
![image](https://user-images.githubusercontent.com/53019884/105488899-6f436d00-5cc3-11eb-859c-378740c6b2a3.png)


## Changelog

### Added

### Updated
* `indicator.js` to check if any of the subindicators have values before appending a chart

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
