### PR TITLE
closing info windows when one of them closes

### DIFF
--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -23,7 +23,7 @@ let facilityRowItem = null;
 let activeMarkers = [];
 let activePoints = [];  //the visible points on the map
 
-const POPUP_OFFSET= [20, 0];
+const POPUP_OFFSET = [20, 0];
 
 /**
  * this class creates the point data dialog
@@ -47,7 +47,7 @@ export class PointData extends Observable {
         tooltipRowItem = $('.' + tooltipRowClsName)[0].cloneNode(true);
         facilityRowItem = $('.' + facilityRowClsName)[0].cloneNode(true);
         facilityItem = $('.' + facilityClsName);
-        $('.facility-info__close').on('click', () => this.hideFacilityModal());
+        $('.facility-info__close').on('click', () => this.hideInfoWindows());
     }
 
     genLayer() {
@@ -191,7 +191,10 @@ export class PointData extends Observable {
             popup
                 .setLatLng({lat: point.y, lng: point.x})
                 .setContent(popupContent)
-                .addTo(this.map);
+                .addTo(this.map)
+                .on('remove', () => {
+                    this.hideInfoWindows();
+                });
             this.triggerEvent('point_data.load_popup.clicked', eventLabel);
         } else {
             popup
@@ -202,6 +205,11 @@ export class PointData extends Observable {
         }
 
         setPopupStyle('facility-tooltip');
+    }
+
+    hideInfoWindows = () => {
+        this.hideFacilityModal();
+        $('a.leaflet-popup-close-button')[0].click()
     }
 
     hideMarkerPopup = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1517,8 +1517,9 @@ adler-32@~1.2.0:
     printj "~1.1.0"
 
 ajv-keywords@^3.5.2:
-  version "3.5.1"
-  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.1.tgz#b83ca89c5d42d69031f424cad49aada0236c6957"
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.5.2.tgz#31f29da5ab6e00d1c2d329acf7b5929614d5014d"
+  integrity sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==
 
 ajv@^6.12.3, ajv@^6.12.4:
   version "6.12.6"


### PR DESCRIPTION
## Description
when one of the info windows(modal or tooltip) closes, closing the other as well

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/186

## How to test it locally
* On the point mapper window select a category
* When the points are loaded into the map click on a point
* On the point tooltip click on `More info` button
* When a tooltip and a modal is visible test and confirm they both close when one is closed

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/105844394-39b3c200-5fea-11eb-8a73-b24268069c3d.png)


## Changelog

### Added

### Updated
* `point_data.js` to handle `remove` event of tooltip and `click` event of `$('.facility-info__close')`(modal close button)

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
