### PR TITLE
Fixing choropleth calculation bug

### DIFF
--- a/__tests__/subindicator_calculator.test.js
+++ b/__tests__/subindicator_calculator.test.js
@@ -1,0 +1,35 @@
+import SubindicatorCalculator from '../src/js/map/choropleth/subindicator_calculator';
+
+describe('SubindicatorCalculator', () => {
+
+  describe('#calculate', () => {
+    describe('all geography codes in both', () => {
+      it('calculates percentage', () => {
+        let expectedResult = [{ code: "code", val: 0.2 }];
+        let data = { code: 1 }
+        let subindicatorArr = [ { children: { code: 1 }}, { children: { code: 4 } }]
+        let bt = new SubindicatorCalculator();
+
+        let result = bt.calculate({ data, subindicatorArr })
+
+        expect(result).toEqual(expectedResult)
+
+      });
+    });
+    describe('geography code not in children', () => {
+      it('calculates percentage', () => {
+        let expectedPercentage = 0.2
+        let expectedResult = [{ code: "code", val: expectedPercentage }];
+        let data = { code: 1 }
+        let subindicatorArr = [ { children: { code2: 1 }}, { children: { code: 5 } }]
+        let bt = new SubindicatorCalculator();
+
+        let result = bt.calculate({ data, subindicatorArr })
+
+        expect(result).toEqual(expectedResult)
+
+      });
+    });
+  });
+});
+

--- a/src/js/map/choropleth/subindicator_calculator.js
+++ b/src/js/map/choropleth/subindicator_calculator.js
@@ -2,7 +2,7 @@ import {percFmt, numFmt} from '../../utils'
 
 export default class SubindicatorCalculator {
     calculate(args) {
-        if (typeof args.data === 'undefined'){
+        if (typeof args.data === 'undefined') {
             return null;
         }
 
@@ -10,16 +10,15 @@ export default class SubindicatorCalculator {
             const code = childGeography[0];
             const count = childGeography[1];
             const universe = args.subindicatorArr.reduce((el1, el2) => {
-                if (el2.children != undefined && el2.children[code] != undefined) {
-                    let e1 = typeof el1 === 'undefined' ? 0 : el1;
-                    let e2 = typeof  el2.children[code] === 'undefined' ? 0 :  el2.children[code];
-                    let total = e1 + e2;
+                let e1 = typeof el1 === 'undefined' ? 0 : el1;
+                let e2 = typeof el2.children[code] === 'undefined' ? 0 : el2.children[code];
+                let total = e1 + e2;
 
-                    return total;
-                }
+                return total;
             }, 0);
 
             const val = count / universe;
+
             return {code: code, val: val};
         })
 

--- a/src/js/map/choropleth/subindicator_calculator.js
+++ b/src/js/map/choropleth/subindicator_calculator.js
@@ -6,20 +6,15 @@ export default class SubindicatorCalculator {
             return null;
         }
 
-        const result = Object.entries(args.data).map(childGeography => {
-            const code = childGeography[0];
-            const count = childGeography[1];
-            const universe = args.subindicatorArr.reduce((el1, el2) => {
-                let e1 = typeof el1 === 'undefined' ? 0 : el1;
-                let e2 = typeof el2.children[code] === 'undefined' ? 0 : el2.children[code];
-                let total = e1 + e2;
-
-                return total;
+        const result = Object.entries(args.data).map(([code, codeValue]) => {
+            const sumSubindicatorsValueForCode = args.subindicatorArr.reduce((sum, subindicator) => {
+                let childrenValue = subindicator.children[code] || 0;
+                return sum + childrenValue;
             }, 0);
 
-            const val = count / universe;
+            const percentage = codeValue / sumSubindicatorsValueForCode;
 
-            return {code: code, val: val};
+            return {code: code, val: percentage};
         })
 
         return result;


### PR DESCRIPTION
## Description
Searching for the reason and fixing the issue that causes choropleth values bigger than 100%

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/246

## How to test it locally
* set `hostname` parameter in `index.js` as 'sifar-wazi.openup.org.za'
* navigate to `/#geo:199014`
* open data mapper
* select Demographics -> Population -> Population by age -> 00 - 04
* confirm that the choropleth values are correct

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/106604316-878f7380-6570-11eb-901e-df98bd6aa67d.png)


## Changelog
* removed the unnecessary if check in `subindicator_calculator.js`. we already assume each value is `0` if they are `undefined`. that additional if check breaks the calculation 

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
