### PR TITLE
fixing the missing fields on location tooltip

### DIFF
--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -252,7 +252,7 @@ export class PointData extends Observable {
     appendPointData = (point, item, rowItem, itemsClsName, labelClsName, valueClsName) => {
         $('.' + itemsClsName, item).empty();
         point.data.forEach((a, i) => {
-            if (Object.prototype.toString.call(a.value) == '[object String]') {
+            if (Object.prototype.toString.call(a.value) !== '[object Object]') {
                 let itemRow = rowItem.cloneNode(true);
                 $(itemRow).removeClass('last');
                 $('.' + labelClsName, itemRow).text(a.key);


### PR DESCRIPTION
## Description
checking the reason causing some fields to be missing from the location tooltip

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/220

## How to test it locally
* on point mapper select Safety > interchange order test
* click on `more info` button on a point's tooltip to show the modal
* on the modal confirm that all the fields are displayed

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/106614963-012d5e80-657d-11eb-9fc8-6018c4a3c8fa.png)


## Changelog

### Added

### Updated
* `point_data.js` to prevent `Object` type variables to be appended instead of letting just `String` type variablesç

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
