### PR TITLE
Fixes 234

### DIFF
--- a/src/js/elements/mapchip.js
+++ b/src/js/elements/mapchip.js
@@ -137,7 +137,7 @@ export class MapChip extends Observable {
             label = args.indicatorTitle;
         }
 
-        this.title = `${args.category} by ${label}`;
+        this.title = `${label}`;
 
         this.updateMapChipText(label);
         this.showMapChip(args);


### PR DESCRIPTION
## Description
No longer using the category in the map title - it wasn't being used anywhere else either

The title was often too long - the category was usually not necessary to understand the map

## Related Issue
#234 

## How to test it locally
1. Plot a choropleth
2. Download the map
3. Ensure that the map title only contains the name of the indicator and subindicator

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
