### PR TITLE
showing map title on download

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -7038,10 +7038,7 @@ label {
   top: 16px;
   right: auto;
   bottom: auto;
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
+  display: none;
   margin-right: 24px;
   margin-left: 24px;
   padding: 12px;
@@ -7050,6 +7047,9 @@ label {
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.1);
   font-size: 1.2em;
   font-weight: 700;
+  z-index:999;
+  left: 50%;
+  transform: translateX(-50%);
 }
 
 .map-title.webflow {

--- a/src/index.html
+++ b/src/index.html
@@ -312,6 +312,7 @@
       </div>
     </div>
     <div class="map">
+	  <div class="map-title">Loading...</div>
       <div class="map-about hidden">
         <div class="map-about__icon">
           <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">

--- a/src/js/map/map_download.js
+++ b/src/js/map/map_download.js
@@ -12,6 +12,8 @@ export class MapDownload extends Observable {
     prepareDomElements = () => {
         $('.map-download').on('click', () => {
             this.triggerEvent('mapdownload.started');
+            this.titleClass = '.map-title';
+            this.legendClass = '.map-options__legend';
             this.downloadMap();
         });
     }
@@ -19,23 +21,32 @@ export class MapDownload extends Observable {
     downloadMap = () => {
         let self = this;
 
-        const options = {
-            useCORS: true
-        };
-        const title = $(`<div id="map-download-title">${this.mapChip.title}</div>`);
         const element = document.getElementById("main-map");
+        const title = $(self.titleClass)[0].cloneNode(true);
+        $(title).text(this.mapChip.title);
 
-        const legend = document.querySelector('.map-options__legend');
+        const legend = document.querySelector(self.legendClass);
         let clonedLegend = legend.cloneNode(true);
         $(clonedLegend).find('.map-options__legend_label').remove();
         clonedLegend.id = 'map-download-legend';
 
-        $(element).append(title);
         $(element).append(clonedLegend);
+        $(element).prepend(title);
+
+        const options = {
+            useCORS: true,
+            onclone: (clonedElement) => {
+                if (this.mapChip.title !== '')
+                {
+                    $(clonedElement).find(self.titleClass).show();
+                }
+                $(clonedElement).find(self.legendClass).remove();
+            }
+        };
 
         setTimeout(() => {
             html2canvas(element, options).then(function (canvas) {
-                $(title).remove();
+                $(element).find(title).remove();
                 $(clonedLegend).remove();
                 saveAs(canvas.toDataURL(), 'map.png');
                 self.triggerEvent('mapdownload.completed');


### PR DESCRIPTION
## Description
configuring and showing the map title on download to give users more context

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/250

## How to test it locally
* select a sub-indicator to draw choropleth on the map
* download and confirm that the title is included in the screenshot

## Screenshots
a screenshot without choropleth(and without a title)
![image](https://user-images.githubusercontent.com/53019884/107035636-89a03f00-67c9-11eb-934d-01874c895847.png)

a screenshot with a title
![image](https://user-images.githubusercontent.com/53019884/107035800-bc4a3780-67c9-11eb-89d9-1f6602acb039.png)


## Changelog

### Added

### Updated
* `index.html` and `wazimap-ng-v1.webflow.css` to apply the design changes
* `map_download.js` to clone the title into `#main-map` at the time of downloading

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
