### PR TITLE
configuring style

### DIFF
--- a/src/js/elements/style_config.js
+++ b/src/js/elements/style_config.js
@@ -1,0 +1,21 @@
+export class StyleConfig {
+    constructor(styleConfig) {
+        this.styleConfig = styleConfig;
+    }
+
+    insertStyleRules = () => {
+        if (typeof this.styleConfig === 'undefined') {
+            return;
+        }
+
+        let style = document.createElement('style');
+        document.head.appendChild(style);
+        let styleSheet = style.sheet;
+
+        for (const [className, props] of Object.entries(this.styleConfig)) {
+            for (let i = 0; i < props.length; i++) {
+                styleSheet.insertRule(`.${className}{ ${props[i].key}: ${props[i].value} }`, i);
+            }
+        }
+    }
+}

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -34,6 +34,8 @@ import {configureProfileEvents} from './setup/profile';
 import {configureBoundaryEvents} from "./setup/boundaryevents";
 import {configureMapDownloadEvents} from "./setup/mapdownload";
 import {configureTutorialEvents} from "./setup/tutorial";
+import {StyleConfig} from "./elements/style_config";
+import {configureStyleConfigEvents} from "./setup/styleconfig";
 
 
 export default function configureApplication(profileId, config) {
@@ -65,6 +67,7 @@ export default function configureApplication(profileId, config) {
     const boundaryTypeBox = new BoundaryTypeBox(config.config.preferred_children);
     const mapDownload = new MapDownload(mapchip);
     const tutorial = new Tutorial();
+    const styleConfig = new StyleConfig(config.config.style);
 
     // TODO not certain if it is need to register both here and in the controller in loadedGeography
     // controller.registerWebflowEvents();
@@ -83,6 +86,7 @@ export default function configureApplication(profileId, config) {
     configureBoundaryEvents(controller, boundaryTypeBox);
     configureMapDownloadEvents(mapDownload);
     configureTutorialEvents(controller, tutorial, config.config.tutorial);
+    configureStyleConfigEvents(controller, styleConfig);
 
     controller.on('profile.loaded', payload => {
         // there seems to be a bug where menu items close if this is not set

--- a/src/js/setup/styleconfig.js
+++ b/src/js/setup/styleconfig.js
@@ -1,0 +1,3 @@
+export function configureStyleConfigEvents(controller, styleConfig) {
+    controller.on('profile.loaded', () => styleConfig.insertStyleRules())
+}


### PR DESCRIPTION
## Description
configuring site style using API data

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/204

## How to test it locally
* when the BE is ready check if the css classes could be configured

## Screenshots


## Changelog

### Added
* `elements/style_config.js` this file assumes `configuration` key contains `style` property and applies its rules to the page 
![image](https://user-images.githubusercontent.com/53019884/107366492-44448000-6aef-11eb-807e-33d26d00b9c9.png)

assumed data structure is: 
```
style: {
   'bg-primary' : [
        {key:'color', value:'#aaa'},
        {key:'background-color', value:'#bbb'}
    ],
   'text-primary' : [
        {key:'font-size', value:'18px'},
        {key:'font-weight', value:'700'}
    ],
}
```
* `setup/styleconfig.js` to manage style config related events

### Updated
* `load.js` to reference the new files

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
