### PR TITLE
pdf improvements

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -8286,5 +8286,10 @@ label {
     .page-break-before {
         break-before: page;
     }
+
+    body, .main, .rich-data, .rich-data-content, .rich-data-content .section, .profile-indicator{
+        float: none !important;
+        display: block !important;
+    }
 }
 

--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -8282,3 +8282,9 @@ label {
   }
 }
 
+@media print {
+    .page-break-before {
+        page-break-before: always;
+    }
+}
+

--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -8284,7 +8284,7 @@ label {
 
 @media print {
     .page-break-before {
-        page-break-before: always;
+        break-before: page;
     }
 }
 

--- a/src/js/profile/category.js
+++ b/src/js/profile/category.js
@@ -14,7 +14,7 @@ const descriptionClass = '.category-header__description';
 //category > subcategory > indicator > chart
 
 export class Category extends Observable {
-    constructor(formattingConfig, category, detail, _profileWrapper, _id, _removePrevCategories) {
+    constructor(formattingConfig, category, detail, _profileWrapper, _id, _removePrevCategories, isFirst) {
         super();
 
         categoryTemplate = $(categoryClass)[0].cloneNode(true);
@@ -25,7 +25,7 @@ export class Category extends Observable {
         this.formattingConfig = formattingConfig;
 
         this.prepareDomElements();
-        this.addCategory(category, detail);
+        this.addCategory(category, detail, isFirst);
     }
 
     prepareDomElements = () => {
@@ -34,7 +34,7 @@ export class Category extends Observable {
         }
     }
 
-    addCategory = (category, detail) => {
+    addCategory = (category, detail, isFirst) => {
         const newCategorySection = categoryTemplate.cloneNode(true);
         const sectionHeader = $('.category-header')[0].cloneNode(true);
         const indicatorHeader = $('.sub-category-header')[0].cloneNode(true);
@@ -51,7 +51,9 @@ export class Category extends Observable {
             $(descriptionClass, newCategorySection).addClass('hidden');
         }
 
-        $(newCategorySection).addClass('page-break-before');
+        if (!isFirst){
+            $(newCategorySection).addClass('page-break-before');
+        }
 
         this.loadSubcategories(newCategorySection, detail);
 

--- a/src/js/profile/category.js
+++ b/src/js/profile/category.js
@@ -51,6 +51,8 @@ export class Category extends Observable {
             $(descriptionClass, newCategorySection).addClass('hidden');
         }
 
+        $(newCategorySection).addClass('page-break-before');
+
         this.loadSubcategories(newCategorySection, detail);
 
         profileWrapper.append(newCategorySection);

--- a/src/js/profile/profile_loader.js
+++ b/src/js/profile/profile_loader.js
@@ -60,12 +60,14 @@ export default class ProfileLoader extends Observable {
     loadCategories = (profile) => {
         let removePrevCategories = true;
         const categories = profile.profileData;
+        let isFirst = true;
 
         this.createNavItem('top', 'Summary');
         for (const [category, detail] of Object.entries(categories)) {
             const id = this.getNewId();
             this.createNavItem(id, category);
-            let c = new Category(this.formattingConfig, category, detail, profileWrapper, id, removePrevCategories);
+            let c = new Category(this.formattingConfig, category, detail, profileWrapper, id, removePrevCategories, isFirst)
+            isFirst = false;
             this.bubbleEvents(c, [
                 'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
                 'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',

--- a/src/js/profile/subcategory.js
+++ b/src/js/profile/subcategory.js
@@ -32,6 +32,7 @@ export class Subcategory extends Observable {
             $(wrapper).find(subcategoryHeaderClass).remove();
         } else {
             $(scHeader).removeClass('first');
+            $(scHeader).addClass('page-break-before');
         }
 
         $(subcategoryTitleClass, scHeader).text(subcategory);


### PR DESCRIPTION
## Description
improving pdf style, adding appropriate page-breaks 

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/236

## How to test it locally
* run the project
* open rich data panel
* print the page in PDF format
* check the page breaks

## Screenshots


## Changelog

### Added

### Updated
* `css/wazimap-ng-v1.webflow.css` to define `.page-break-before` class which will break the page in print media
* `profile/category.js` to add `.page-break-before` class to the categories
* `profile/subcategory.js` to add `.page-break-before` class to the sub-categories(except the first one)

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
