### PR TITLE
showing a message on data mapper where a choropleth cannot be displayed

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -818,6 +818,15 @@
           </div>
           <div>The Data Mapper cannot be used with this location as it doesn&#x27;t contain any sub-areas which can be used for mapping</div>
         </div>
+        <div class="data-mapper-content__no-data no-choropleth-data hidden">
+          <div class="no-data__icon">
+            <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                <path d="M0 0h24v24H0z" fill="none"></path>
+                <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
+              </svg></div>
+          </div>
+          <div>The Data Mapper cannot be used with this location as it doesn&#x27;t have enough data to display</div>
+        </div>
         <div class="data-mapper-content__list"></div>
       </div>
       <div class="data-mapper-toggles">

--- a/src/index.html
+++ b/src/index.html
@@ -825,7 +825,7 @@
                 <path fill="currentColor" d="M11 15h2v2h-2zm0-8h2v6h-2zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"></path>
               </svg></div>
           </div>
-          <div>The Data Mapper cannot be used with this location as it doesn&#x27;t have enough data to display</div>
+          <div>The Data Mapper cannot be used with this location as no choropleth can be displayed</div>
         </div>
         <div class="data-mapper-content__list"></div>
       </div>

--- a/src/js/elements/menu.js
+++ b/src/js/elements/menu.js
@@ -8,6 +8,7 @@ const subCategoryTemplate = $(".data-category__h2", categoryTemplate)[0].cloneNo
 const indicatorTemplate = $(".data-category__h2_content", subCategoryTemplate)[0].cloneNode(true);
 const indicatorItemTemplate = $(".data-category__h4", subCategoryTemplate)[0].cloneNode(true);
 const noDataWrapperClsName = 'data-mapper-content__no-data';
+const noChoroplethDataWrapperClsName = 'no-choropleth-data';
 const loadingClsName = 'data-mapper-content__loading';
 
 function subindicatorsInCategory(category) {
@@ -55,6 +56,8 @@ function indicatorHasChildren(indicator) {
 
 // TODO this entire file needs to be refactored to use thhe observer pattern
 export function loadMenu(data, subindicatorCallback) {
+    let hasDataForChoropleth = false;
+
     function addSubIndicators(wrapper, category, subcategory, indicator, subindicators, indicators) {
 
         if (subindicators == undefined || !Array.isArray(subindicators)) {
@@ -68,6 +71,10 @@ export function loadMenu(data, subindicatorCallback) {
                     const newSubIndicatorElement = indicatorItemTemplate.cloneNode(true);
                     $(".truncate", newSubIndicatorElement).text(subIndicator.label);
                     $(newSubIndicatorElement).attr('title', subIndicator.label);
+
+                    hasDataForChoropleth = hasDataForChoropleth || subindicators.some(function (e) {
+                        return (e.children !== null && typeof e.children !== 'undefined')
+                    });
 
                     wrapper.append(newSubIndicatorElement);
 
@@ -147,7 +154,6 @@ export function loadMenu(data, subindicatorCallback) {
     let hasNoItems = true;
     $(parentContainer).find('.data-category').remove();
 
-
     for (const [category, detail] of Object.entries(data)) {
         let count = subindicatorsInCategory(detail);
 
@@ -166,10 +172,19 @@ export function loadMenu(data, subindicatorCallback) {
             $('.' + noDataWrapperClsName).removeClass(hideondeployClsName);
         }
     }
+
+    if (hasDataForChoropleth) {
+        $(parentContainer).removeClass('hidden');
+        $('.' + noChoroplethDataWrapperClsName).addClass('hidden');
+    } else {
+        $(parentContainer).addClass('hidden');
+        $('.' + noChoroplethDataWrapperClsName).removeClass('hidden');
+    }
 }
 
-export function showNoData(){
+export function showNoData() {
     $(parentContainer).empty();
     $('.' + loadingClsName).addClass('hidden');
     $('.' + noDataWrapperClsName).removeClass('hidden');
+    $('.' + noChoroplethDataWrapperClsName).addClass('hidden');
 }


### PR DESCRIPTION
## Description
showing a meaningful message on the data mapper to explain the users why a choropleth cannot be displayed

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/238

## How to test it locally
* navigate to a geography where we don't have enough data to display choropleth
* confirm that on the data mapper, there is a warning message instead of the indicators & sub-indicators

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/107941327-9b889b80-6f9a-11eb-8155-2e7b77ebf5a6.png)


## Changelog

### Added

### Updated
* `index.html` to add the warning message
* `menu.js` to hide the indicators and show the warning message when there is not enough data to display choropleth

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
