### PR TITLE
adding a clickable tab notice to the right-hand side of the screen

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -6736,8 +6736,7 @@ label {
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
-  display: flex;
-  overflow: hidden;
+  display: flex; 
   height: 44px;
   border-top-left-radius: 2px;
   border-top-right-radius: 2px;

--- a/src/index.html
+++ b/src/index.html
@@ -224,6 +224,14 @@
     </div>
   </div>
   <div class="main">
+    <div class="tab-notice hidden">
+      <div class="tab-notice__inner">
+        <a href="#" class="tab-notice__content w-inline-block">
+          <div class="tab-notice__text">Loading...</div>
+        </a>
+        <div class="plate bg-primary"></div>
+      </div>
+    </div>
     <div class="nav">
       <div data-w-id="66ee4f1f-99f3-8310-c69c-b5d00bdac74c" style="opacity:1;display:none" class="nav__search-deselect"></div>
       <div class="nav__shadow"></div>

--- a/src/js/dataobjects.js
+++ b/src/js/dataobjects.js
@@ -54,7 +54,6 @@ export class Profile {
         this._parents = js.geography.parents.map(el => new Geography(el));
         this._highlights = js.highlights;
         this._profileData = js.profile_data;
-        this._feedback = js.feedback;
 
         Object.values(this._profileData).forEach(category => {
             category = self._fixCategory(category)
@@ -114,10 +113,6 @@ export class Profile {
 
     get keyMetrics() {
         return this._keyMetrics;
-    }
-
-    get feedback() {
-        return this._feedback;
     }
 }
 

--- a/src/js/dataobjects.js
+++ b/src/js/dataobjects.js
@@ -54,6 +54,7 @@ export class Profile {
         this._parents = js.geography.parents.map(el => new Geography(el));
         this._highlights = js.highlights;
         this._profileData = js.profile_data;
+        this._feedback = js.feedback;
 
         Object.values(this._profileData).forEach(category => {
             category = self._fixCategory(category)
@@ -113,6 +114,10 @@ export class Profile {
 
     get keyMetrics() {
         return this._keyMetrics;
+    }
+
+    get feedback() {
+        return this._feedback;
     }
 }
 

--- a/src/js/elements/tab_notice.js
+++ b/src/js/elements/tab_notice.js
@@ -1,20 +1,21 @@
 export class TabNotice {
-    constructor() {
+    constructor(feedback) {
         this.tab = $('.tab-notice');
+        this.feedback = feedback;
     }
 
-    modifyTabNotice = (profile) => {
-        if (typeof profile.feedback === 'undefined' || profile.feedback === null) {
+    modifyTabNotice = () => {
+        if (typeof this.feedback === 'undefined' || this.feedback === null) {
             return;
         }
 
-        if (profile.feedback.visible) {
+        if (this.feedback.visible) {
             this.tab.removeClass('hidden');
         } else {
             this.tab.addClass('hidden');
         }
 
-        this.tab.find('a.tab-notice__content').attr('href', profile.feedback.url);
-        this.tab.find('a.tab-notice__content .tab-notice__text').text(profile.feedback.text);
+        this.tab.find('a.tab-notice__content').attr('href', this.feedback.url);
+        this.tab.find('a.tab-notice__content .tab-notice__text').text(this.feedback.text);
     }
 }

--- a/src/js/elements/tab_notice.js
+++ b/src/js/elements/tab_notice.js
@@ -1,0 +1,20 @@
+export class TabNotice {
+    constructor() {
+        this.tab = $('.tab-notice');
+    }
+
+    modifyTabNotice = (profile) => {
+        if (typeof profile.feedback === 'undefined' || profile.feedback === null) {
+            return;
+        }
+
+        if (profile.feedback.visible) {
+            this.tab.removeClass('hidden');
+        } else {
+            this.tab.addClass('hidden');
+        }
+
+        this.tab.find('a.tab-notice__content').attr('href', profile.feedback.url);
+        this.tab.find('a.tab-notice__content .tab-notice__text').text(profile.feedback.text);
+    }
+}

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -67,7 +67,7 @@ export default function configureApplication(profileId, config) {
     const boundaryTypeBox = new BoundaryTypeBox(config.config.preferred_children);
     const mapDownload = new MapDownload(mapchip);
     const tutorial = new Tutorial();
-    const tabNotice = new TabNotice();
+    const tabNotice = new TabNotice(config.config.feedback);
 
     // TODO not certain if it is need to register both here and in the controller in loadedGeography
     // controller.registerWebflowEvents();

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -20,6 +20,7 @@ import {Tutorial} from "./elements/tutorial";
 import "data-visualisations/src/charts/bar/reusable-bar-chart/stories.styles.css";
 import "../css/barchart.css";
 import {Popup} from "./map/popup";
+import {TabNotice} from "./elements/tab_notice";
 
 import {configureBreadcrumbsEvents} from './setup/breadcrumbs';
 import {configureChoroplethEvents} from './setup/choropleth';
@@ -34,6 +35,7 @@ import {configureProfileEvents} from './setup/profile';
 import {configureBoundaryEvents} from "./setup/boundaryevents";
 import {configureMapDownloadEvents} from "./setup/mapdownload";
 import {configureTutorialEvents} from "./setup/tutorial";
+import {configureTabNoticeEvents} from "./setup/tabnotice";
 
 
 export default function configureApplication(profileId, config) {
@@ -65,6 +67,7 @@ export default function configureApplication(profileId, config) {
     const boundaryTypeBox = new BoundaryTypeBox(config.config.preferred_children);
     const mapDownload = new MapDownload(mapchip);
     const tutorial = new Tutorial();
+    const tabNotice = new TabNotice();
 
     // TODO not certain if it is need to register both here and in the controller in loadedGeography
     // controller.registerWebflowEvents();
@@ -83,6 +86,7 @@ export default function configureApplication(profileId, config) {
     configureBoundaryEvents(controller, boundaryTypeBox);
     configureMapDownloadEvents(mapDownload);
     configureTutorialEvents(controller, tutorial, config.config.tutorial);
+    configureTabNoticeEvents(controller, tabNotice);
 
     controller.on('profile.loaded', payload => {
         // there seems to be a bug where menu items close if this is not set

--- a/src/js/setup/tabnotice.js
+++ b/src/js/setup/tabnotice.js
@@ -1,0 +1,3 @@
+export function configureTabNoticeEvents(controller, tabNotice) {
+    controller.on('profile.loaded', payload => tabNotice.modifyTabNotice(payload.state.profile.profile))
+}

--- a/src/js/setup/tabnotice.js
+++ b/src/js/setup/tabnotice.js
@@ -1,3 +1,3 @@
 export function configureTabNoticeEvents(controller, tabNotice) {
-    controller.on('profile.loaded', payload => tabNotice.modifyTabNotice(payload.state.profile.profile))
+    controller.on('profile.loaded', payload => tabNotice.modifyTabNotice())
 }


### PR DESCRIPTION
## Description
adding a per-profile customizable tab notice to the right-hand side of the screen

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/214

## How to test it locally

add something like this to the profile configuration in the admin interface:
```json

  "feedback": {
    "url": "https://www.google.com",
    "text": "Tab text",
    "visible": true
  },

and then go the site for that profile and look at the bottom right. 
```
## Screenshots
![image](https://user-images.githubusercontent.com/53019884/107950839-65eaaf00-6fa8-11eb-8e9d-e1124ed49246.png)


## Changelog

### Added
* `elements/tab_notice.js` to contain the functions that modify the tab notice
* `setup/tabnotice.js` to contain the events related with tab notice

### Updated
* `dataobjects.js` to add the `feedback` property to the `data bundle`. a sample data structure of the `feedback` property is assumed as 
```
        this._feedback = {
            visible: true,
            url: 'https://www.google.com',
            text: 'Tab text'
        }
```
* `index.html` to add the tab notice html
* `wazimap-ng-v1.webflow.css ` to modify the tab notice design
* `load.js` to reference the new classes

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
