### PR TITLE
Added configuration options to chart types

### DIFF
--- a/src/js/defaultValues.js
+++ b/src/js/defaultValues.js
@@ -1,9 +1,10 @@
 const DEFAULT_CONFIG = 'default'
 let chartConfiguration = {
     types: {
-        Value: {formatting: '~s', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG},
-        Percentage: {formatting: '.0%', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG}
-    }
+        Value: {formatting: '~s', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG, disabled: false},
+        Percentage: {formatting: '.0%', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG, disabled: false}
+    },
+    defaultType: 'Value' // [Value|Percentage]
 };
 export const defaultValues = {
     chartConfiguration,

--- a/src/js/defaultValues.js
+++ b/src/js/defaultValues.js
@@ -4,7 +4,7 @@ let chartConfiguration = {
         Value: {formatting: '~s', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG, disabled: false},
         Percentage: {formatting: '.0%', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG, disabled: false}
     },
-    defaultType: 'Value' // [Value|Percentage]
+    defaultType: 'Percentage' // [Value|Percentage]
 };
 export const defaultValues = {
     chartConfiguration,

--- a/src/js/defaultValues.js
+++ b/src/js/defaultValues.js
@@ -1,9 +1,10 @@
 const DEFAULT_CONFIG = 'default'
 let chartConfiguration = {
     types: {
-        Value: {formatting: '~s', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG, disabled: false},
-        Percentage: {formatting: '.0%', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG, disabled: false}
+        Value: {formatting: '~s', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG},
+        Percentage: {formatting: '.0%', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG}
     },
+    disableToggle: false,
     defaultType: 'Percentage' // [Value|Percentage]
 };
 export const defaultValues = {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -16,12 +16,12 @@ const tooltipClass = '.bar-chart__row_tooltip';
 let tooltipClone = null;
 
 export class Chart extends Observable {
-    constructor(config, subindicators, groups, indicators, graphValueType, _subCategoryNode, title) {
+    constructor(config, subindicators, groups, indicators, _subCategoryNode, title) {
         //we need the subindicators and groups too even though we have detail parameter. they are used for the default chart data
         super();
 
         this.subindicators = subindicators;
-        this.graphValueType = graphValueType;
+        this.graphValueType = config.defaultType
         this.title = title;
         this.config = config;
         this.selectedFilter = null;
@@ -32,6 +32,7 @@ export class Chart extends Observable {
 
         const chartContainer = $(chartContainerClass, this.subCategoryNode);
         this.container = chartContainer[0];
+        this.containerParent = $(this.container).closest('.profile-indicator');
 
         this.handleChartFilter(indicators, groups, title);
         this.addChart();
@@ -114,12 +115,18 @@ export class Chart extends Observable {
 
         return arr;
     }
+    
+    enableChartTypeToggle(enable) {
+        if (!enable) {
+            $(this.containerParent).find('.hover-menu__content_item--no-link:first').hide()
+            $(this.containerParent).find('.hover-menu__content_list').hide()
+        }
+
+    }
 
     setChartMenu = (barChart) => {
         const self = this;
-        const containerParent = $(this.container).closest('.profile-indicator');
-
-        const saveImgButton = $(containerParent).find('.hover-menu__content a.hover-menu__content_item:nth-child(1)');
+        const saveImgButton = $(this.containerParent).find('.hover-menu__content a.hover-menu__content_item:nth-child(1)');
 
         $(saveImgButton).off('click');
         $(saveImgButton).on('click', () => {
@@ -130,14 +137,18 @@ export class Chart extends Observable {
         })
 
         //todo:don't use index, specific class names should be used here when the classes are ready
-        $(containerParent).find('.hover-menu__content_list a').each(function (index) {
+        $(this.containerParent).find('.hover-menu__content_list a').each(function (index) {
             $(this).off('click');
             $(this).on('click', () => {
-                self.selectedGraphValueTypeChanged(containerParent, index);
+                self.selectedGraphValueTypeChanged(self.containerParent, index);
             })
         });
 
-        $(containerParent).find('.hover-menu__content_list--last a').each(function (index) {
+        const hasDisabledType = this.config.types.Value.disabled || this.config.types.Percentage.disabled
+        this.enableChartTypeToggle(!hasDisabledType);
+        
+
+        $(this.containerParent).find('.hover-menu__content_list--last a').each(function (index) {
             $(this).off('click');
             $(this).on('click', () => {
                 const downloadFn = {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -122,12 +122,11 @@ export class Chart extends Observable {
         return arr;
     }
     
-    enableChartTypeToggle(enable) {
-        if (!enable) {
+    disableChartTypeToggle = (disable) => {
+        if (disable) {
             $(this.containerParent).find('.hover-menu__content_item--no-link:first').hide()
             $(this.containerParent).find('.hover-menu__content_list').hide()
         }
-
     }
 
     setChartMenu = (barChart) => {
@@ -150,8 +149,7 @@ export class Chart extends Observable {
             })
         });
 
-        const hasDisabledType = this.config.types.Value.disabled || this.config.types.Percentage.disabled
-        this.enableChartTypeToggle(!hasDisabledType);
+        this.disableChartTypeToggle(this.config.disableToggle);
         
 
         $(this.containerParent).find('.hover-menu__content_list--last a').each(function (index) {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -14,6 +14,11 @@ const chartContainerClass = '.indicator__chart';
 const tooltipClass = '.bar-chart__row_tooltip';
 
 let tooltipClone = null;
+const typeIndex = {
+    'Percentage': 0,
+    'Value': 1
+}
+
 
 export class Chart extends Observable {
     constructor(config, subindicators, groups, indicators, _subCategoryNode, title) {
@@ -34,8 +39,9 @@ export class Chart extends Observable {
         this.container = chartContainer[0];
         this.containerParent = $(this.container).closest('.profile-indicator');
 
+
         this.handleChartFilter(indicators, groups, title);
-        this.addChart();
+        this.selectedGraphValueTypeChanged(this.containerParent, typeIndex[this.graphValueType]);
     }
 
     addChart = () => {
@@ -170,7 +176,6 @@ export class Chart extends Observable {
     }
 
     selectedGraphValueTypeChanged = (containerParent, index) => {
-        this.graphValueType = graphValueTypes[index];
         this.triggerEvent('profile.chart.valueTypeChanged', this);
 
         $(containerParent).find('.hover-menu__content_list a').each(function (itemIndex) {

--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -52,7 +52,7 @@ export class Indicator extends Observable {
         let hasValues = this.subindicators.some(function(e) { return e.count > 0 });
 
         if (hasValues) {
-            let c = new Chart(configuration, this.subindicators, this.groups, indicators, 'Percentage', indicator, title);
+            let c = new Chart(configuration, this.subindicators, this.groups, indicators, indicator, title);
             this.bubbleEvents(c, [
                 'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
                 'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',


### PR DESCRIPTION
## Description

Provides configuration options to set whether a graph should default to the percentage or value view. 
Configuration options can also be used to disable the type toggle in the chart context menu

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/240

## How to test it locally

1. Open up a profile indicator in the admin
2. Add the following to the chart_configuration: 
`
{"defaultType": "Value"}
`
3. Save and refresh the UI
4. You will see that the chart by default displays values rather than percentages


To test the disable configuration do the following:
1. Open up a profile indicator in the admin
2. Add the following to the chart_configuration:
`{"disableToggle": true}`
3. Save and refresh the UI
4. You will see the the chart option menu does not show the Percentage/Value toggle

## Screenshots


## Changelog

### Added

### Updated
1. Added a new defaultValue configuration option for the chart toggle
2. Added a disableToggle configuration option for chart toggle
3. Added the relevant functions to support these options

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
