### PR TITLE
fix: don't remove map legend every time

### DIFF
--- a/src/js/map/map_download.js
+++ b/src/js/map/map_download.js
@@ -36,11 +36,11 @@ export class MapDownload extends Observable {
         const options = {
             useCORS: true,
             onclone: (clonedElement) => {
-                if (this.mapChip.title !== '')
-                {
+                if (this.mapChip.title !== '') {
                     $(clonedElement).find(self.titleClass).show();
+                } else {
+                    $(clonedElement).find(self.legendClass).remove();
                 }
-                $(clonedElement).find(self.legendClass).remove();
             }
         };
 


### PR DESCRIPTION
## Description
only remove the map legend when there is no mapChip title and therefore no choropleth map.


## Related Issue


## How to test it locally
* select the "Data mapper"
* Map a value
* Download the map
* You should see the legend on the bottom

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
