### PR TITLE
fix: Switching Between Percent and Absolute in Graphs

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -174,6 +174,7 @@ export class Chart extends Observable {
     }
 
     selectedGraphValueTypeChanged = (containerParent, index) => {
+        this.graphValueType = graphValueTypes[index];
         this.triggerEvent('profile.chart.valueTypeChanged', this);
 
         $(containerParent).find('.hover-menu__content_list a').each(function (itemIndex) {


### PR DESCRIPTION
## Description

this removal slipped through my initial testing and results in a non-working toggle for switching between Percentage and absolute values 
adding this line will save the value type change

## Related Issue
#240
PR: #256 

## How to test it locally
* go to a chart in the Rich Data View and click on the menu to toggle between "Percent" and "Value"
* it should switch between those

## Screenshots


## Changelog

### Added

### Updated
* added the change of `graphValueType` back in
### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
