### PR TITLE
Added configurable ticks for barcharts

### DIFF
--- a/src/js/defaultValues.js
+++ b/src/js/defaultValues.js
@@ -5,7 +5,8 @@ let chartConfiguration = {
         Percentage: {formatting: '.0%', minX: DEFAULT_CONFIG, maxX: DEFAULT_CONFIG}
     },
     disableToggle: false,
-    defaultType: 'Percentage' // [Value|Percentage]
+    defaultType: 'Percentage', // [Value|Percentage]
+    xTicks: null
 };
 export const defaultValues = {
     chartConfiguration,

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -68,6 +68,7 @@ export class Chart extends Observable {
             .xAxisPadding(10) //padding of the xAxis values(numbers)
             .yAxisPadding(10)
             .xLabelPadding(30)    //padding of the label
+            .xTicks(this.config.xTicks)
             .barHeight(24)
             .barPadding(6)
             .margin({

--- a/src/js/reusable-charts/horizontal-bar-chart.js
+++ b/src/js/reusable-charts/horizontal-bar-chart.js
@@ -29,6 +29,7 @@ export function horizontalBarChart() {
         reverse: false,
         minX: 0,
         maxX: null,
+        xTicks: null,
         barTextPadding: {
             top: 15,
             left: 10
@@ -45,6 +46,7 @@ export function horizontalBarChart() {
                 d = d.substring(0, barLabelLength) + '...'
             return d;
         }
+
     };
 
     let data = initialConfiguration.data;
@@ -65,6 +67,7 @@ export function horizontalBarChart() {
     let reverse = initialConfiguration.reverse;
     let minX = initialConfiguration.minX;
     let maxX = initialConfiguration.maxX;
+    let xTicks = initialConfiguration.xTicks;
     let barTextPadding = initialConfiguration.barTextPadding;
 
     function chart(selection) {
@@ -97,10 +100,14 @@ export function horizontalBarChart() {
                 .tickSize(0)
                 .tickPadding(yAxisPadding)
                 .tickFormat(yAxisFormatter);
+
             const xAxis = axisBottom(x)
                 .tickSize(0)
                 .tickPadding(xAxisPadding)
                 .tickFormat(xAxisFormatter);
+
+            if (xTicks)
+                xAxis.ticks(xTicks)
 
             /**
              * append y axis
@@ -387,6 +394,13 @@ export function horizontalBarChart() {
         xLabelPadding = value;
         return chart;
     };
+
+
+    chart.xTicks = function (value) {
+        if (!arguments.length) return xTicks;
+        xTicks = value;
+        return chart;
+    }
 
     chart.barHeight = function (value) {
         if (!arguments.length) return barHeight;


### PR DESCRIPTION

## Description

The data administrator can configure the number of ticks desired on the x-axis

## Related Issue
https://trello.com/c/1kqbxK8H/570-add-configuration-to-charts-to-control-the-number-of-ticks-in-a-graph

## How to test it locally
Add xTicks: 2 to the configuration of a profile indicator in the admin backend, e.g.
`
{
    xTicks: 2
};
`

The barchart for that indicator should now only display two ticks

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
