### PR TITLE
Side panels can now be hidden through configuration

### DIFF
--- a/__tests__/elements/side_panels.test.js
+++ b/__tests__/elements/side_panels.test.js
@@ -1,0 +1,60 @@
+import { screen, fireEvent, getByText } from '@testing-library/dom'
+
+import { SidePanels } from "../../src/js/elements/side_panels.js";
+
+describe('SidePanels', () => {
+  let sp;
+  let triggerEvent;
+  let showPanels = { 'rich_data': true, 'point_data': true, 'data_explorer': true }
+  beforeEach(() => {
+    document.body.innerHTML = `
+    <div class="rich-data-toggles">
+      <div class="panel-toggle" data-testid="rich-data-rich"></div>
+      <div class="panel-toggle" data-testid="rich-data-point"></div>
+      <div class="panel-toggle" data-testid="rich-data-map"></div>
+    </div>
+    <div class="point-mapper-toggles">
+      <div class="panel-toggle" data-testid="point-mapper-rich"></div>
+      <div class="panel-toggle" data-testid="point-mapper-point"></div>
+      <div class="panel-toggle" data-testid="point-mapper-map"></div>
+    </div>
+    <div class="data-mapper-toggles">
+      <div class="panel-toggle" data-testid="data-mapper-rich"></div>
+      <div class="panel-toggle" data-testid="data-mapper-point"></div>
+      <div class="panel-toggle" data-testid="data-mapper-map"></div>
+    </div>
+    <div class="panel-toggles">
+      <div class="panel-toggle" data-testid="empty-rich"></div>
+      <div class="panel-toggle" data-testid="empty-point"></div>
+      <div class="panel-toggle" data-testid="empty-map"></div>
+    </div>
+    `;
+  })
+  describe('click interactions', () => {
+    describe('just close the panel', () => {
+      test('calls close event', () => {
+        sp = new SidePanels(showPanels)
+        triggerEvent = jest.spyOn(sp, 'triggerEvent')
+
+        fireEvent.click(screen.getByTestId('rich-data-rich'));
+
+        expect(triggerEvent).toBeCalledTimes(1);
+        expect(triggerEvent).toHaveBeenNthCalledWith(1, 'panel.rich_data.closed');
+      });
+      })
+    describe('open a new panel', () => {
+      test('call close and open event', () => {
+        sp = new SidePanels(showPanels)
+        triggerEvent = jest.spyOn(sp, 'triggerEvent')
+
+        fireEvent.click(screen.getByTestId('rich-data-point'));
+
+        expect(triggerEvent).toBeCalledTimes(2);
+        expect(triggerEvent).toHaveBeenNthCalledWith(1, 'panel.point_mapper.opened');
+        expect(triggerEvent).toHaveBeenNthCalledWith(2, 'panel.rich_data.closed');
+      });
+    });
+
+  })
+})
+

--- a/src/js/configurations/geography_sa.js
+++ b/src/js/configurations/geography_sa.js
@@ -23,6 +23,13 @@ export class Config {
         return NO_PANELS;
     }
 
+    panelEnabled(panel) {
+        if (this.config.panels != undefined && this.config.panels[panel] != undefined)
+            return this.config.panels[panel]
+
+        return true;
+    }
+
     get rootGeography() {
         if (this.config["root_geography"] != undefined)
             return this.config["root_geography"];

--- a/src/js/configurations/geography_sa.js
+++ b/src/js/configurations/geography_sa.js
@@ -24,8 +24,8 @@ export class Config {
     }
 
     panelEnabled(panel) {
-        if (this.config.panels != undefined && this.config.panels[panel] != undefined)
-            return this.config.panels[panel]
+        if (this.config.panels != undefined && this.config.panels[panel] != undefined && this.config.panels[panel]['visible'] != undefined)
+            return this.config.panels[panel]['visible']
 
         return true;
     }

--- a/src/js/elements/side_panels.js
+++ b/src/js/elements/side_panels.js
@@ -6,10 +6,14 @@ export const DATA_EXPLORER_PANEL = "data_explorer";
 export const NO_PANELS = "no_panels";
 
 export class SidePanels extends Observable {
-    constructor() {
+    constructor(showPanels) {
         super();
         this.prepareDomElements();
         this.initialiseTriggers();
+
+        if (!showPanels[RICH_DATA_PANEL]) this.hidePanel("richData")
+        if (!showPanels[POINT_DATA_PANEL]) this.hidePanel("pointData")
+        if (!showPanels[DATA_EXPLORER_PANEL]) this.hidePanel("mapExplorer")
     }
 
     prepareDomElements = () => {
@@ -117,6 +121,14 @@ export class SidePanels extends Observable {
 
     toggleMapExplorer = () => {
         this.emptyPanel.mapExplorer.click();
+    }
+
+
+    hidePanel = (panel) => {
+        this.emptyPanel[panel].hide();
+        this.mapExplorerPanel[panel].hide();
+        this.richDataPanel[panel].hide();
+        this.pointDataPanel[panel].hide();
     }
 
     togglePanel = panel => {

--- a/src/js/setup/miscelements.js
+++ b/src/js/setup/miscelements.js
@@ -7,7 +7,13 @@ export const pdfprinter = new PDFPrinter();
 export const printButton = $("#profile-print");
 
 export function configureMiscElementEvents(controller) {
-    const sidePanels = new SidePanels();
+    let showPanels = {}
+
+    showPanels[RICH_DATA_PANEL] = controller.config.panelEnabled(RICH_DATA_PANEL)
+    showPanels[POINT_DATA_PANEL] = controller.config.panelEnabled(POINT_DATA_PANEL)
+    showPanels[DATA_EXPLORER_PANEL] = controller.config.panelEnabled(DATA_EXPLORER_PANEL)
+
+    const sidePanels = new SidePanels(showPanels);
     const defaultPanel = controller.config.defaultPanel;
 
     controller.on('profile.loaded', payload => profileLayout.displayLogo(payload.payload.logo))
@@ -27,4 +33,5 @@ export function configureMiscElementEvents(controller) {
     ]);
 
     sidePanels.togglePanel(defaultPanel);
+
 }


### PR DESCRIPTION
## Description

Side panel visibility can now be configured.

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/261


## How to test it locally

In the profile config, you can add the following top-level key:
`
"panels": {
    "point_data": {
      "visible": false
    }
  },
`
This will hide the point data side panel. rich_data and data_explorer can also be used. Documentation can be found here: https://app.gitbook.com/@openup/s/wazi-ng-technical/profile-configuation

## Screenshots


## Changelog
Added a configuration and hide side panel mechanism

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
