### PR TITLE
excel download issue

### DIFF
--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -15,6 +15,8 @@ let geography = null;
 const breadcrumbClass = '.breadcrumb';
 const locationDescriptionClass = '.location__description';
 
+const SHEETNAME_CHAR_LIMIT = 31;
+
 export class Profile_header extends Observable {
     constructor(_parents, _geometries, _api, _profileId, _geography) {
         super();
@@ -135,7 +137,8 @@ export class Profile_header extends Observable {
     }
 
     downloadPointData = (category) => {
-        const sheetName = category.label;
+        const suffix = '...';
+        const sheetName = category.label.length > SHEETNAME_CHAR_LIMIT ? category.label.substring(0, SHEETNAME_CHAR_LIMIT - suffix.length) + suffix : category.label;
         const fileName = 'Export-' + category.label + '.xlsx';
         this.getAddressPoints(category)
             .then((points) => {


### PR DESCRIPTION
## Description
in some cases sheet name, which is set using category name, exceeds 31 chars. This caused the following error
```
Error: Sheet names cannot exceed 31 chars
  at None (../src/js/profile/profile_header.js:147:28)
```

limited the sheet name with 31 chars and appended `...` to the sheet name in case the category name exceeds that limit

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/270

## How to test it locally
* open the rich data panel
* click on the `show locations` button
* find a category name that is longer than 31 chars, for example `Additional DEL facilities (unverified)` on `beta.youthexplorer.org.za` instance
* click on it to download the data excel
* confirm that it is downloaded and the sheet name of the excel ends with `...`

## Screenshots


## Changelog

### Added

### Updated
* `profile/profile_header.js` to limit the sheet name

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
