### PR TITLE
displaying choropleth when geo type is switched

### DIFF
--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -65,4 +65,7 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
         mapchip.onSubIndicatorChange(args);
     });
 
+    controller.on('redraw', payload => {
+        controller.handleNewProfileChoropleth()
+    })
 }


### PR DESCRIPTION
## Description
Preventing choropleth dissappearing when switching between mainplace and ward.

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/239

## How to test it locally
* navigate to a geography that has both `wards` and `mainplaces`, for example `/#geo:CPT` on `youthexplorer`
* open data mapper
* select Economic Opportunities -> Employment -> Employment Status -> Employed
* switch to wards
* confirm that the choropleth is displayed

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/110249895-94492200-7f89-11eb-908b-b4707604d760.png)
![image](https://user-images.githubusercontent.com/53019884/110249897-96ab7c00-7f89-11eb-8c94-53b888fed4f7.png)


## Changelog

### Added

### Updated
* `setup/choropleth.js ` to trigger controller to display choropleth on `redraw` event. `redraw` event is triggered when the geography type is switched

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
