### PR TITLE
print style for facility modal

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -8500,5 +8500,29 @@ label {
     .rich-data__print, .tab-notice{
       display: none;
     }
+
+    .rich-data[style*="display: none;"]{
+        display: none !important;
+    }
+
+    .facility-info{
+      display: inline-table !important;
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      top: 0;
+      left: 0;
+      background-color: #fff;
+      max-height: 100%;
+      max-width: 100%;
+    }
+
+    .facility-info__view-google-map{
+      display: none;
+    }
+
+    .facility-info[style*="display: none;"]{
+      display: none !important;
+    }
 }
 

--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -6995,9 +6995,12 @@ label {
   grid-template-rows: auto;
 }
 
-.facility-info__download {
+.facility-info__print {
   z-index: 1;
-  display: none;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
   width: 36px;
   height: 36px;
   padding: 2px;
@@ -7020,11 +7023,11 @@ label {
   cursor: pointer;
 }
 
-.facility-info__download:hover {
+.facility-info__print:hover {
   color: #000;
 }
 
-.facility-info__download.hidden {
+.facility-info__print.hidden {
   display: none;
 }
 
@@ -8517,7 +8520,7 @@ label {
       max-width: 100%;
     }
 
-    .facility-info__view-google-map{
+    .facility-info__view-google-map, .facility-info__print, .facility-info__close{
       display: none;
     }
 

--- a/src/index.html
+++ b/src/index.html
@@ -690,12 +690,12 @@
     <div class="facility-info">
       <div class="facility-info__header">
         <h3 class="facility-info__title">Loading...</h3>
-        <div title="Download information (.pdf)" class="facility-info__download">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+        <a href="#" onclick="window.print()" title="Download information (.pdf)" class="facility-info__print">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
               <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+              <path fill="CurrentColor" d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"></path>
             </svg></div>
-        </div>
+        </a>
         <div title="Close" class="facility-info__close">
           <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
               <path d="M0 0h24v24H0z" fill="none"></path>

--- a/src/js/setup/pointdata.js
+++ b/src/js/setup/pointdata.js
@@ -5,6 +5,9 @@ export function configurePointDataEvents(controller, objs = {pointDataTray: null
     controller.on("point_tray.category.selected", payload => pointData.showCategoryPoint(payload.payload));
     controller.on("point_tray.category.unselected", payload => pointData.removeCategoryPoints(payload.payload));
     controller.on("map.zoomed", payload => pointData.onMapZoomed(payload.payload));
+    controller.on("panel.rich_data.opened",payload => {
+        pointData.hideFacilityModal();
+    })
 
     controller.bubbleEvents(pointDataTray, [
         'point_tray.theme.selected', 'point_tray.theme.unselected',

--- a/src/js/setup/pointdata.js
+++ b/src/js/setup/pointdata.js
@@ -5,7 +5,7 @@ export function configurePointDataEvents(controller, objs = {pointDataTray: null
     controller.on("point_tray.category.selected", payload => pointData.showCategoryPoint(payload.payload));
     controller.on("point_tray.category.unselected", payload => pointData.removeCategoryPoints(payload.payload));
     controller.on("map.zoomed", payload => pointData.onMapZoomed(payload.payload));
-    controller.on("panel.rich_data.opened",payload => {
+    controller.on("panel.rich_data.opened", payload => {
         pointData.hideFacilityModal();
     })
 


### PR DESCRIPTION
## Description
Printing the information in a facility info window

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/231

## How to test it locally
* select a category in the point mapper window
* wait until the point markers are created on the map
* click on any of them
* click on `More info` button
* when the modal is opened print the page 

## Screenshots
when the facility window is open
![image](https://user-images.githubusercontent.com/53019884/111224250-3a7ed280-85ef-11eb-8fcc-5b2078e7b96a.png)

print dialog shows : 
![image](https://user-images.githubusercontent.com/53019884/111224258-3d79c300-85ef-11eb-9660-9da6c942089d.png)


## Changelog

### Added

### Updated
* `wazimap-ng-v1.webflow.css` to add the print media styling

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
