### PR TITLE
setting the visibility of map download button

### DIFF
--- a/src/js/elements/side_panels.js
+++ b/src/js/elements/side_panels.js
@@ -55,20 +55,20 @@ export class SidePanels extends Observable {
         })
 
         this.richDataPanel.pointData.click(() => {
-            this.triggerEvent('panel.point_mapper.opened');
             this.triggerEvent('panel.rich_data.closed');
+            this.triggerEvent('panel.point_mapper.opened');
         })
 
         this.richDataPanel.mapExplorer.click(() => {
-            this.triggerEvent('panel.data_mapper.opened');
             this.triggerEvent('panel.rich_data.closed');
+            this.triggerEvent('panel.data_mapper.opened');
         })
     }
 
     initialisePointDataTriggers = () => {
         this.pointDataPanel.richData.click(() => {
-            this.triggerEvent('panel.rich_data.opened');
             this.triggerEvent('panel.point_mapper.closed');
+            this.triggerEvent('panel.rich_data.opened');
         })
 
         this.pointDataPanel.pointData.click(() => {
@@ -76,20 +76,20 @@ export class SidePanels extends Observable {
         })
 
         this.pointDataPanel.mapExplorer.click(() => {
-            this.triggerEvent('panel.data_mapper.opened');
             this.triggerEvent('panel.point_mapper.closed');
+            this.triggerEvent('panel.data_mapper.opened');
         })
     }
 
     initialiseMapeExplorerTriggers = () => {
         this.mapExplorerPanel.richData.click(() => {
-            this.triggerEvent('panel.rich_data.opened');
             this.triggerEvent('panel.data_mapper.closed');
+            this.triggerEvent('panel.rich_data.opened');
         })
 
         this.mapExplorerPanel.pointData.click(() => {
-            this.triggerEvent('panel.point_mapper.opened');
             this.triggerEvent('panel.data_mapper.closed');
+            this.triggerEvent('panel.point_mapper.opened');
         })
 
         this.mapExplorerPanel.mapExplorer.click(() => {

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -84,7 +84,7 @@ export default function configureApplication(profileId, config) {
     configureMiscElementEvents(controller);
     configureRichDataView(controller);
     configureBoundaryEvents(controller, boundaryTypeBox);
-    configureMapDownloadEvents(mapDownload);
+    configureMapDownloadEvents(controller, mapDownload);
     configureTutorialEvents(controller, tutorial, config.config.tutorial);
     configureTabNoticeEvents(controller, tabNotice);
 

--- a/src/js/map/map_download.js
+++ b/src/js/map/map_download.js
@@ -18,6 +18,14 @@ export class MapDownload extends Observable {
         });
     }
 
+    hideButton = () => {
+        $('.map-download').hide();
+    }
+
+    showButton = () => {
+        $('.map-download').show();
+    }
+
     downloadMap = () => {
         let self = this;
 

--- a/src/js/setup/mapdownload.js
+++ b/src/js/setup/mapdownload.js
@@ -1,7 +1,21 @@
-export function configureMapDownloadEvents(mapDownload) {
+export function configureMapDownloadEvents(controller, mapDownload) {
     let initialHtml = $('.map-download').html();
     let loadState = $('.location-tag__loading-icon')[0].cloneNode(true);
 
     mapDownload.on('mapdownload.started', payload => $('.map-download').html(loadState))
     mapDownload.on('mapdownload.completed', payload => $('.map-download').html(initialHtml))
+
+    let showEvents = ['panel.rich_data.closed', 'panel.point_mapper.closed','panel.data_mapper.closed'];
+    showEvents.forEach(event => {
+        controller.on(event, () => {
+            mapDownload.showButton();
+        })
+    });
+
+    let hideEvents = ['panel.rich_data.opened', 'panel.point_mapper.opened','panel.data_mapper.opened'];
+    hideEvents.forEach(event => {
+        controller.on(event, () => {
+            mapDownload.hideButton();
+        })
+    });
 }

--- a/src/js/setup/miscelements.js
+++ b/src/js/setup/miscelements.js
@@ -32,6 +32,8 @@ export function configureMiscElementEvents(controller) {
         'panel.data_mapper.closed', 'panel.data_mapper.opened',
     ]);
 
-    sidePanels.togglePanel(defaultPanel);
+    setTimeout(() => {
+        sidePanels.togglePanel(defaultPanel);
+    }, 0)
 
 }


### PR DESCRIPTION
## Description
Hiding the map download button when any of the side panels are open

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/224

## How to test it locally


## Screenshots
![image](https://user-images.githubusercontent.com/53019884/111461274-0c53dc80-872e-11eb-9f15-70c7acfa4ffa.png)
![image](https://user-images.githubusercontent.com/53019884/111461297-14138100-872e-11eb-8833-dcc1cd7046a3.png)


## Changelog

### Added

### Updated
* `elements/side_panels.js` to switch the order of the events so when a user switches from one side panel to another, the download button's visibility is set correctly
* `setup/mapdownload.js` to listen to the panel-related events and call `hide` and `show` functions
* `map/map_download.js` to hide / show the button

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
