### PR TITLE
Tutorial is now configurable from the database

### DIFF
--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -1,3 +1,5 @@
+import {EVENTS as TUTORIAL_EVENTS} from './elements/tutorial';
+
 window.dataLayer = window.dataLayer || [];
 
 const MISSING_TIME = -1;
@@ -302,6 +304,16 @@ export default class Analytics {
         })
 
     }
+    
+    registerTutorialEvents(controller) {
+        controller.on(TUTORIAL_EVENTS.next, payload => {
+            this.basicLogEvent(payload, 'tutorial', 'next');
+        })
+
+        controller.on(TUTORIAL_EVENTS.prev, payload => {
+            this.basicLogEvent(payload, 'tutorial', 'previous');
+        })
+    }
 
 
     registerEvents(controller) {
@@ -314,6 +326,7 @@ export default class Analytics {
         this.registerProfileEvents(controller);
         this.registerChoroplethEvents(controller);
         this.registerMapchipEvents(controller);
+        this.registerTutorialEvents(controller);
 
 
     // controller.on("map.zoomed", payload => pointData.onMapZoomed(payload.payload));

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -262,6 +262,10 @@ export default class Controller extends Observable {
         this.triggerEvent('controller.breadcrumbs.selected', payload);
         this.changeHash(payload.code)
     }
+    
+    onTutorial(event, payload) {
+        this.triggerEvent(event)
+    }
 
     /**
      * When a search result is clicked

--- a/src/js/elements/tutorial.js
+++ b/src/js/elements/tutorial.js
@@ -40,7 +40,9 @@ export class Tutorial extends Observable {
         this.tutorials = tutorialArr || [];
         if (this.tutorials.length > 0) {
             this._preloadImages()
-            this.prepareDomElements();
+            this.prepareDomElements(); 
+            this.updateSlideNumber()
+ 
         }
     }
     

--- a/src/js/elements/tutorial.js
+++ b/src/js/elements/tutorial.js
@@ -1,17 +1,101 @@
-export class Tutorial {
+import {Observable} from '../utils';
+
+export const EVENTS = {
+    next: 'tutorial.nextSlide',
+    prev: 'tutorial.previousSlide',
+}
+
+export class Tutorial extends Observable {
     constructor() {
+        super();
         this.wrapperClass = '.w-slider-mask';
         this.slideClass = '.w-slide';
+        
+        this.tutorials = [];
+        this.curIdx = 0;
+    }
+    
+    _preloadImages = () => {
+        this.tutorials.forEach(slide => {
+            let img = new Image();
+            img.src = slide.image;
+        })
+    }
+    
+    prepareDomElements = () => {
+        this.tutorialContainer = $('.tutorial');
+        this.tutorialSlider = $('.tutorial__slider');
+        this.rightButton = $('.right-arrow', this.tutorialSlider);
+        this.leftButton = $('.left-arrow', this.tutorialSlider);
+        this.rightButton.off('click')
+        this.leftButton.off('click')
+        
+        this.rightButton.on("click", () => this.nextSlide());
+        this.leftButton.on("click", () => this.prevSlide());
+        
+        this.tutorialPageNumber = $('.tutorial__slide-number', this.tutorialContainer);
     }
 
     createSlides = (tutorialArr) => {
-        let tutorials = tutorialArr || [];
+        this.tutorials = tutorialArr || [];
+        if (this.tutorials.length > 0) {
+            this._preloadImages()
+            this.prepareDomElements();
+        }
+    }
+    
+    createPayload = () => {
+        return {
+            slide: this.curIdx
+        }
+    }
+    
+    nextSlide = () => {
+        if (this.curIdx + 1 < this.tutorials.length)
+            this.curIdx++;
+        else
+            this.curIdx = 0;
+        
+        this.displaySlide(this.curIdx);
+        
+        const payload = this.createPayload();
+        this.triggerEvent(EVENTS.next, payload);
+    }
 
-        tutorials.forEach((slide, i) => {
-            let item = $(this.wrapperClass).find(this.slideClass)[i];
-            $('.slide-info__title', item).text(slide.title);
-            $('.slide-info__introduction', item).text(slide.body);
-            $('.tutorial__slide-image', item).css('background-image', `url(${slide.image})`);
-        });
+    prevSlide = () => {
+        if (this.curIdx == 0)
+            this.curIdx = this.tutorials.length - 1;
+        else
+            this.curIdx--
+        
+        this.displaySlide(this.curIdx);
+
+        const payload = this.createPayload();
+        this.triggerEvent(EVENTS.prev, payload);
+    }
+    
+    displaySlide = (slideIdx) => {
+        this.curIdx = slideIdx;
+        const numSlides = this.tutorials.length;
+        
+        if (numSlides < this.curIdx + 1) {
+            console.error(`Could not display tutorial slide ${this.curIdx} as there are only ${numSlides} slides`);
+            return
+        }
+        
+        const slide = this.tutorials[this.curIdx];
+        
+        let item = $(this.wrapperClass).find(this.slideClass)[0];
+        $('.slide-info__title', item).text(slide.title);
+        $('.slide-info__introduction', item).text(slide.body);
+        $('.tutorial__slide-image', item).css('background-image', `url(${slide.image})`);
+        
+        this.updateSlideNumber();
+    }
+    
+    updateSlideNumber = () => {
+        const currentSlide = this.curIdx + 1;
+        const numSlides = this.tutorials.length;
+        this.tutorialPageNumber.text(`${currentSlide}/${numSlides}`);
     }
 }

--- a/src/js/setup/tutorial.js
+++ b/src/js/setup/tutorial.js
@@ -1,3 +1,7 @@
+import {EVENTS} from '../elements/tutorial';
+
 export function configureTutorialEvents(controller, tutorialObj, tutorialArr) {
     controller.on('profile.loaded', () => tutorialObj.createSlides(tutorialArr))
+    tutorialObj.on(EVENTS.next, () => controller.onTutorial(EVENTS.next))
+    tutorialObj.on(EVENTS.prev, () => controller.onTutorial(EVENTS.prev))
 }


### PR DESCRIPTION
## Description

Previously the number of slides was hard-coded - this update now uses whatever is sent from the server. If no configuration is received then the webflow default is show. Also added Google Analytics events.

## Related Issue


## How to test it locally

Add the following key to the profile config. The tutorial should only have two pages.
"tutorial": [
    {
      "body": "This website was developed to enable you to easily find spatial information related to geographic areas. By clicking on the map or using the search bar, you can navigate to an area of interest and find relevant information about it.",
      "image": "https://wazimap-ng.s3-eu-west-1.amazonaws.com/GCRO/Screenshot+1.jpg",
      "title": "Introduction:"
    },
    {
      "body": "To get started, first select a location on the map or use the search box to find the location you would like to analyse.",
      "image": "https://wazimap-ng.s3-eu-west-1.amazonaws.com/GCRO/Screenshot+2.jpg",
      "title": "Location Search:"
    }
  ]

## Screenshots
![Screenshot from 2021-03-23 13-10-57](https://user-images.githubusercontent.com/420786/112138012-ab1e8400-8bd9-11eb-999d-d1346c7f95da.png)

## Changelog

### Added

### Updated
- Changed the way that tutorial slides are created
- Add analytics events

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
