### PR TITLE
Added a mechanism to configure the HTML page title from the server

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -197,7 +197,6 @@ export default class Controller extends Observable {
                     // self.registerWebflowEvents();
                 }
             }, 600)
-            document.title = dataBundle.overview.name;
         })
     }
 

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -1,9 +1,6 @@
-import {select as d3select} from 'd3-selection';
 import Controller from './controller';
 import ProfileLoader from "./profile/profile_loader";
 import {MapControl} from './map/maps';
-import {numFmt} from './utils';
-import {Profile} from './profile';
 import {onProfileLoaded as onProfileLoadedSearch, Search} from './elements/search';
 import {MapChip} from './elements/mapchip';
 import {LocationInfoBox} from './elements/location_info_box';
@@ -11,8 +8,6 @@ import {PointData} from "./map/point_data";
 import {ZoomToggle} from "./mapmenu/zoomtoggle";
 import {PreferredChildToggle} from "./mapmenu/preferred_child_toggle";
 import {PointDataTray} from './elements/point_tray/tray';
-import {API} from './api';
-import Analytics from './analytics';
 import {BoundaryTypeBox} from "./map/boundary_type_box";
 import {MapDownload} from "./map/map_download";
 import {Tutorial} from "./elements/tutorial";
@@ -36,6 +31,7 @@ import {configureBoundaryEvents} from "./setup/boundaryevents";
 import {configureMapDownloadEvents} from "./setup/mapdownload";
 import {configureTutorialEvents} from "./setup/tutorial";
 import {configureTabNoticeEvents} from "./setup/tabnotice";
+import {configurePage} from "./setup/general";
 
 
 export default function configureApplication(profileId, config) {
@@ -43,8 +39,6 @@ export default function configureApplication(profileId, config) {
 
     const api = config.api;
     const controller = new Controller(api, config, profileId);
-    if (config.analytics)
-        config.analytics.registerEvents(controller);
 
     let defaultFormattingConfig = {
         decimal: ",.1f",
@@ -87,6 +81,7 @@ export default function configureApplication(profileId, config) {
     configureMapDownloadEvents(mapDownload);
     configureTutorialEvents(controller, tutorial, config.config.tutorial);
     configureTabNoticeEvents(controller, tabNotice);
+    configurePage(controller, config);
 
     controller.on('profile.loaded', payload => {
         // there seems to be a bug where menu items close if this is not set

--- a/src/js/setup/general.js
+++ b/src/js/setup/general.js
@@ -1,0 +1,7 @@
+export function configurePage(controller, config) {
+    if (config.config.page_title)
+        $('title').text(config.config.page_title);
+
+    if (config.analytics)
+        config.analytics.registerEvents(controller);
+}


### PR DESCRIPTION
## Description

Created a general.js setup page and move the analytics configuration there as well.

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/286

## How to test it locally

added "page_title": "This is my title" into the profile configuration. You should see the change in the title of the page.

## Screenshots


## Changelog

### Added
general.js to store page specific setup

### Updated

### Removed

## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
