### PR TITLE
Firing Google Analytics event when the tab is clicked

### DIFF
--- a/src/js/analytics.js
+++ b/src/js/analytics.js
@@ -1,3 +1,5 @@
+import { EVENTS as TAB_EVENTS } from './elements/tab_notice';
+
 window.dataLayer = window.dataLayer || [];
 
 const MISSING_TIME = -1;
@@ -303,6 +305,11 @@ export default class Analytics {
 
     }
 
+    registerTabNoticeEvents(controller) {
+        controller.on(TAB_EVENTS.clicked, payload => {
+            this.basicLogEvent(payload, 'tab_notice', 'clicked');
+        })
+    }
 
     registerEvents(controller) {
 
@@ -314,6 +321,7 @@ export default class Analytics {
         this.registerProfileEvents(controller);
         this.registerChoroplethEvents(controller);
         this.registerMapchipEvents(controller);
+        this.registerTabNoticeEvents(controller);
 
 
     // controller.on("map.zoomed", payload => pointData.onMapZoomed(payload.payload));

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -263,6 +263,10 @@ export default class Controller extends Observable {
         this.changeHash(payload.code)
     }
 
+    onTabClicked(event) {
+        this.triggerEvent(event)
+    }
+
     /**
      * When a search result is clicked
      * {code: WC011, level: municipality, name: Matzikama}

--- a/src/js/elements/tab_notice.js
+++ b/src/js/elements/tab_notice.js
@@ -1,5 +1,12 @@
-export class TabNotice {
+import {Observable} from '../utils';
+
+export const EVENTS = {
+    clicked: 'tab_notice.clicked'
+}
+
+export class TabNotice extends Observable {
     constructor(feedback) {
+        super()
         this.tab = $('.tab-notice');
         this.feedback = feedback;
     }
@@ -17,5 +24,6 @@ export class TabNotice {
 
         this.tab.find('a.tab-notice__content').attr('href', this.feedback.url);
         this.tab.find('a.tab-notice__content .tab-notice__text').text(this.feedback.text);
+        this.tab.on('click', () => this.triggerEvent(EVENTS.clicked))
     }
 }

--- a/src/js/setup/tabnotice.js
+++ b/src/js/setup/tabnotice.js
@@ -1,3 +1,8 @@
+import {EVENTS} from '../elements/tab_notice';
+
 export function configureTabNoticeEvents(controller, tabNotice) {
     controller.on('profile.loaded', payload => tabNotice.modifyTabNotice())
+    tabNotice.on(EVENTS.clicked, payload => {
+        controller.onTabClicked(EVENTS.clicked);
+    })
 }


### PR DESCRIPTION
## Description

Added a Google Analytics event whenever the tab is clicked

## Related Issue

https://github.com/OpenUpSA/wazimap-ng-ui/issues/288


## How to test it locally
Click on the tab and look at the developer tools. You should see an analytics event sent to Googl Analytics


## Screenshots

![Screenshot from 2021-03-23 14-30-01](https://user-images.githubusercontent.com/420786/112146882-c3e06700-8be4-11eb-86c9-c6a80dd97dd9.png)
![Screenshot from 2021-03-23 14-29-55](https://user-images.githubusercontent.com/420786/112146885-c5119400-8be4-11eb-9afd-c6b9b362e319.png)

## Changelog

### Added

### Updated
Added analytics events

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
