### PR TITLE
Fix: Wrong image on first slide of tutorial

### DIFF
--- a/src/js/elements/tutorial.js
+++ b/src/js/elements/tutorial.js
@@ -10,18 +10,18 @@ export class Tutorial extends Observable {
         super();
         this.wrapperClass = '.w-slider-mask';
         this.slideClass = '.w-slide';
-        
+
         this.tutorials = [];
         this.curIdx = 0;
     }
-    
+
     _preloadImages = () => {
         this.tutorials.forEach(slide => {
             let img = new Image();
             img.src = slide.image;
         })
     }
-    
+
     prepareDomElements = () => {
         this.tutorialContainer = $('.tutorial');
         this.tutorialSlider = $('.tutorial__slider');
@@ -29,37 +29,38 @@ export class Tutorial extends Observable {
         this.leftButton = $('.left-arrow', this.tutorialSlider);
         this.rightButton.off('click')
         this.leftButton.off('click')
-        
+
         this.rightButton.on("click", () => this.nextSlide());
         this.leftButton.on("click", () => this.prevSlide());
-        
+
         this.tutorialPageNumber = $('.tutorial__slide-number', this.tutorialContainer);
+        this.displaySlide(this.curIdx);
     }
 
     createSlides = (tutorialArr) => {
         this.tutorials = tutorialArr || [];
         if (this.tutorials.length > 0) {
             this._preloadImages()
-            this.prepareDomElements(); 
+            this.prepareDomElements();
             this.updateSlideNumber()
- 
+
         }
     }
-    
+
     createPayload = () => {
         return {
             slide: this.curIdx
         }
     }
-    
+
     nextSlide = () => {
         if (this.curIdx + 1 < this.tutorials.length)
             this.curIdx++;
         else
             this.curIdx = 0;
-        
+
         this.displaySlide(this.curIdx);
-        
+
         const payload = this.createPayload();
         this.triggerEvent(EVENTS.next, payload);
     }
@@ -69,32 +70,32 @@ export class Tutorial extends Observable {
             this.curIdx = this.tutorials.length - 1;
         else
             this.curIdx--
-        
+
         this.displaySlide(this.curIdx);
 
         const payload = this.createPayload();
         this.triggerEvent(EVENTS.prev, payload);
     }
-    
+
     displaySlide = (slideIdx) => {
         this.curIdx = slideIdx;
         const numSlides = this.tutorials.length;
-        
+
         if (numSlides < this.curIdx + 1) {
             console.error(`Could not display tutorial slide ${this.curIdx} as there are only ${numSlides} slides`);
             return
         }
-        
+
         const slide = this.tutorials[this.curIdx];
-        
+
         let item = $(this.wrapperClass).find(this.slideClass)[0];
         $('.slide-info__title', item).text(slide.title);
         $('.slide-info__introduction', item).text(slide.body);
         $('.tutorial__slide-image', item).css('background-image', `url(${slide.image})`);
-        
+
         this.updateSlideNumber();
     }
-    
+
     updateSlideNumber = () => {
         const currentSlide = this.curIdx + 1;
         const numSlides = this.tutorials.length;


### PR DESCRIPTION
## Description
Using the right image for first slide (Guateng).
Tutorial class method `displaySlide` is not called for the first slide, but works for the rest, fixed this by calling displaySlide for the first slide so the correct image url is used, not the url defined in the css file.
## Related Issue
#299

## How to test it locally


## Screenshots


## Changelog

### Added

### Updated
`elements/tutorial.js` to call the displaySlide method for the first slide.
### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
