### PR TITLE
add styles for rich tables:

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -7267,11 +7267,100 @@ label {
   margin-right: 4px;
 }
 
-.chart-table, .chart-table tr, .chart-table th, .chart-table td {
-     border: 1px solid #000;
-     border-collapse: collapse;
-     text-align: center;
- }
+ .profile-indicator__table {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.profile-indicator__table_row {
+  display: -ms-grid;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 33.333333333%;
+  -ms-grid-columns: 33.333333333%;
+  grid-template-columns: 33.333333333%;
+  -ms-grid-rows: auto;
+  grid-template-rows: auto;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.06);
+  font-size: 13px;
+}
+
+.profile-indicator__table_row:hover {
+  background-color: rgba(0, 0, 0, 0.06);
+}
+
+.profile-indicator__table_row.profile-indicator__table_row--header {
+  grid-auto-columns: 33.333333333%;
+  border-bottom: 1px solid #707070;
+  background-color: hsla(0, 0%, 100%, 0.06);
+  box-shadow: 0 10px 10px -9px rgba(0, 0, 0, 0.1);
+  font-weight: 700;
+}
+
+.profile-indicator__table_row.profile-indicator__table_row--alt {
+  background-color: hsla(0, 0%, 100%, 0.06);
+}
+
+.profile-indicator__table_row.profile-indicator__table_row--2-col {
+  grid-auto-columns: minmax(120px, 50%);
+  -ms-grid-columns: minmax(120px, 50%);
+  grid-template-columns: minmax(120px, 50%);
+}
+
+.profile-indicator__table_cell {
+  padding: 8px;
+  border-left: 1px solid rgba(0, 0, 0, 0.06);
+  white-space: nowrap;
+}
+
+.profile-indicator__table_cell.profile-indicator__table_cell--first {
+  border-left-style: none;
+}
+
+.profile-indicator__table_content {
+  max-height: 300px;
+  overflow: hidden;
+}
+
+.profile-indicator__table_show-more {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin-top: 2em;
+  -webkit-box-orient: vertical;
+  -webkit-box-direction: normal;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.profile-indicator__table_show-more.hidden {
+  display: none;
+}
+
+.profile-indicator__table_showing {
+  margin-top: 1em;
+  font-size: 13px;
+}
+
+.profile-indicator__table_load-more {
+  width: 100%;
+  background-color: #f0f0f0;
+  color: #333;
+  text-align: center;
+}
+
+.profile-indicator__table_inner {
+  max-height: 400px;
+}
 
 @media screen and (max-width: 991px) {
   .rich-data-content {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -61,42 +61,62 @@ export class Chart extends Observable {
     showChartDataTable = () => {
         let data = this.getValuesFromSubindicators();
 
-        this.containerParent.find('.chart-table').remove();
+        this.containerParent.find('.profile-indicator__table').remove();
 
         let table = document.createElement('table');
-        $(table).addClass('chart-table');
+        $(table).addClass('profile-indicator__table profile-indicator__table_content');
         let thead = document.createElement('thead');
+        $(thead).addClass('profile-indicator__table_row--header');
         let headRow = document.createElement('tr');
+        $(headRow).addClass('profile-indicator__table_row');
         let headCol1 = document.createElement('th');
+        $(headCol1).addClass('profile-indicator__table_cell profile-indicator__table_cell--first');
         $(headCol1).text(this.title);
         $(headRow).append(headCol1);
         let headCol2 = document.createElement('th');
+        $(headCol2).addClass('profile-indicator__table_cell');
         $(headCol2).text('Absolute');
         $(headRow).append(headCol2);
         let headCol3 = document.createElement('th');
+        $(headCol3).addClass('profile-indicator__table_cell');
         $(headCol3).text('Percentage');
         $(headRow).append(headCol3);
 
         $(thead).append(headRow);
         $(table).append(thead);
+        let tbody = document.createElement('tbody');
+
 
         for (const [label, subindicator] of Object.entries(this.subindicators)) {
             let absolute_val = subindicator.count;
             let percentage_val = this.getPercentageValue(absolute_val, this.subindicators);
             let row = document.createElement('tr');
+            $(row).addClass('profile-indicator__table_row');
             let col1 = document.createElement('td');
+            $(col1).addClass('profile-indicator__table_cell profile-indicator__table_cell--first');
             $(col1).text(subindicator.keys);
             let col2 = document.createElement('td');
+            $(col2).addClass('profile-indicator__table_cell');
             $(col2).text(d3format(this.config.types[VALUE_TYPE].formatting)(absolute_val));
             let col3 = document.createElement('td');
+            $(col3).addClass('profile-indicator__table_cell');
             $(col3).text(d3format(this.config.types[PERCENTAGE_TYPE].formatting)(percentage_val));
             $(row).append(col1);
             $(row).append(col2);
             $(row).append(col3);
-            $(table).append(row);
+            $(tbody).append(row);
         }
-
+        $(table).append(tbody);
         this.containerParent.append(table);
+        // Append button
+        if (data.length > 7) { // TODO: make this row count a constant
+          let btnDiv = document.createElement('div');
+          $(btnDiv).addClass('profile-indicator__table_show-more profile-indicator__table_showing profile-indicator__table_load-more');
+          let btn = document.createElement('button');
+          $(btn).text('Load more rows');
+          btnDiv.append(btn);
+          this.containerParent.append(btnDiv);
+        }
     }
 
     setChartOptions = (chart) => {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -19,6 +19,7 @@ const typeIndex = {
     'Value': 1
 }
 
+const MAX_RICH_TABLE_ROWS = 7
 
 export class Chart extends Observable {
     constructor(config, subindicators, groups, indicators, _subCategoryNode, title) {
@@ -108,12 +109,17 @@ export class Chart extends Observable {
         }
         $(table).append(tbody);
         this.containerParent.append(table);
-        // Append button
-        if (data.length > 7) { // TODO: make this row count a constant
+        if (data.length > MAX_RICH_TABLE_ROWS) {
+          let showExtraRows = false;
           let btnDiv = document.createElement('div');
           $(btnDiv).addClass('profile-indicator__table_show-more profile-indicator__table_showing profile-indicator__table_load-more');
           let btn = document.createElement('button');
           $(btn).text('Load more rows');
+          $(btn).on("click", () => {
+            showExtraRows = !showExtraRows;
+            showExtraRows ? $(btn).text('Show less rows') : $(btn).text('Load more rows');
+            showExtraRows ? $(table).removeClass("profile-indicator__table_content") : $(table).addClass("profile-indicator__table_content");
+          })
           btnDiv.append(btn);
           this.containerParent.append(btnDiv);
         }


### PR DESCRIPTION
## Description

- Add basic styles for the rich data table
- Implement basic functionality for the load more button

## Related Issue

https://github.com/OpenUpSA/wazimap-ng-ui/issues/302

## How to test it locally

Serve the app via `yarn start` and navigate to the rich data panel, the rich data tables should now be styled accordingly, and for tables that exceed 7 rows (arbitrary) the tables have a `Load more button` appended at the bottom of the table

## Screenshots

**Before:**

![Screenshot from 2021-04-09 21-44-05](https://user-images.githubusercontent.com/6994982/114227052-22e00300-997d-11eb-858d-2a437ac9ffec.png)

**After:**

Without the button:

![Screenshot from 2021-04-09 21-38-13](https://user-images.githubusercontent.com/6994982/114227134-3ee3a480-997d-11eb-956f-f2150c982617.png)

With the button:

![Screenshot from 2021-04-09 21-38-44](https://user-images.githubusercontent.com/6994982/114227176-4d31c080-997d-11eb-97e7-13e0ba59b454.png)

After the button is clicked:

![Screenshot from 2021-04-12 20-54-20](https://user-images.githubusercontent.com/6994982/114439871-23250c00-9bd2-11eb-85d6-e501fdb628ef.png)

## Changelog

https://app.gitbook.com/@openup/s/wazi-ng-technical/changelog#04-09-2021-rich-data-tables

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
