### PR TITLE
adding translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "d3-selection": "^1.4.1",
     "data-visualisations": "https://github.com/vulekamali/data-visualisations.git#reusable",
     "html2canvas": "^1.0.0-rc.5",
+    "i18next": "^20.2.1",
     "jquery": "^3.5.1",
     "js": "^0.1.0",
     "leaflet": "~1.3.1",

--- a/src/index.html
+++ b/src/index.html
@@ -628,7 +628,7 @@
                     </svg></div>
                 </div>
                 <div class="location__facilities_title">
-                  <div>This <span class="location__facilities_geo-type">area</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong data-i18n="locations" class="i18n"> locations</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
+                  <div>This <span class="location__facilities_geo-type">area</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span> <strong data-i18n="locations" class="i18n">locations</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
                 </div>
               </div>
               <div class="location__facilities_download-all location__facilities_download-all--header">

--- a/src/index.html
+++ b/src/index.html
@@ -739,7 +739,7 @@
           </div>
         </div>
         <div class="point-mapper-content__description">
-          <div class="i18n" data-i18n="lorem ipsum">Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong></div>
+          <div>Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong></div>
         </div>
         <div class="point-mapper-content__loading">
           <div class="loading">

--- a/src/index.html
+++ b/src/index.html
@@ -735,11 +735,11 @@
               </svg></div>
           </div>
           <div class="point-data__header_title">
-            <div>Point Mapper </div>
+            <div class="i18n" data-i18n="Point Mapper">Point Mapper </div>
           </div>
         </div>
         <div class="point-mapper-content__description">
-          <div>Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong></div>
+          <div class="i18n" data-i18n="lorem ipsum">Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong></div>
         </div>
         <div class="point-mapper-content__loading">
           <div class="loading">

--- a/src/index.html
+++ b/src/index.html
@@ -619,27 +619,43 @@
               </div>
             </div>
             <div class="location__facilities_header hidden">
-              <div class="location__facilities_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                  </svg></div>
+              <div class="location__facilities_header-wrapper">
+                <div class="location__facilities_icon">
+                  <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                      <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                    </svg></div>
+                </div>
+                <div class="location__facilities_title">
+                  <div>This <span class="location__facilities_geo-type">area</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong data-i18n="locations" class="i18n"> locations</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
+                </div>
               </div>
-              <div class="location__facilities_title">
-                <div>This <span class="location__facilities_geo-type">area</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> locations</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
+              <div class="location__facilities_download-all location__facilities_download-all--header">
+                <div>Download all <span data-i18n="locations" class="i18n">locations</span></div>
+                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                  </svg></div>
               </div>
             </div>
             <div class="location__facilities_trigger hidden">
               <div data-w-id="043d7c6f-c1d6-89bf-425b-062a1bf20e63" class="location__facilities_expand bg-primary">
-                <div>Show locations</div>
+                <div>Show <span data-i18n="locations" class="i18n">locations</span></div>
               </div>
               <div data-w-id="043d7c6f-c1d6-89bf-425b-062a1bf20e66" class="location__facilities_contract bg-primary">
-                <div>Hide locations</div>
+                <div>Hide <span data-i18n="locations" class="i18n">locations</span></div>
               </div>
             </div>
             <div style="height:0PX" class="location__facilities_content">
               <div class="location__facilities_content-wrapper"></div>
+              <div class="location__facilities_download-all location__facilities_download-all--footer">
+                <div>Download all facilities</div>
+                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                  </svg></div>
+              </div>
             </div>
           </div>
         </section>
@@ -667,9 +683,7 @@
               <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
             </svg></div>
           <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Point Mapper</div>
-            </div>
+            <div data-i18n="Point Mapper" class="panel-toggle__tooltip_text i18n">Point Mapper</div>
             <div class="panel-toggle__tooltip_notch"></div>
           </div>
         </div>
@@ -734,9 +748,7 @@
                 <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
               </svg></div>
           </div>
-          <div class="point-data__header_title">
-            <div class="i18n" data-i18n="Point Mapper">Point Mapper </div>
-          </div>
+          <div data-i18n="Point Mapper" class="point-data__header_title i18n">Point Mapper </div>
         </div>
         <div class="point-mapper-content__description">
           <div>Select the category, or specific type of point data you would like to overlay onto the map.<strong><br></strong></div>
@@ -784,9 +796,7 @@
               <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
             </svg></div>
           <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Point Mapper</div>
-            </div>
+            <div data-i18n="Point Mapper" class="panel-toggle__tooltip_text i18n">Point Mapper</div>
             <div class="panel-toggle__tooltip_notch"></div>
           </div>
         </div>
@@ -859,9 +869,7 @@
               <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
             </svg></div>
           <div class="panel-toggle__tooltip">
-            <div class="panel-toggle__tooltip_text">
-              <div>Point Mapper</div>
-            </div>
+            <div data-i18n="Point Mapper" class="panel-toggle__tooltip_text i18n">Point Mapper</div>
             <div class="panel-toggle__tooltip_notch"></div>
           </div>
         </div>
@@ -894,9 +902,7 @@
       </div>
       <div data-w-id="cb33504b-ce21-a841-3478-0f9742bd5340" class="panel-toggle point-mapper-panel__open">
         <div class="panel-toggle__tooltip">
-          <div class="panel-toggle__tooltip_text">
-            <div>Point Mapper</div>
-          </div>
+          <div data-i18n="Point Mapper" class="panel-toggle__tooltip_text i18n">Point Mapper</div>
           <div class="panel-toggle__tooltip_notch"></div>
         </div>
         <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">

--- a/src/js/elements/translations.js
+++ b/src/js/elements/translations.js
@@ -1,0 +1,43 @@
+import {Observable} from "../utils";
+import i18next from 'i18next';
+
+export class Translations extends Observable {
+    constructor(translations) {
+        super();
+
+        this.translations = translations;
+    }
+
+    translate() {
+        //todo:remove this when the BE is ready
+        if (typeof this.translations === 'undefined') {
+            this.translations = {
+                en: {
+                    translation: {
+                        'Point Mapper': 'Service Mapper',
+                        'lorem ipsum': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam a lacinia diam. Aliquam sollicitudin lectus ipsum,'
+                    }
+                }
+            }
+        }
+        //remove this when the BE is ready
+
+        if (typeof this.translations === 'undefined') {
+            return;
+        }
+
+        i18next
+            .init({
+                lng: 'en',
+                resources: this.translations
+            })
+            .then(
+                function (t) {
+                    $('.i18n').each(function () {
+                        $(this).html(t($(this).attr('data-i18n')));
+                    });
+                }
+            )
+        ;
+    }
+}

--- a/src/js/elements/translations.js
+++ b/src/js/elements/translations.js
@@ -13,6 +13,10 @@ export class Translations extends Observable {
             return;
         }
 
+        Object.keys(this.translations).forEach((key) => {
+            this.translations[key] = {translation: this.translations[key]}
+        })
+
         i18next
             .init({
                 lng: 'en',

--- a/src/js/elements/translations.js
+++ b/src/js/elements/translations.js
@@ -9,19 +9,6 @@ export class Translations extends Observable {
     }
 
     translate() {
-        //todo:remove this when the BE is ready
-        if (typeof this.translations === 'undefined') {
-            this.translations = {
-                en: {
-                    translation: {
-                        'Point Mapper': 'Service Mapper',
-                        'lorem ipsum': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam a lacinia diam. Aliquam sollicitudin lectus ipsum,'
-                    }
-                }
-            }
-        }
-        //remove this when the BE is ready
-
         if (typeof this.translations === 'undefined') {
             return;
         }

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -31,7 +31,9 @@ import {configureBoundaryEvents} from "./setup/boundaryevents";
 import {configureMapDownloadEvents} from "./setup/mapdownload";
 import {configureTutorialEvents} from "./setup/tutorial";
 import {configureTabNoticeEvents} from "./setup/tabnotice";
+import {configureTranslationEvents} from "./setup/translations"
 import {configurePage} from "./setup/general";
+import {Translations} from "./elements/translations";
 
 
 export default function configureApplication(profileId, config) {
@@ -62,6 +64,7 @@ export default function configureApplication(profileId, config) {
     const mapDownload = new MapDownload(mapchip);
     const tutorial = new Tutorial();
     const tabNotice = new TabNotice(config.config.feedback);
+    const translations = new Translations(config.config.translations);
 
     // TODO not certain if it is need to register both here and in the controller in loadedGeography
     // controller.registerWebflowEvents();
@@ -81,6 +84,7 @@ export default function configureApplication(profileId, config) {
     configureMapDownloadEvents(mapDownload);
     configureTutorialEvents(controller, tutorial, config.config.tutorial);
     configureTabNoticeEvents(controller, tabNotice);
+    configureTranslationEvents(controller, translations);
     configurePage(controller, config);
 
     controller.on('profile.loaded', payload => {

--- a/src/js/setup/translations.js
+++ b/src/js/setup/translations.js
@@ -1,0 +1,5 @@
+export function configureTranslationEvents(controller, translations) {
+    controller.on('profile.loaded', payload => {
+        translations.translate();
+    });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -906,6 +906,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.0":
+  version "7.13.10"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.13.10.tgz#47d42a57b6095f4468da440388fdbad8bebf0d7d"
+  integrity sha512-4QPkjJq6Ns3V/RgpEahRk+AGfL0eO6RHHtTWoNNr5mO49G6B5+X6d6THgWEAvTrznU5xYpbAlVKRYcsCgh/Akw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.10.4", "@babel/template@^7.12.7", "@babel/template@^7.3.3", "@babel/template@^7.4.4":
   version "7.12.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.12.7.tgz#c817233696018e39fbb6c491d2fb684e05ed43bc"
@@ -4788,6 +4795,13 @@ https-browserify@^1.0.0:
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
+
+i18next@^20.2.1:
+  version "20.2.1"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-20.2.1.tgz#8aedfdc596f7d54b9d3f6d87bcb89214467cb785"
+  integrity sha512-JLruWDEQ3T6tKT6P7u+DsNtToMHUwUcQIYOMRcnNBdUhSfKkoIDUKdVDKgGtmqr//LrirxjADUdr3d5Gwbow6g==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24:
   version "0.4.24"


### PR DESCRIPTION
## Description
Translating texts on the fly using `i18next` library. Assumed data structure is as follows :
```
            this.translations = {
                en: {
                    translation: {
                        'Point Mapper': 'Service Mapper',
                        'lorem ipsum': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. 
                                   Nullam a lacinia diam. Aliquam sollicitudin lectus ipsum,'
                    }
                }
            }
```

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/237

## How to test it locally


## Screenshots
before translations : 
![image](https://user-images.githubusercontent.com/53019884/114364407-0a8d0580-9b82-11eb-8411-c7d7fb15757d.png)

after translations : 
![image](https://user-images.githubusercontent.com/53019884/114364443-137dd700-9b82-11eb-9a68-d095e93971a2.png)


## Changelog

### Added
* `setup/translations.js` to handle translation related events - for now it fires `translate()` function on `profile.loaded` event
* `elements/translations.js` to translate the html elements that have `.i18n` class 

### Updated
* `package.json` to add `i18next` library to the project
* `index.html` to modify the elements that should be translated
* `load.js` to add references of the new classes

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
