### PR TITLE
improving pdf output of facility modal

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -8533,5 +8533,9 @@ label {
     .facility-info[style*="display: none;"]{
       display: none !important;
     }
+
+    .facility-info[style*="display: flex;"] ~ .point-mapper, .facility-info[style*="display: flex;"] ~ .rich-data, .facility-info[style*="display: flex;"] ~ .data-mapper {
+      display: none !important;
+    }
 }
 

--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -8514,16 +8514,17 @@ label {
         display: none !important;
     }
 
-    .facility-info{
-      display: inline-table !important;
-      position: absolute;
-      width: 100%;
-      height: 100%;
-      top: 0;
-      left: 0;
-      background-color: #fff;
-      max-height: 100%;
-      max-width: 100%;
+    .facility-info {
+      position: fixed;
+      width: 100vw !important;
+      height: 100vh !important;
+      max-width: none;
+      max-height: none;
+      left: 0%;
+      right: 0%;
+      top: 0%;
+      Bottom: 0%;
+      z-index: 100000;
     }
 
     .facility-info__view-google-map, .facility-info__print, .facility-info__close{
@@ -8534,7 +8535,7 @@ label {
       display: none !important;
     }
 
-    .facility-info[style*="display: flex;"] ~ .point-mapper, .facility-info[style*="display: flex;"] ~ .rich-data, .facility-info[style*="display: flex;"] ~ .data-mapper {
+    .nav,.map,.rich-data,.panel-toggles,.data-mapper,.point-mapper,.tab-notice,.facility-info__close,.facility-info__print,.facility-info__view-google-map {
       display: none !important;
     }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -516,6 +516,43 @@
       </div>
       <div id="main-map" class="map-area"></div>
     </div>
+    <div class="facility-info">
+      <div class="facility-info__header">
+        <h3 class="facility-info__title">Loading...</h3>
+        <a href="#" onclick="window.print()" title="Download information (.pdf)" class="facility-info__print">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="CurrentColor" d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"></path>
+            </svg></div>
+        </a>
+        <div title="Close" class="facility-info__close">
+          <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
+            </svg></div>
+        </div>
+      </div>
+      <a href="#" class="facility-info__view-google-map hidden w-inline-block">
+        <div class="facility-info__google-map-icon">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0 0 150 150">
+              <path fill="#1a73e8" d="M89.77,10.4c-4.4-1.39-9.08-2.15-13.94-2.15c-14.18,0-26.87,6.41-35.33,16.48l21.8,18.34L89.77,10.4z"></path>
+              <path fill="#ea4335" d="M40.49,24.73c-6.74,8.02-10.81,18.37-10.81,29.66c0,8.68,1.73,15.71,4.57,22.01l28.04-33.33L40.49,24.73z"></path>
+              <path fill="#4285f4" d="M75.83,36.75c9.75,0,17.65,7.9,17.65,17.65c0,4.34-1.57,8.32-4.17,11.39c0,0,13.94-16.58,27.47-32.66   c-5.59-10.75-15.28-19.02-27-22.73L62.29,43.07C65.53,39.2,70.39,36.75,75.83,36.75"></path>
+              <path fill="#fbbc04" d="M75.83,72.04c-9.75,0-17.65-7.9-17.65-17.65c0-4.31,1.55-8.26,4.11-11.33L34.25,76.4   c4.79,10.63,12.76,19.16,20.97,29.91L89.3,65.79C86.07,69.61,81.23,72.04,75.83,72.04"></path>
+              <path fill="#34a853" d="M88.63,117.37c15.39-24.07,33.34-35,33.34-62.98c0-7.67-1.88-14.9-5.19-21.26l-61.55,73.18   c2.61,3.42,5.24,7.06,7.81,11.07c9.36,14.46,6.76,23.13,12.8,23.13C81.86,140.51,79.27,131.83,88.63,117.37"></path>
+            </svg></div>
+        </div>
+        <div class="facility-info__google-map-text">View location in Google Maps</div>
+      </a>
+      <div class="facility-info__content">
+        <div class="facility-info__items">
+          <div class="facility-info__item last">
+            <div class="facility-info__item_label">Loading...</div>
+            <div class="facility-info__item_value">...</div>
+          </div>
+        </div>
+      </div>
+    </div>
     <div class="rich-data">
       <div data-w-id="daa39c00-4f7f-ebc9-ea04-511e668d9825" class="rich-data-nav">
         <div data-w-id="67e8fb10-ba62-0c25-f511-60f23abff4b7" class="rich-data-nav__toggle">
@@ -683,43 +720,6 @@
               <div>Data Mapper</div>
             </div>
             <div class="panel-toggle__tooltip_notch"></div>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="facility-info">
-      <div class="facility-info__header">
-        <h3 class="facility-info__title">Loading...</h3>
-        <a href="#" onclick="window.print()" title="Download information (.pdf)" class="facility-info__print">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" height="24" viewbox="0 0 24 24" width="24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="CurrentColor" d="M19 8H5c-1.66 0-3 1.34-3 3v6h4v4h12v-4h4v-6c0-1.66-1.34-3-3-3zm-3 11H8v-5h8v5zm3-7c-.55 0-1-.45-1-1s.45-1 1-1 1 .45 1 1-.45 1-1 1zm-1-9H6v4h12V3z"></path>
-            </svg></div>
-        </a>
-        <div title="Close" class="facility-info__close">
-          <div class="svg-icon svg-icon--no-size w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"></path>
-            </svg></div>
-        </div>
-      </div>
-      <a href="#" class="facility-info__view-google-map hidden w-inline-block">
-        <div class="facility-info__google-map-icon">
-          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0 0 150 150">
-              <path fill="#1a73e8" d="M89.77,10.4c-4.4-1.39-9.08-2.15-13.94-2.15c-14.18,0-26.87,6.41-35.33,16.48l21.8,18.34L89.77,10.4z"></path>
-              <path fill="#ea4335" d="M40.49,24.73c-6.74,8.02-10.81,18.37-10.81,29.66c0,8.68,1.73,15.71,4.57,22.01l28.04-33.33L40.49,24.73z"></path>
-              <path fill="#4285f4" d="M75.83,36.75c9.75,0,17.65,7.9,17.65,17.65c0,4.34-1.57,8.32-4.17,11.39c0,0,13.94-16.58,27.47-32.66   c-5.59-10.75-15.28-19.02-27-22.73L62.29,43.07C65.53,39.2,70.39,36.75,75.83,36.75"></path>
-              <path fill="#fbbc04" d="M75.83,72.04c-9.75,0-17.65-7.9-17.65-17.65c0-4.31,1.55-8.26,4.11-11.33L34.25,76.4   c4.79,10.63,12.76,19.16,20.97,29.91L89.3,65.79C86.07,69.61,81.23,72.04,75.83,72.04"></path>
-              <path fill="#34a853" d="M88.63,117.37c15.39-24.07,33.34-35,33.34-62.98c0-7.67-1.88-14.9-5.19-21.26l-61.55,73.18   c2.61,3.42,5.24,7.06,7.81,11.07c9.36,14.46,6.76,23.13,12.8,23.13C81.86,140.51,79.27,131.83,88.63,117.37"></path>
-            </svg></div>
-        </div>
-        <div class="facility-info__google-map-text">View location in Google Maps</div>
-      </a>
-      <div class="facility-info__content">
-        <div class="facility-info__items">
-          <div class="facility-info__item last">
-            <div class="facility-info__item_label">Loading...</div>
-            <div class="facility-info__item_value">...</div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
fixing the issues with pdf output of the facility modal. the issues are :
* when the facility modal has few attributes to show, the point mapper or the charts are visible on the pdf

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/294

## How to test it locally
* on the point mapper select a category - preferably a category with few attributes so the pdf export is shorter. for example `Health > Pharmacies` on YE instance
* wait until the markers are created on the map
* click on any marker and click `More Info` to show the facility modal
* open any of the side panels
* print the page and confirm that panels are not visible on the export

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/114518787-63bf6c80-9c48-11eb-90b8-7a73076cac7c.png)
![image](https://user-images.githubusercontent.com/53019884/114518801-66ba5d00-9c48-11eb-96c3-323bf8690c20.png)


## Changelog

### Added

### Updated
* `css/wazimap-ng-v1.webflow.css` to hide the panels when the facility modal is open
* `index.html` to change the order of the divs

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
