### PR TITLE
Fix: Added Error state for Point mapper.

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -6753,7 +6753,19 @@ label {
 }
 
 .point-mapper-content__error {
+  display: none;
+  align-items: center;
   margin-bottom: 16px;
+  background-color: #f0f0f0;
+  padding: 5px;
+}
+
+.point-mapper-content__error .material-icons{
+  padding: 0px 5px;
+}
+
+.point-mapper-error__text{
+  flex-grow: 1;
 }
 
 .error {

--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -6757,7 +6757,7 @@ label {
   align-items: center;
   margin-bottom: 16px;
   background-color: #f0f0f0;
-  padding: 5px;
+  padding: 6px;
 }
 
 .point-mapper-content__error .material-icons{

--- a/src/index.html
+++ b/src/index.html
@@ -753,7 +753,10 @@
           <span class="material-icons">
             error
           </span>
-          <span class="point-mapper-error__text">Oops, something went wrong. Please try again or reload the page. <a href="#">Contact us</a> if the problem persists.</span>
+          <span class="point-mapper-error__text">
+            Oops, something went wrong. Please try again or reload the page. 
+            <a href="mailto:info@mma.org.za">Contact us</a> if the problem persists.
+          </span>
         </div>
         <div class="point-mapper-content__no-data hidden">
           <div class="no-data">

--- a/src/index.html
+++ b/src/index.html
@@ -749,6 +749,12 @@
             </div>
           </div>
         </div>
+        <div class="point-mapper-content__error">
+          <span class="material-icons">
+            error
+          </span>
+          <span class="point-mapper-error__text">Oops, something went wrong. Please try again or reload the page. <a href="#">Contact us</a> if the problem persists.</span>
+        </div>
         <div class="point-mapper-content__no-data hidden">
           <div class="no-data">
             <div class="no-data__icon">

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -85,6 +85,10 @@ export function setPopupStyle(clsName) {
     $('.map-tooltip__geography-chip').css('left', leftOffset);
 }
 
+export function showPointError(){
+    $('.point-mapper-content__error').css('display', 'flex');
+}
+
 export class ThemeStyle {
     static replaceChildDivWithThemeIcon(themeId, colorElement, iconElement) {
         let iconClass = '.';

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -89,6 +89,10 @@ export function showPointError(){
     $('.point-mapper-content__error').css('display', 'flex');
 }
 
+export function disablePointError(){
+    $('.point-mapper-content__error').css('display', 'none');
+}
+
 export class ThemeStyle {
     static replaceChildDivWithThemeIcon(themeId, colorElement, iconElement) {
         let iconClass = '.';


### PR DESCRIPTION
## Description

Added Error state with class `.point-mapper-content__error` which can be toggled from showPointError function in utils.js

## Related Issue
#297 

## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
