### PR TITLE
showing subindicators even if the indicators dont have count property

### DIFF
--- a/src/js/elements/menu.js
+++ b/src/js/elements/menu.js
@@ -128,13 +128,9 @@ export function loadMenu(data, subindicatorCallback) {
         $(".data-category__h2", h2Wrapper).remove();
 
         for (const [subcategory, detail] of Object.entries(subcategories)) {
-            let hasChildren = checkIfSubCategoryHasChildren(subcategory, detail);
-
-            if (hasChildren) {
-                let count = subindicatorsInSubCategory(detail);
-                if (count > 0) {
-                    addIndicators(h2Wrapper, category, subcategory, detail.indicators);
-                }
+            let count = subindicatorsInSubCategory(detail);
+            if (count > 0) {
+                addIndicators(h2Wrapper, category, subcategory, detail.indicators);
             }
         }
     }


### PR DESCRIPTION
## Description

Reverting back feature #242 

## Related Issue
#216 

## How to test it locally
got to https://deploy-preview-314--wazimap-staging.netlify.app?dev-tools=true
select ADH as a profile form the dev-tools
confirm that Africa level data us still usable with the data mapper.

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
