### PR TITLE
adding data-id to the chart type toggle

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -2536,41 +2536,45 @@
                           <div>Save as image</div>
                         </div>
                       </a>
-                      <div class="hover-menu__content_item--no-link">
-                        <div class="icon--small">
-                          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                              <path d="M0 0h24v24H0z" fill="none"></path>
-                              <path fill="currentColor" d="M21 6H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v8z"></path>
-                            </svg></div>
+                      <div data-element="chart-value-select" class="hover-menu__chart-value">
+                        <div class="hover-menu__content_item--no-link">
+                          <div class="icon--small">
+                            <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                                <path d="M0 0h24v24H0z" fill="none"></path>
+                                <path fill="currentColor" d="M21 6H3c-1.1 0-2 .9-2 2v8c0 1.1.9 2 2 2h18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm0 10H3V8h2v4h2V8h2v4h2V8h2v4h2V8h2v4h2V8h2v8z"></path>
+                              </svg></div>
+                          </div>
+                          <div class="content__item_title">
+                            <div>Chart values as:</div>
+                          </div>
                         </div>
-                        <div class="content__item_title">
-                          <div>Chart values as:</div>
-                        </div>
-                      </div>
-                      <div class="hover-menu__content_list">
-                        <a href="#" class="hover-menu__content_list-item active w-inline-block">
-                          <div>Percentage</div>
-                        </a>
-                        <a href="#" class="hover-menu__content_list-item--last w-inline-block">
-                          <div>Value</div>
-                        </a>
-                      </div>
-                      <div class="hover-menu__content_item--no-link">
-                        <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c3974bdbe09f2e_download-24px.svg" alt=""></div>
-                        <div class="content__item_title">
-                          <div>Click to download data:</div>
+                        <div class="hover-menu__content_list">
+                          <a href="#" class="hover-menu__content_list-item active w-inline-block">
+                            <div>Percentage</div>
+                          </a>
+                          <a href="#" class="hover-menu__content_list-item last w-inline-block">
+                            <div>Value</div>
+                          </a>
                         </div>
                       </div>
-                      <div class="hover-menu__content_list--last">
-                        <a href="#" class="hover-menu__content_list-item w-inline-block">
-                          <div>CSV</div>
-                        </a>
-                        <a href="#" class="hover-menu__content_list-item w-inline-block">
-                          <div>Excel</div>
-                        </a>
-                        <a href="#" class="hover-menu__content_list-item w-inline-block">
-                          <div>JSON</div>
-                        </a>
+                      <div data-element="chart-download-data" class="hover-menu__download-data">
+                        <div class="hover-menu__content_item--no-link">
+                          <div class="icon--small"><img src="https://uploads-ssl.webflow.com/5ea151b3c7c39749f3e09ee7/5ea151b3c7c3974bdbe09f2e_download-24px.svg" alt=""></div>
+                          <div class="content__item_title">
+                            <div>Click to download data:</div>
+                          </div>
+                        </div>
+                        <div class="hover-menu__content_list--last">
+                          <a href="#" class="hover-menu__content_list-item w-inline-block">
+                            <div>CSV</div>
+                          </a>
+                          <a href="#" class="hover-menu__content_list-item w-inline-block">
+                            <div>Excel</div>
+                          </a>
+                          <a href="#" class="hover-menu__content_list-item w-inline-block">
+                            <div>JSON</div>
+                          </a>
+                        </div>
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
## Description
applying design changes on chart type toggle

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/307

## How to test it locally
* expend the rich data panel
* hover over the popup menu of any chart
* confirm that 
      -> hover menu chart value type selector has `data-element="chart-value-select"`
      -> hover menu download data options have `data-element="chart-download-data"`


## Screenshots


## Changelog

### Added

### Updated
* `index.html` to apply design changes

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
