### PR TITLE
Integration tests for the Homepage

### DIFF
--- a/__tests__/integration/homepage.feature
+++ b/__tests__/integration/homepage.feature
@@ -1,0 +1,11 @@
+Feature: Home (?)
+  This feature allow the users to navigate the homepage features
+
+  Scenario: Verify the homepage information is displayed
+    # Enter steps here
+    Given I am on the Wazimap Homepage
+    Then Tutorial button should be visible
+    And "Tutorial" should be displayed
+    Then Panel Toggles should be visible
+    And I click on Rich Data panel
+    Then "Summary" should be displayed

--- a/__tests__/integration/homepage/home.js
+++ b/__tests__/integration/homepage/home.js
@@ -1,0 +1,23 @@
+import { When, Given, Then } from "cypress-cucumber-preprocessor/steps";
+
+Given('I am on the Wazimap Homepage', () => {
+  cy.visit("/");
+});
+
+Then('Tutorial button should be visible', () => {
+  cy.get("div[class=nav__link-wrap]");
+  cy.get("a[class='nav__link tutorial__open w-inline-block']");
+});
+
+Then('Panel Toggles should be visible', () => {
+  cy.get("div[class=point-mapper-toggles]").then(panel => {
+    panel.get("div[class='panel-toggle rich-data-panel__open']");
+    panel.get("div[class='panel-toggle point-mapper-panel__close cc-active']");
+  });
+});
+
+When("I click on Rich Data panel", () => {
+  cy.get("div[class=point-mapper-toggles]").then(panel => {
+  panel.find("div[class='panel-toggle rich-data-panel__open']").click();
+  });
+})


### PR DESCRIPTION
## Description

Our tests are being migrated from Python to Js Cypress tests, these are samples of the tests that are being moved.

## Related Issue

https://github.com/OpenUpSA/wazimap-ng-ui/issues/317

## How to test it locally

Ensure your local development server is running (`yarn start`).

`npm run cypress:open`

## Screenshots

![Screenshot from 2021-04-20 15-08-09](https://user-images.githubusercontent.com/6994982/115393340-3e070a00-a1ea-11eb-8ef3-821e801ddcde.png)


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
