### PR TITLE
feat: add E2E tests to test profiles

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches:
       - staging
+  schedule:
+    - cron:  '30 2 * * *'
 jobs:
   tests:
     runs-on: ubuntu-latest

--- a/__tests__/integration/Profiles.feature
+++ b/__tests__/integration/Profiles.feature
@@ -1,0 +1,11 @@
+Feature: Initial Page Load
+
+  Scenario Outline: Page Title
+    Given I am on the "<Profile>" Homepage
+    Then I should see a Geography in the breadcrumps
+    And I should see a title in the Rich Data View
+
+    Examples:
+      | Profile |
+      | Youth Explorer |
+      | GCRO |

--- a/__tests__/integration/common/i_m_on_profile_homepgae.js
+++ b/__tests__/integration/common/i_m_on_profile_homepgae.js
@@ -1,0 +1,6 @@
+import { Given } from "cypress-cucumber-preprocessor/steps";
+
+Given('I am on the {string} Homepage', (profile) => {
+  cy.setProfile(profile);
+  cy.visit("/")
+})

--- a/__tests__/integration/profiles.feature
+++ b/__tests__/integration/profiles.feature
@@ -1,6 +1,6 @@
 Feature: Initial Page Load
 
-  Scenario Outline: Page Title
+  Scenario Outline: Geography Loads and Rich Data View
     Given I am on the "<Profile>" Homepage
     Then I should see a Geography in the breadcrumps
     And I should see a title in the Rich Data View

--- a/__tests__/integration/profiles/Homepage.js
+++ b/__tests__/integration/profiles/Homepage.js
@@ -1,0 +1,21 @@
+import { When, Given, Then } from "cypress-cucumber-preprocessor/steps";
+
+
+const profiles = {
+  "Youth Explorer": "beta.youthexplorer.org.za",
+  "GCRO": "gcro.openup.org.za"
+}
+
+Given('I am on the {string} Homepage', (profile) => {
+  window.sessionStorage.setItem("wazi-hostname", profiles[profile])
+  cy.visit("/")
+})
+
+Then('I should see a Geography in the breadcrumps', () => {
+  cy.get(".map-location__tags .location-tag__name").should('not.contain', 'Loading...')
+})
+
+Then('I should see a title in the Rich Data View', () => {
+  cy.get(".location__title h1").should('not.be.empty')
+})
+

--- a/__tests__/integration/profiles/Homepage.js
+++ b/__tests__/integration/profiles/Homepage.js
@@ -1,10 +1,10 @@
 import { When, Given, Then } from "cypress-cucumber-preprocessor/steps";
 
 Then('I should see a Geography in the breadcrumps', () => {
-  cy.get(".map-location__tags .location-tag__name").should('not.contain', 'Loading...')
+  cy.get(".map-location__tags .location-tag__name", { timeout: 100000 }).should('not.contain', 'Loading...')
 })
 
 Then('I should see a title in the Rich Data View', () => {
-  cy.get(".location__title h1").should('not.be.empty')
+  cy.get(".location__title h1", { timeout: 100000 }).should('not.be.empty')
 })
 

--- a/__tests__/integration/profiles/Homepage.js
+++ b/__tests__/integration/profiles/Homepage.js
@@ -1,16 +1,5 @@
 import { When, Given, Then } from "cypress-cucumber-preprocessor/steps";
 
-
-const profiles = {
-  "Youth Explorer": "beta.youthexplorer.org.za",
-  "GCRO": "gcro.openup.org.za"
-}
-
-Given('I am on the {string} Homepage', (profile) => {
-  window.sessionStorage.setItem("wazi-hostname", profiles[profile])
-  cy.visit("/")
-})
-
 Then('I should see a Geography in the breadcrumps', () => {
   cy.get(".map-location__tags .location-tag__name").should('not.contain', 'Loading...')
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,1 +1,18 @@
 import '@testing-library/cypress/add-commands';
+
+const PROFILES = {
+  "Youth Explorer": "beta.youthexplorer.org.za",
+  "GCRO": "gcro.openup.org.za"
+}
+
+Cypress.Commands.add('setSessionStorage', (key, value) => {
+  cy.window().then((window) => {
+    window.sessionStorage.setItem(key, value)
+  })
+})
+
+Cypress.Commands.add('setProfile', (value) => {
+  cy.window().then((window) => {
+    window.sessionStorage.setItem("wazi-hostname", PROFILES[value])
+  })
+})


### PR DESCRIPTION
## Description
Add structure for E2E tests how we will test that all profiles work. And that the most important features work on all profiles. 
This can lead to failures if the profiles change or get removed.
That's why this needs to be monitored and adjusted accordingly. 

If the tests break the profiles can't be loaded. Indicator for a problem. 

## Related Issue

## How to test it locally
Run `npm run cypress:open` to watch the tests complete (will open a chrome window)

## Screenshots
_not applicable_

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
