### PR TITLE
adding download all facilities button

### DIFF
--- a/src/css/wazimap-ng-v1.webflow.css
+++ b/src/css/wazimap-ng-v1.webflow.css
@@ -7362,6 +7362,59 @@ label {
   max-height: 400px;
 }
 
+.location__facilities_download-all {
+  display: -ms-grid;
+  display: grid;
+  height: 36px;
+  padding-right: 10px;
+  padding-left: 10px;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex: 0;
+  -webkit-flex: 0 0 auto;
+  -ms-flex: 0 0 auto;
+  flex: 0 0 auto;
+  grid-auto-columns: 1fr;
+  grid-column-gap: 4px;
+  grid-row-gap: 16px;
+  -ms-grid-columns: 1fr -webkit-max-content;
+  -ms-grid-columns: 1fr max-content;
+  grid-template-columns: 1fr -webkit-max-content;
+  grid-template-columns: 1fr max-content;
+  -ms-grid-rows: auto;
+  grid-template-rows: auto;
+  border-radius: 2px;
+  background-color: rgba(0, 0, 0, 0.06);
+  cursor: pointer;
+}
+
+.location__facilities_download-all:hover {
+  background-color: rgba(0, 0, 0, 0.1);
+}
+
+.location__facilities_download-all.location__facilities_download-all--footer {
+  display: none;
+  margin-top: 8px;
+  margin-left: 8px;
+}
+
+.location__facilities_header-wrapper {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-align: center;
+  -webkit-align-items: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-flex: 1;
+  -webkit-flex: 1;
+  -ms-flex: 1;
+  flex: 1;
+}
+
 @media screen and (max-width: 991px) {
   .rich-data-content {
     padding-top: 44px;

--- a/src/index.html
+++ b/src/index.html
@@ -619,15 +619,24 @@
               </div>
             </div>
             <div class="location__facilities_header hidden">
-              <div class="location__facilities_icon">
-                <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
-                    <path d="M0 0h24v24H0z" fill="none"></path>
-                    <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
-                    <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
-                  </svg></div>
+              <div class="location__facilities_header-wrapper">
+                <div class="location__facilities_icon">
+                  <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                      <path d="M0 0h24v24H0z" fill="none"></path>
+                      <path fill="currentColor" d="M8.92,11.22a2.56,2.56,0,1,1,2.55-2.55,2.55,2.55,0,0,1-2.55,2.55m0-9.72A7.16,7.16,0,0,0,1.76,8.67C1.76,14,8.92,22,8.92,22S16.08,14,16.08,8.67A7.17,7.17,0,0,0,8.92,1.5Z"></path>
+                      <path fill="currentColor" d="M18.77,16.26V12.54h-2v3.72H14.39c-.42.69-.85,1.36-1.28,2h3.67V22h2V18.24h3.72v-2Z"></path>
+                    </svg></div>
+                </div>
+                <div class="location__facilities_title">
+                  <div>This <span class="location__facilities_geo-type">area</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> locations</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
+                </div>
               </div>
-              <div class="location__facilities_title">
-                <div>This <span class="location__facilities_geo-type">area</span> has <span class="location__facilities_facilities-value"><strong>0000</strong></span><strong> locations</strong> in <span class="location__facilities_categories-value"><strong>0000</strong></span><strong> categories</strong>.</div>
+              <div class="location__facilities_download-all location__facilities_download-all--header">
+                <div>Download all facilities</div>
+                <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24">
+                    <path d="M0 0h24v24H0z" fill="none"></path>
+                    <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                  </svg></div>
               </div>
             </div>
             <div class="location__facilities_trigger hidden">


### PR DESCRIPTION
## Description
adding `download all facilities` button on the rich data panel

## Related Issue


## How to test it locally
* expand the rich data panel
* confirm that the `Download all facilities` button looks as the design.

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/115781246-c9d38e80-a3c2-11eb-9cb7-a0a8d498ce86.png)


## Changelog

### Added

### Updated
* `index.html` and `wazimap-ng-v1.webflow.css` to apply the design changes

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
