### PR TITLE
updating tables when charts are filtered

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -438,6 +438,7 @@ export class Chart extends Observable {
       } else {
         this.vegaView.signal('applyFilter', false).run()
       }
+    this.showChartDataTable();
   };
 
   exportAsCsv = () => {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -39,6 +39,7 @@ export class Chart extends Observable {
     this.config = config;
     this.selectedFilter = null;
     this.selectedGroup = null;
+    this.table = null;
 
     tooltipClone = $(tooltipClass)[0].cloneNode(true);
     this.subCategoryNode = _subCategoryNode;
@@ -246,10 +247,15 @@ export class Chart extends Observable {
   };
 
   showChartDataTable = () => {
+      this.createDataTable();
+      this.appendDataToTable();
+  }
+
+  createDataTable = () => {
     this.containerParent.find('.profile-indicator__table').remove();
 
-    let table = document.createElement('table');
-    $(table).addClass('profile-indicator__table profile-indicator__table_content');
+    this.table = document.createElement('table');
+    $(this.table).addClass('profile-indicator__table profile-indicator__table_content');
     let thead = document.createElement('thead');
     $(thead).addClass('profile-indicator__table_row--header');
     let headRow = document.createElement('tr');
@@ -268,7 +274,13 @@ export class Chart extends Observable {
     $(headRow).append(headCol3);
 
     $(thead).append(headRow);
-    $(table).append(thead);
+    $(this.table).append(thead);
+
+    this.containerParent.append(this.table);
+  }
+
+  appendDataToTable = () => {
+    $(this.table).find('tbody').remove();
 
     let tbody = document.createElement('tbody');
 
@@ -296,9 +308,8 @@ export class Chart extends Observable {
       $(tbody).append(row);
     })
 
-    $(table).append(tbody);
+    $(this.table).append(tbody);
 
-    this.containerParent.append(table);
     if (dataArr.length > MAX_RICH_TABLE_ROWS) {
       let showExtraRows = false;
       let btnDiv = document.createElement('div');
@@ -308,7 +319,7 @@ export class Chart extends Observable {
       $(btn).on("click", () => {
         showExtraRows = !showExtraRows;
         showExtraRows ? $(btn).text('Show less rows') : $(btn).text('Load more rows');
-        showExtraRows ? $(table).removeClass("profile-indicator__table_content") : $(table).addClass("profile-indicator__table_content");
+        showExtraRows ? $(table).removeClass("profile-indicator__table_content") : $(this.table).addClass("profile-indicator__table_content");
       })
       btnDiv.append(btn);
       this.containerParent.append(btnDiv);
@@ -438,7 +449,7 @@ export class Chart extends Observable {
       } else {
         this.vegaView.signal('applyFilter', false).run()
       }
-    this.showChartDataTable();
+    this.appendDataToTable();
   };
 
   exportAsCsv = () => {


### PR DESCRIPTION
## Description
Updating the table when user applies filtering to a chart

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/335

## How to test it locally
* expand the rich data panel
* apply filter to any chart
* confirm that the table data is updated and shows the filtered data

## Screenshots


## Changelog

### Added

### Updated
* `profile/chart.js` to repopulate the table in `applyFilter()` function

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
