### PR TITLE
disabling facility download

### DIFF
--- a/__tests__/profile/profile_header.test.js
+++ b/__tests__/profile/profile_header.test.js
@@ -145,24 +145,34 @@ describe('downloading facilities', () => {
     const geography = {code: 'ZA'};
     let config = {};
 
-    document.body.innerHTML = `
-<div class="location-facility">
-    <a href="#" class="location-facility__list_item w-inline-block">
-        <div class="location-facility__item_name">
-          <div class="truncate">Thusong centres (unverified)</div>
-        </div>
-        <div class="location-facility__item_value">
-          <div>140</div>
-        </div>
-        <div id="w-node-a4312e607bde-e148319d" class="location-facility__item_download" data-testid='download-btn'>
-          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
-              <path d="M0 0h24v24H0z" fill="none"></path>
-              <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
-            </svg>
+    beforeEach(() => {
+        document.body.innerHTML = `
+<div class="location__facilities">
+    <div class="location__facilities_content">
+        <div class="location__facilities_content-wrapper">
+            <div class="location-facility">
+                <div class="location-facility__list">
+                    <a href="#" class="location-facility__list_item w-inline-block">
+                    <div class="location-facility__item_name">
+                      <div class="truncate">Thusong centres (unverified)</div>
+                    </div>
+                    <div class="location-facility__item_value">
+                      <div>140</div>
+                    </div>
+                    <div id="w-node-a4312e607bde-e148319d" class="location-facility__item_download" data-testid='download-btn'>
+                      <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+                          <path d="M0 0h24v24H0z" fill="none"></path>
+                          <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+                        </svg>
+                        </div>
+                    </div>
+                </a>
+                </div>
             </div>
         </div>
-    </a>
+    </div>
 </div>`;
+    })
 
     test('download is enabled', () => {
         const header = new Profile_header(parents, geometries, api, null, geography, config);

--- a/__tests__/profile/profile_header.test.js
+++ b/__tests__/profile/profile_header.test.js
@@ -119,8 +119,9 @@ describe('profile header', () => {
     const geometries = {themes: []};
     const api = null;
     const geography = {code: 'ZA'};
+    const config = {};
 
     test('initialize successully', () => {
-        const header = new Profile_header(parents, geometries, api, null, geography);
+        const header = new Profile_header(parents, geometries, api, null, geography, config);
     })
 })

--- a/__tests__/profile/profile_header.test.js
+++ b/__tests__/profile/profile_header.test.js
@@ -1,5 +1,6 @@
 import {Profile_header} from "../../src/js/profile/profile_header";
 import {extractSheetsData} from "../../src/js/utils";
+import {screen} from "@testing-library/dom";
 
 const FACILITIES = {
     count: 2,
@@ -123,5 +124,61 @@ describe('profile header', () => {
 
     test('initialize successully', () => {
         const header = new Profile_header(parents, geometries, api, null, geography, config);
+    })
+})
+
+describe('downloading facilities', () => {
+    const parents = [];
+    const geometries = {
+        themes: [{
+            id: 1,
+            name: 'test',
+            icon: 'icon',
+            subthemes: [{
+                count: 5,
+                label: 'test category',
+                id: 14
+            }]
+        }]
+    };
+    const api = null;
+    const geography = {code: 'ZA'};
+    let config = {};
+
+    document.body.innerHTML = `
+<div class="location-facility">
+    <a href="#" class="location-facility__list_item w-inline-block">
+        <div class="location-facility__item_name">
+          <div class="truncate">Thusong centres (unverified)</div>
+        </div>
+        <div class="location-facility__item_value">
+          <div>140</div>
+        </div>
+        <div id="w-node-a4312e607bde-e148319d" class="location-facility__item_download" data-testid='download-btn'>
+          <div class="svg-icon small w-embed"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24">
+              <path d="M0 0h24v24H0z" fill="none"></path>
+              <path fill="currentColor" d="M19,9h-4V3H9v6H5l7,7L19,9z M5,18v2h14v-2H5z"></path>
+            </svg>
+            </div>
+        </div>
+    </a>
+</div>`;
+
+    test('download is enabled', () => {
+        const header = new Profile_header(parents, geometries, api, null, geography, config);
+        let downloadBtn = screen.getByTestId('download-btn');
+        expect(downloadBtn.classList.contains('hidden')).toBe(false);
+    })
+
+    test('download is disabled', () => {
+        config = {
+            richdata: {
+                hide: ['facility-downloads']
+            }
+        }
+
+        const header = new Profile_header(parents, geometries, api, null, geography, config);
+        let downloadBtn = screen.getByTestId('download-btn');
+        expect(downloadBtn).toHaveClass('hidden');
     })
 })

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -56,7 +56,7 @@ export default function configureApplication(profileId, config) {
     const pointDataTray = new PointDataTray(api, profileId);
     const mapchip = new MapChip(config.choropleth);
     const search = new Search(api, profileId, 2);
-    const profileLoader = new ProfileLoader(formattingConfig, api, profileId);
+    const profileLoader = new ProfileLoader(formattingConfig, api, profileId, config.config);
     const locationInfoBox = new LocationInfoBox(formattingConfig);
     const zoomToggle = new ZoomToggle();
     const preferredChildToggle = new PreferredChildToggle();

--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -26,7 +26,7 @@ export class Profile_header extends Observable {
         this.api = _api;
         this.profileId = _profileId;
         this.config = _config;
-        this.facilityDownloadEnabled = true;
+        this.isDownloadsDisabled = false;
 
         parents = _parents;
         geometries = _geometries;
@@ -41,19 +41,16 @@ export class Profile_header extends Observable {
 
         $(downloadAllFacilities).on('click', () => this.downloadAllFacilities());
 
-        this.checkIfDownloadsEnabled();
+        this.checkIfDownloadsDisabled();
         this.setPointSource();
         this.addBreadCrumbs();
         this.addFacilities();
         this.setLocationDescription();
     }
 
-    checkIfDownloadsEnabled = () => {
-        if (typeof this.config['richdata'] === 'undefined' || typeof this.config['richdata']['hide'] === 'undefined') {
-            return;
-        }
-        if (this.config['richdata']['hide'].indexOf(FACILITY_DOWNLOADS) >= 0) {
-            this.facilityDownloadEnabled = false;
+    checkIfDownloadsDisabled = () => {
+        if ('richdata' in this.config && 'hide' in this.config['richdata']) {
+            this.isDownloadsDisabled = this.config['richdata']['hide'].includes(FACILITY_DOWNLOADS);
         }
     }
 
@@ -132,7 +129,7 @@ export class Profile_header extends Observable {
 
                     $('.location-facility__list', facilityItem).append(rowItem);
 
-                    if (this.facilityDownloadEnabled) {
+                    if (!this.isDownloadsDisabled) {
                         $(rowItem).on('click', () => {
                             self.downloadPointData(themeCategories[i]);
                         })

--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -12,17 +12,21 @@ let parents = null;
 let geometries = null;
 let geography = null;
 
+const FACILITY_DOWNLOADS = 'facility-downloads';
+
 const breadcrumbClass = '.breadcrumb';
 const locationDescriptionClass = '.location__description';
 
 const downloadAllFacilities = '.location__facilities_download-all';
 
 export class Profile_header extends Observable {
-    constructor(_parents, _geometries, _api, _profileId, _geography) {
+    constructor(_parents, _geometries, _api, _profileId, _geography, _config) {
         super();
 
         this.api = _api;
         this.profileId = _profileId;
+        this.config = _config;
+        this.facilityDownloadEnabled = true;
 
         parents = _parents;
         geometries = _geometries;
@@ -37,10 +41,20 @@ export class Profile_header extends Observable {
 
         $(downloadAllFacilities).on('click', () => this.downloadAllFacilities());
 
+        this.checkIfDownloadsEnabled();
         this.setPointSource();
         this.addBreadCrumbs();
         this.addFacilities();
         this.setLocationDescription();
+    }
+
+    checkIfDownloadsEnabled = () => {
+        if (typeof this.config['richdata'] === 'undefined' || typeof this.config['richdata']['hide'] === 'undefined') {
+            return;
+        }
+        if (this.config['richdata']['hide'].indexOf(FACILITY_DOWNLOADS) >= 0) {
+            this.facilityDownloadEnabled = false;
+        }
     }
 
     addBreadCrumbs = () => {
@@ -118,9 +132,13 @@ export class Profile_header extends Observable {
 
                     $('.location-facility__list', facilityItem).append(rowItem);
 
-                    $(rowItem).on('click', () => {
-                        self.downloadPointData(themeCategories[i]);
-                    })
+                    if (this.facilityDownloadEnabled) {
+                        $(rowItem).on('click', () => {
+                            self.downloadPointData(themeCategories[i]);
+                        })
+                    } else {
+                        $('.location-facility__item_download', rowItem).addClass('hidden');
+                    }
                 }
                 $('.location-facility__description', facilityItem).addClass('hidden')
 

--- a/src/js/profile/profile_loader.js
+++ b/src/js/profile/profile_loader.js
@@ -13,13 +13,15 @@ let indicatorTemplate = null;
 let profileWrapper = null;
 
 
+
 export default class ProfileLoader extends Observable {
-    constructor(formattingConfig, _api, _profileId) {
+    constructor(formattingConfig, _api, _profileId, _config) {
         super();
 
         this.api = _api;
         this.profileId = _profileId;
         this.formattingConfig = formattingConfig;
+        this.config = _config;
     }
 
     loadProfile = (dataBundle) => {
@@ -32,7 +34,7 @@ export default class ProfileLoader extends Observable {
         this.loadCategories(profile);
         this.updateGeography(profile);
 
-        let profileHeader = new Profile_header(profile.parents, geometries, this.api, this.profileId, geography);
+        let profileHeader = new Profile_header(profile.parents, geometries, this.api, this.profileId, geography, this.config);
         profileHeader.on('profile.breadcrumbs.selected', parent => this.triggerEvent('profile.breadcrumbs.selected', parent));
     }
 


### PR DESCRIPTION
## Description
disabling facility download based on `config` property

assumed data structure : 

```
config:{
   "richdata": { 
     "hide": ["facility-downloads"]
   }
}
```

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/330

## How to test it locally


## Screenshots


## Changelog

### Added

### Updated
* `profile_header.js` to add the click event based on config

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
