### PR TITLE
Hiding subindicators in data mapper where no data is available

### DIFF
--- a/src/js/elements/menu.js
+++ b/src/js/elements/menu.js
@@ -37,7 +37,7 @@ function subindicatorsInSubCategory(subcategory) {
 }
 
 function subindicatorsInIndicator(indicator) {
-  return indicator.metadata.groups.length;
+    return indicator.metadata.groups.length;
 }
 
 // TODO this entire file needs to be refactored to use thhe observer pattern
@@ -112,9 +112,13 @@ export function loadMenu(data, subindicatorCallback) {
         $(".data-category__h2", h2Wrapper).remove();
 
         for (const [subcategory, detail] of Object.entries(subcategories)) {
-            let count = subindicatorsInSubCategory(detail);
-            if (count > 0) {
-                addIndicators(h2Wrapper, category, subcategory, detail.indicators);
+            let hasChildren = checkIfSubCategoryHasChildren(subcategory, detail);
+
+            if (hasChildren) {
+                let count = subindicatorsInSubCategory(detail);
+                if (count > 0) {
+                    addIndicators(h2Wrapper, category, subcategory, detail.indicators);
+                }
             }
         }
     }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -293,18 +293,20 @@ export function fillMissingKeys(obj, defaultObj, deep_copy = false) {
     return merge({}, defaultObj, obj)
 }
 
-export function checkIfSubCategoryHasChildren (subcategory, detail)  {
+export function checkIfSubCategoryHasChildren(subcategory, detail) {
     let hasChildren = false;
     for (const [title, data] of Object.entries(detail.indicators)) {
-        hasChildren = hasChildren || data.data.some(function (e) {
-            return e.count > 0
-        });
+        if (!hasChildren && typeof data.child_data !== 'undefined') {
+            for (const [geo, arr] of Object.entries(data.child_data)) {
+                hasChildren = hasChildren || arr.length > 0;
+            }
+        }
     }
 
     return hasChildren;
 }
 
-export function filterAndSumGeoCounts(childData, primaryGroup, selectedSubindicator){
+export function filterAndSumGeoCounts(childData, primaryGroup, selectedSubindicator) {
     let sumData = {};
     Object.entries(childData).map(([code, data]) => {
         let filteredArr = data.filter((a) => {
@@ -319,7 +321,7 @@ export function filterAndSumGeoCounts(childData, primaryGroup, selectedSubindica
     return sumData;
 }
 
-export function getFilterGroups(groups, primaryGroup){
+export function getFilterGroups(groups, primaryGroup) {
     groups = groups.reduce(function (memo, e1) {
         let matches = memo.filter(function (e2) {
             return e1.name === e2.name
@@ -352,9 +354,9 @@ export function extractSheetsData(data) {
 export function extractSheetData(rawData, categoryName) {
     const sheetName = getSheetName(categoryName);
     let rows = rawData.features.map((f) => {
-        let { properties: { name, data } } =  f;
-        let mapped = data.map(item => ({ [item.key]: item.value }) );
-        return Object.assign({name}, ...mapped );
+        let {properties: {name, data}} = f;
+        let mapped = data.map(item => ({[item.key]: item.value}));
+        return Object.assign({name}, ...mapped);
     })
 
     return {


### PR DESCRIPTION
## Description
Checking if a sub-indicator has data to show and not adding it in data mapper and the rich data panel if no data is available

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/216


## How to test it locally


## Screenshots


## Changelog

### Added

### Updated
* `checkIfSubCategoryHasChildren()` function in `utils.js` to work with the new data structure
* `menu.j` to add back the `hasChildren` check

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
