### PR TITLE
feat: loading the index.html for tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
     test: {
       plugins: [
         '@babel/plugin-proposal-class-properties',
+        'preval'
       ]
     }
  },

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "cypress": "^5.2.0",
     "cypress-cucumber-preprocessor": "^2.5.5",
     "jest": "^26.4.2",
+    "babel-plugin-preval": "^5.0.0",
     "miragejs": "^0.1.41",
     "parcel": "1.12.4",
     "parcel-bundler": "1.12.5"

--- a/setup-jest.js
+++ b/setup-jest.js
@@ -1,2 +1,7 @@
 import $ from 'jquery';
 global.$ = global.jQuery = $;
+
+global.mainDocument = preval`
+  const fs = require('fs')
+  module.exports = fs.readFileSync(require.resolve('./src/index.html'), 'utf8')
+`


### PR DESCRIPTION
## Description

using the nice plugin babel-plugin-preval to include files on loading
not bundling, we don't need that in production or anywhere else in the
bundle, this is just needed for tests
it's "easier" but definetely smaller than any of the loaders, which
might have big side effects. using this plugin is very nimble and allows
us to just use the file system to load the src index.html as a string

## Related Issue


## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
