### PR TITLE
setting default map coordinates

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -108,7 +108,7 @@ async function init() {
     // TODO add this to config - check the <script> tag in the HTML which hardcodes this value
     pc.config.analytics = new Analytics('UA-93649482-25', pc.profile);
     pc.config.profile = data.id;
-    pc.config.map.defaultCoordinates = data.configuration.default_coordinates;
+    pc.config.map.defaultCoordinates = data.configuration.default_coordinates || pc.config.map.defaultCoordinates;
 
     configureApplication(data.id, pc.config);
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -108,6 +108,7 @@ async function init() {
     // TODO add this to config - check the <script> tag in the HTML which hardcodes this value
     pc.config.analytics = new Analytics('UA-93649482-25', pc.profile);
     pc.config.profile = data.id;
+    pc.config.map.defaultCoordinates = data.configuration.default_coordinates;
 
     configureApplication(data.id, pc.config);
 }


### PR DESCRIPTION
## Description
Setting the default map coordinates using the `default_coordinates` key in the config

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/344

## How to test it locally
* confirm that when the map is created, the coordinates that the API sends are the default coordinates

## Screenshots


## Changelog

### Added

### Updated
* `index.js` to modify `config`

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
