### PR TITLE
fix: Rich data table reference updated

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -319,7 +319,7 @@ export class Chart extends Observable {
       $(btn).on("click", () => {
         showExtraRows = !showExtraRows;
         showExtraRows ? $(btn).text('Show less rows') : $(btn).text('Load more rows');
-        showExtraRows ? $(table).removeClass("profile-indicator__table_content") : $(this.table).addClass("profile-indicator__table_content");
+        showExtraRows ? $(this.table).removeClass("profile-indicator__table_content") : $(this.table).addClass("profile-indicator__table_content");
       })
       btnDiv.append(btn);
       this.containerParent.append(btnDiv);


### PR DESCRIPTION
## Description

Table reference in the code was outdated and was throwing some errors. 
I also noticed the error on Sentry
Sentry link: https://sentry.io/organizations/openupsa/issues/2408465837/?referrer=alert_email&environment=production

![Screenshot from 2021-05-24 13-43-38](https://user-images.githubusercontent.com/6994982/119336231-1518df80-bc96-11eb-80a5-3e72b8b29a3f.png)


## How to test it locally

Load web app and try clicking on the `show more` button in the rich data tables panel

## Screenshots

BEFORE:
![Screenshot from 2021-05-24 13-41-31](https://user-images.githubusercontent.com/6994982/119336094-da16ac00-bc95-11eb-9fb7-bf41b8f35e34.png)

AFTER click on button
![Screenshot from 2021-05-24 13-41-39](https://user-images.githubusercontent.com/6994982/119336121-e69b0480-bc95-11eb-93b8-e3f092338c25.png)

## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
