### PR TITLE
fix: Make sure chart filters work with different filter names

### DIFF
--- a/__tests__/profile/charts/utils.test.js
+++ b/__tests__/profile/charts/utils.test.js
@@ -1,4 +1,4 @@
-import { createFiltersForGroups } from '../../../src/js/profile/charts/utils';
+import { createFiltersForGroups, slugify } from '../../../src/js/profile/charts/utils';
 
 describe('#createFiltersForGroups', () => {
   let groups;
@@ -40,5 +40,12 @@ describe('#createFiltersForGroups', () => {
      * 
     **/
     expect(filter).toHaveProperty('expr', '!ageFilter || (ageFilter && datum.age === ageFilterValue)')
+  });
+});
+describe('#slugify', () => {
+  test.each([
+    ['abc123', 'abc123'], ['ab c', 'abc'],  ['ab-c', 'abc'],
+    ['ab.cd-_fsw', 'abcdfsw'], ['ab  ', 'ab'],  ['ab-c', 'abc']])('slugify(%s)', (value, expected) => {
+      expect(slugify(value)).toBe(expected);
   });
 });

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -11,6 +11,7 @@ import Papa from 'papaparse';
 import embed from "vega-embed";
 
 import { configureBarchart } from './charts/barChart';
+import { slugify } from './charts/utils';
 
 const PERCENTAGE_TYPE = "percentage";
 const VALUE_TYPE = "value";
@@ -321,7 +322,8 @@ export class Chart extends Observable {
     this.filteredData = filteredData;
     this.selectedFilter = selectedFilter;
     this.selectedGroup = selectedGroup;
-    const { name:filterName } = selectedGroup;
+    let { name:filterName } = selectedGroup;
+    filterName = slugify(filterName)
     if(selectedFilter !== "All values") {
       this.setDownloadUrl();
       this.vegaView.signal(`${filterName}Filter`, true)

--- a/src/js/profile/charts/utils.js
+++ b/src/js/profile/charts/utils.js
@@ -1,6 +1,6 @@
 
 export const slugify = (string) => {
-    return string.replace(/^\s+|\s+$/g, '').replace(/[^a-z0-9 -]/g, '').replace(/\s+/g, '_').replace(/_+/g, '_');
+    return string.replace(/^\s+|\s+$/g, '').replace(/[^a-z0-9]/g, '').replace(/\s+/g, '_').replace(/_+/g, '_');
 }
 /**
  * createFiltersForGroups


### PR DESCRIPTION
## Description

vega filter expressions will fail if there is a hyphen which vega will
evaluate as a minus
we need to slugify and remove all special characters for these filter otherwise Vega will try to evaluate this. 

We need to use slugify when setting the filter as well. (this was causing another problem)

## Related Issue
closes #360 
closes #365 

## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
