### PR TITLE
fix: NaN on choropleth; choropleth not showing the correct values

### DIFF
--- a/src/js/map/choropleth/absolute_value_calculator.js
+++ b/src/js/map/choropleth/absolute_value_calculator.js
@@ -8,7 +8,7 @@ export default class AbsoluteValueCalculator {
         const result = Object.entries(sumData).map(childGeography => {
             const code = childGeography[0];
             const count = childGeography[1];
-            return {code: code, total: count};
+            return {code: code, val: count, total: count};
         })
 
         return result


### PR DESCRIPTION
## Description
With the new data format the choropleth was not showing any values for specific indicators.
Figured out that these are related to the absolute method.
we use `val` to calculate the extend and show the actual value, we use `total` for the tooltip. 
The fix was to include `val` in the absolute method as well.

_this should probably be refactored._

## Related Issue
closes #366 

## How to test it locally
Open ADH on Africa and look at hospital beds
Open Sanef Sandbox 

## Screenshots
![Bildschirmfoto 2021-06-02 um 19 42 40](https://user-images.githubusercontent.com/688980/120527564-c2989b00-c3da-11eb-9289-78654b8e75f0.png)
![Bildschirmfoto 2021-06-02 um 19 42 59](https://user-images.githubusercontent.com/688980/120527581-c6c4b880-c3da-11eb-9772-de0f7de9e0e1.png)

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
