### PR TITLE
fixing chart filter typeerror

### DIFF
--- a/src/js/profile/subindicator_filter.js
+++ b/src/js/profile/subindicator_filter.js
@@ -113,7 +113,7 @@ export class SubindicatorFilter extends Observable {
         if (i !== 0 && $(li).hasClass('selected')) {
           //leave the first item selected in default
           //                    $(li).removeClass('selected')
-          //                                    
+          //
         }
         if (typeof item.name === 'undefined') {
           $('.truncate', li).text(item);
@@ -196,19 +196,15 @@ export class SubindicatorFilter extends Observable {
   getFilteredGroups(selectedFilter) {
     let filteredData = {};
 
-    Object.entries(this.childData).map(([code, data]) => {
-      filteredData[code] = data.filter((cd) => {
-        return cd[this.selectedGroup.name] === selectedFilter
-
-
-      })
-
-
-    })
+    if(typeof this.childData !== 'undefined'){
+        Object.entries(this.childData).map(([code, data]) => {
+            filteredData[code] = data.filter((cd) => {
+                return cd[this.selectedGroup.name] === selectedFilter
+            })
+        })
+    }
 
     return filteredData;
-
-
   }
 
   resetDropdowns = (dropdowns) => {


### PR DESCRIPTION
## Description
Checking and fixing the chart filter TypeError on Vulekamali profile

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/361

## How to test it locally
* select Vulekamali profile against the migration backend
* navigate to GEO:NC
* expand the rich data panel
* filter `Mid-year estimates by gender` chart and confirm there is no error throwed by js

## Screenshots


## Changelog

### Added

### Updated
* `subindicator_filter.js` to prevent error in case of missing data

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
