### PR TITLE
Fix: Vega Filters & Data Table where not behaving as expected. 

### DIFF
--- a/__tests__/profile/charts/utils.test.js
+++ b/__tests__/profile/charts/utils.test.js
@@ -39,7 +39,21 @@ describe('#createFiltersForGroups', () => {
      * Vega is set out to filter values that return false, only filters that return true will be left in. 
      * 
     **/
-    expect(filter).toHaveProperty('expr', '!ageFilter || (ageFilter && datum.age === ageFilterValue)')
+    expect(filter).toHaveProperty('expr', '!ageFilter || (ageFilter && datum["age"] === ageFilterValue)')
+  });
+  describe('strange values', () => {
+    test.each([
+      ['age group', 'agegroup']
+    ])('createFilterForGroups name %s', (value, expected) => {
+      let groups = [
+        {
+          name: value
+        }
+      ]
+      let { signals, filters } = createFiltersForGroups(groups);
+      let [filter] = filters;
+      expect(filter).toHaveProperty('expr', `!${expected}Filter || (${expected}Filter && datum["${value}"] === ${expected}FilterValue)`)
+    });
   });
 });
 describe('#slugify', () => {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -58,7 +58,7 @@ export class Chart extends Observable {
   addChart = (data) => {
     $(".bar-chart", this.container).remove();
     $("svg", this.container).remove();
-    
+
     let vegaSpec = configureBarchart(data.data, data.metadata, this.config);
 
     const calculatePosition = (event, tooltipBox, offsetX, offsetY) => {
@@ -314,8 +314,8 @@ export class Chart extends Observable {
       ".profile-indicator__filters"
     );
 
-    let g = groups.filter((g) => { return g.name !== indicators.metadata.primary_group })
-    let siFilter = new SubindicatorFilter(filterArea, g, title, this.applyFilter, dropdowns, undefined, indicators.child_data);
+    this.filterGroups = groups.filter((g) => { return g.name !== indicators.metadata.primary_group })
+    let siFilter = new SubindicatorFilter(filterArea, this.filterGroups, title, this.applyFilter, dropdowns, undefined, indicators.child_data);
     this.bubbleEvent(siFilter, "point_tray.subindicator_filter.filter");
   };
 
@@ -323,14 +323,21 @@ export class Chart extends Observable {
     this.filteredData = filteredData;
     this.selectedFilter = selectedFilter;
     this.selectedGroup = selectedGroup;
-    let { name:filterName } = selectedGroup;
-    filterName = slugify(filterName)
+    this.filterGroups.forEach((group) => {
+      let { name:filterName } = group;
+      filterName = slugify(filterName)
+      this.vegaView.signal(`${filterName}Filter`, false)
+    });
+
     if(selectedFilter !== "All values") {
+      let { name:filterName } = selectedGroup;
+      filterName = slugify(filterName)
       this.setDownloadUrl();
       this.vegaView.signal(`${filterName}Filter`, true)
-      this.vegaView.signal(`${filterName}FilterValue`, selectedFilter).run()
+      this.vegaView.signal(`${filterName}FilterValue`, selectedFilter)
       this.appendDataToTable();
     }
+    this.vegaView.run()
   };
 
   exportAsCsv = () => {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -191,7 +191,8 @@ export class Chart extends Observable {
 
     $(this.table).append(tbody);
 
-    if (dataArr.length > MAX_RICH_TABLE_ROWS) {
+    let $showExtra = $('.profile-indicator__table_load-more', this.containerParent);
+    if (dataArr.length > MAX_RICH_TABLE_ROWS && $showExtra.length < 1) {
       let showExtraRows = false;
       let btnDiv = document.createElement('div');
       $(btnDiv).addClass('profile-indicator__table_show-more profile-indicator__table_showing profile-indicator__table_load-more');

--- a/src/js/profile/charts/utils.js
+++ b/src/js/profile/charts/utils.js
@@ -12,11 +12,11 @@ export const createFiltersForGroups = (groups) => {
   let filters = new Map();
   let signals = new Map();
   groups.forEach((group) => {
-    let { name:keyName } = group;
-    keyName = slugify(keyName)
+    let { name } = group;
+    let keyName = slugify(name)
     filters.set(keyName, {
       type: "filter",
-      expr: `!${keyName}Filter || (${keyName}Filter && datum.${keyName} === ${keyName}FilterValue)`
+      expr: `!${keyName}Filter || (${keyName}Filter && datum["${name}"] === ${keyName}FilterValue)`
     })
     signals.set(keyName, { name: `${keyName}Filter`, value: false })
     signals.set(`${keyName}Value`, { name: `${keyName}FilterValue`})


### PR DESCRIPTION
## Description

Fixing three issues with the charts and data tables:
* we call `appendDataToTable` every time the chart is filtered to update the values but before this change the "Show more rows" button would appear every time. we still need it in this method since the data could potentially (probably not though) increase.
* we need to slugify the name for vega but we still need the old name because the object still has the strange name as it's key (which it probably shouldn't)
* allow resetting of filters to work properly

## Related Issue


## How to test it locally
Look at a chart with long list of items so that you can see the data table with "Show more rows"
Make sure it only shows up once when you filter the chart.

Find a chart which has a name like "age  group" and filter by that value. it should work as well. 

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
