### PR TITLE
fixing the choropleth bug when a different subindicator is selected

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -114,8 +114,6 @@ export default class Controller extends Observable {
         this.state.subindicator = subindicator;
         this.state.selectedSubindicator = payload.selectedSubindicator;
 
-        console.log({'state': this.state})
-
         this.triggerEvent("map_explorer.subindicator.click", payload);
     };
 

--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -107,8 +107,14 @@ export default class Controller extends Observable {
             chartConfiguration: payload.indicators[payload.indicatorTitle].chartConfiguration,
             indicatorId: payload.indicatorId
         }
+        if (typeof subindicator.data.originalChildData !== 'undefined' && subindicator.data.originalChildData !== null) {
+            subindicator.data.child_data = subindicator.data.originalChildData;
+            subindicator.data.originalChildData = null;
+        }
         this.state.subindicator = subindicator;
         this.state.selectedSubindicator = payload.selectedSubindicator;
+
+        console.log({'state': this.state})
 
         this.triggerEvent("map_explorer.subindicator.click", payload);
     };
@@ -249,7 +255,7 @@ export default class Controller extends Observable {
         this.triggerEvent('controller.breadcrumbs.selected', payload);
         this.changeHash(payload.code)
     }
-    
+
     onTutorial(event, payload) {
         this.triggerEvent(event)
     }

--- a/src/js/profile/subindicator_filter.js
+++ b/src/js/profile/subindicator_filter.js
@@ -113,7 +113,7 @@ export class SubindicatorFilter extends Observable {
         if (i !== 0 && $(li).hasClass('selected')) {
           //leave the first item selected in default
           //                    $(li).removeClass('selected')
-          //                                    
+          //
         }
         if (typeof item.name === 'undefined') {
           $('.truncate', li).text(item);

--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -53,6 +53,9 @@ function loadAndDisplayChoropleth(payload, mapcontrol, showMapchip = false, chil
     const selectedSubindicator = ps.selectedSubindicator;
     const filter = ps.subindicator.filter;
     let data = ps.subindicator.data
-    if (childData) data.child_data = childData;
+    if (childData) {
+        data.originalChildData = data.child_data;
+        data.child_data = childData;
+    }
     mapcontrol.handleChoropleth(data, method, selectedSubindicator, indicatorTitle, showMapchip, filter);
 }


### PR DESCRIPTION
## Description
when a different subindicator or geo is selected, choropleth shows NaN values

## Related Issue
https://trello.com/c/caCk1qdt/775-nan-values-and-grey-choropleth-regions

## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
