### PR TITLE
choropleth filtering bug when after navigating to a child geography

### DIFF
--- a/__tests__/profile/subindicator.test.js
+++ b/__tests__/profile/subindicator.test.js
@@ -87,7 +87,7 @@ describe('SubindicatorFilter', () => {
     let dropdowns = $(document).find('.mapping-options__filter');
     const filterArea = $(document).find('.map-options__filters_content');
     applyFilter = jest.fn();
-    si = new SubindicatorFilter(filterArea, GROUPS, title, applyFilter, dropdowns, [], CHILD_DATA, true);
+    si = new SubindicatorFilter(filterArea, GROUPS, title, applyFilter, dropdowns, undefined, CHILD_DATA, true);
   })
 
 

--- a/src/js/profile/subindicator_filter.js
+++ b/src/js/profile/subindicator_filter.js
@@ -46,7 +46,9 @@ export class SubindicatorFilter extends Observable {
     let groupCallback = (selected) => this.groupSelected(selected, subindicatorDd, title);
 
     this.setOptionSelected(indicatorDd, this.selectedGroup, groupCallback);
+    $(indicatorDd).find('.dropdown__list_item.selected').click();
     this.setOptionSelected(subindicatorDd, selectedFilter, this.handleFilter);
+    $(subindicatorDd).find('.dropdown__list_item.selected').click();
 
   }
 
@@ -113,7 +115,7 @@ export class SubindicatorFilter extends Observable {
         if (i !== 0 && $(li).hasClass('selected')) {
           //leave the first item selected in default
           //                    $(li).removeClass('selected')
-          //                                    
+          //
         }
         if (typeof item.name === 'undefined') {
           $('.truncate', li).text(item);


### PR DESCRIPTION
## Description
Choropleth fills surrounds when changing filter after navigating to a child chography and changing a filter

## Related Issue
https://trello.com/c/DsxofFcc/774-choropleth-fills-surrounds-when-changing-filter-after-navigating-to-a-child-chography-and-changing-a-filter

## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
