### PR TITLE
fix: Prevent Tooltip from breaking the app

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -22,8 +22,6 @@ const graphValueTypes = {
 const chartContainerClass = ".indicator__chart";
 const tooltipClass = ".bar-chart__row_tooltip";
 
-let tooltipClone = null;
-
 const MAX_RICH_TABLE_ROWS = 7
 
 export class Chart extends Observable {
@@ -44,7 +42,6 @@ export class Chart extends Observable {
     this.selectedGroup = null;
     this.table = null;
 
-    tooltipClone = $(tooltipClass)[0].cloneNode(true);
     this.subCategoryNode = _subCategoryNode;
 
     const chartContainer = $(chartContainerClass, this.subCategoryNode);


### PR DESCRIPTION
## Description

If you open rich data view hover over a chart to get the tooltip and then click on different geography it will break

## Related Issue

fixes https://github.com/OpenUpSA/wazimap-ng-ui/issues/380

## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [ ]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
