### PR TITLE
fix: tooltips should update when filtering

### DIFF
--- a/src/js/profile/charts/barChart.js
+++ b/src/js/profile/charts/barChart.js
@@ -177,14 +177,14 @@ export const configureBarchart = (data, metadata, config) => {
             y: { scale: "yscale", field: {signal: "mainGroup"} },
             height: { scale: "yscale", band: 1 },
             x: { scale: "xscale", field: { signal: "datatype[Units]" } },
-            tooltip: {
-              signal: "{'percentage': format(datum.percentage, numberFormat.percentage), 'group': datum[mainGroup], 'count': format(datum.count, numberFormat.value)}"
-            }
           },
           update: {
             fill: { value: "rgb(57, 173, 132)" },
             x: { scale: "xscale", field: { signal: "datatype[Units]" } },
             x2: { scale: "xscale", value: 0 },
+            tooltip: {
+              signal: "{'percentage': format(datum.percentage, numberFormat.percentage), 'group': datum[mainGroup], 'count': format(datum.count, numberFormat.value)}"
+            }
           },
           hover: {
             fill: { value: "rgb(57, 173, 132, 0.7)" },


### PR DESCRIPTION
## Description
Tooltips did not update properly.
moving the tooltips into update makes sure they will get updated

## Related Issue
fixes #382 

## How to test it locally
Look at a chart in rich data view. Open a tooltip. then change the filter and the tooltip should update properly. 

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
