### PR TITLE
Fix/empty choropleth data

### DIFF
--- a/src/js/map/choropleth/choropleth.js
+++ b/src/js/map/choropleth/choropleth.js
@@ -73,6 +73,7 @@ export class Choropleth extends Observable {
     }
 
     showChoropleth(calculations, setLayerToSelected) {
+        this.reset(true);
         const self = this;
         const childGeographyValues = [...calculations];
         const values = childGeographyValues.map(el => el.val);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -315,9 +315,11 @@ export function filterAndSumGeoCounts(childData, primaryGroup, selectedSubindica
             return a[primaryGroup] === selectedSubindicator;
         });
 
+      if(filteredArr.length > 0) {
         sumData[code] = filteredArr.reduce(function (s, a) {
             return s + parseFloat(a.count);
         }, 0);
+      }
     })
 
     return sumData;


### PR DESCRIPTION
## Description

The choropleth was showing 0 for certain values when the geography had data for at least one subindicator (but not that specific one that you were looking at). 
And the choropleth did not reset when there was no data available for that geography but rather just updated the new values. 

This PR fixes both of those issues. 

## Related Issue
fixes #390 
and likely this one as well:
https://trello.com/c/2rKFaOJZ

## How to test it locally
Go to #geo:NW
profile sanef
select Spending of capital budget -> % of over spending
select different year ranges. 

you should see the choropleth resetting and updating correctly. 

## Screenshots

<img width="1386" alt="Bildschirmfoto 2021-06-08 um 14 40 16" src="https://user-images.githubusercontent.com/688980/121186556-83999800-c867-11eb-9462-9d73e88478a4.png">
<img width="1365" alt="Bildschirmfoto 2021-06-08 um 14 40 34" src="https://user-images.githubusercontent.com/688980/121186566-885e4c00-c867-11eb-901e-c3eb7a58b6c6.png">
<img width="1447" alt="Bildschirmfoto 2021-06-08 um 14 40 29" src="https://user-images.githubusercontent.com/688980/121186570-88f6e280-c867-11eb-8cca-e8f463132137.png">



## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
