### PR TITLE
Updating tables when charts are filtered

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -464,11 +464,11 @@ export class Chart extends Observable {
                     this.setDownloadUrl();
                     this.vegaView.signal(`${filterName}Filter`, true)
                     this.vegaView.signal(`${filterName}FilterValue`, sf.value)
-                    this.appendDataToTable()
                 }
             });
         }
-        this.vegaView.run()
+        this.vegaView.run();
+        this.appendDataToTable();
     };
 
     exportAsCsv = () => {


### PR DESCRIPTION
## Description
Updating the table when user applies filtering to a chart

## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/377

## How to test it locally
* expand the rich data panel
* apply filter to any chart
* confirm that the table data is updated and shows the filtered data

## Screenshots


## Changelog

### Added

### Updated
* `profile/chart.js` to call `this.appendDataToTable();` function after `this.vegaView.run();` so the table is renewed after vega data is ready

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
