### PR TITLE
excluding primary group from the non-aggregatable filter list

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -319,7 +319,9 @@ export class Chart extends Observable {
         let filtersToAdd = [];
         let defaultFilters = this.getDefaultFilters();
         let nonAggFilters = this.getNonAggFilters();
-        filtersToAdd = defaultFilters.concat(nonAggFilters);
+        filtersToAdd = defaultFilters.concat(nonAggFilters).filter((f) => {
+            return f.group !== indicators.metadata.primary_group
+        });
 
         for (let i = 1; i < filtersToAdd.length; i++) {
             this.addFilter(filtersToAdd[i].default);


### PR DESCRIPTION
## Description
not showing a filter for the main group even when it is flagged as non-aggregatable

## Related Issue


## How to test it locally


## Screenshots


## Changelog

### Added

### Updated
* `profile/chart.js` to filter out the primary group 

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
