### PR TITLE
preventing duplicate filter

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -321,6 +321,12 @@ export class Chart extends Observable {
         let nonAggFilters = this.getNonAggFilters();
         filtersToAdd = defaultFilters.concat(nonAggFilters);
 
+        filtersToAdd = filtersToAdd.filter((f, index, self) =>
+            index === self.findIndex((t) => (
+                t.group === f.group
+            ))
+        )
+
         for (let i = 1; i < filtersToAdd.length; i++) {
             this.addFilter(filtersToAdd[i].default);
         }


### PR DESCRIPTION
## Description
when a default filter group is also flagged as non-aggregatable, duplicate filters are created. 

## Related Issue


## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
