### PR TITLE
preventing duplicate default filter

### DIFF
--- a/src/js/elements/mapchip.js
+++ b/src/js/elements/mapchip.js
@@ -1,4 +1,4 @@
-import {checkIterate, getFilterGroups, Observable} from '../utils';
+import {appendFilterArrays, checkIterate, getFilterGroups, Observable} from '../utils';
 import {format as d3format} from 'd3-format';
 import {SubindicatorFilter} from "../profile/subindicator_filter";
 import DropdownMenu from "./dropdown_menu";
@@ -49,11 +49,41 @@ export class MapChip extends Observable {
         this.groups = groups;
 
         $(mapOptionsClass).find(`${filterRowClass}[data-isextra=true]`).remove();
+        $(mapOptionsClass).find(`${filterRowClass} .mapping-options__remove-filter`).addClass('is--hidden');
         const filterArea = $(mapOptionsClass).find(filterContentClass);
-        let defaultFilters = [];
+
+        //remove this
+        args.data.chartConfiguration.filter = {
+            defaults: [{
+                name: 'race',
+                value: 'Indian or Asian'
+            }]
+        };
+
+        args.data.metadata.groups[1].can_aggregate = false;
+        //remove this
+
+        let filtersToAdd = [];
         if (typeof args.filter !== 'undefined') {
-            Array.prototype.push.apply(defaultFilters, args.filter);
+            filtersToAdd = appendFilterArrays(filtersToAdd, args.filter, primaryGroup);
+        } else {
+            let defaultFilters = this.getDefaultFilters(args);
+            let nonAggFilters = this.getNonAggFilters(args);
+            filtersToAdd = appendFilterArrays(defaultFilters, nonAggFilters, primaryGroup);
         }
+
+        for (let i = 1; i < filtersToAdd.length; i++) {
+            this.addFilter(filtersToAdd[i].default);
+        }
+        let dropdowns = $(mapOptionsClass).find(`${filterRowClass} .mapping-options__filter`);
+
+        this.filter = new SubindicatorFilter(filterArea, groups, args.indicatorTitle, this.applyFilter, dropdowns, filtersToAdd, args.data.child_data, '.map-options__filter-row');
+
+        this.setAddFilterButton();
+    }
+
+    getDefaultFilters = (args) => {
+        let defaultFilters = [];
 
         if (typeof args.data.chartConfiguration.filter !== 'undefined') {
             args.data.chartConfiguration.filter['defaults'].forEach((f) => {
@@ -74,14 +104,33 @@ export class MapChip extends Observable {
             })
         }
 
-        for (let i = 1; i < defaultFilters.length; i++) {
-            this.addFilter(defaultFilters[i].default);
-        }
-        let dropdowns = $(mapOptionsClass).find(`${filterRowClass} .mapping-options__filter`);
+        return defaultFilters;
+    }
 
-        this.filter = new SubindicatorFilter(filterArea, groups, args.indicatorTitle, this.applyFilter, dropdowns, defaultFilters, args.data.child_data);
+    getNonAggFilters = (args) => {
+        let filterArr = [];
 
-        this.setAddFilterButton();
+        let nonAgg = [...args.data.metadata.groups].filter((g) => {
+            return !g.can_aggregate;
+        })
+        nonAgg.forEach((n) => {
+            let filter = {
+                group: n.name,
+                value: n.subindicators[Math.floor(Math.random() * n.subindicators.length)],
+                default: true
+            }
+
+            let item = filterArr.filter((df) => {
+                return df.group === n.name
+            })[0];
+            if (item !== null && typeof item !== 'undefined') {
+                item.default = true;
+            } else {
+                filterArr.push(filter);
+            }
+        })
+
+        return filterArr;
     }
 
     applyFilter = (filterResult, selectedFilter) => {
@@ -174,9 +223,8 @@ export class MapChip extends Observable {
         let subindicatorDd = $(filterRow).find('.mapping-options__filter')[1];
 
         $(filterRow).attr('data-isextra', true);
-        if (!isDefault) {
-            this.setRemoveFilter(filterRow, indicatorDd, subindicatorDd);
-        }
+        $(filterRow).attr('data-isdefault', isDefault);
+        this.setRemoveFilter(filterRow, indicatorDd, subindicatorDd, isDefault);
         $(filterRow).insertBefore($('a.mapping-options__add-filter'));
 
         new DropdownMenu($(filterRow));
@@ -189,12 +237,16 @@ export class MapChip extends Observable {
         }
     }
 
-    setRemoveFilter(filterRow, indicatorDd, subindicatorDd) {
+    setRemoveFilter(filterRow, indicatorDd, subindicatorDd, isDefault) {
         let btn = $(filterRow).find('.mapping-options__remove-filter');
-        btn.removeClass('is--hidden');
-        btn.on('click', () => {
-            this.removeFilter(filterRow, indicatorDd, subindicatorDd);
-        })
+        if (!isDefault) {
+            btn.removeClass('is--hidden');
+            btn.on('click', () => {
+                this.removeFilter(filterRow, indicatorDd, subindicatorDd);
+            })
+        } else {
+            btn.addClass('is--hidden');
+        }
     }
 
     removeFilter(filterRow, indicatorDd, subindicatorDd) {

--- a/src/js/elements/mapchip.js
+++ b/src/js/elements/mapchip.js
@@ -52,17 +52,6 @@ export class MapChip extends Observable {
         $(mapOptionsClass).find(`${filterRowClass} .mapping-options__remove-filter`).addClass('is--hidden');
         const filterArea = $(mapOptionsClass).find(filterContentClass);
 
-        //remove this
-        args.data.chartConfiguration.filter = {
-            defaults: [{
-                name: 'race',
-                value: 'Indian or Asian'
-            }]
-        };
-
-        args.data.metadata.groups[1].can_aggregate = false;
-        //remove this
-
         let filtersToAdd = [];
         if (typeof args.filter !== 'undefined') {
             filtersToAdd = appendFilterArrays(filtersToAdd, args.filter, primaryGroup);

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -1,7 +1,7 @@
 import {format as d3format} from "d3-format/src/defaultLocale";
 import {select as d3select} from "d3-selection";
 
-import {Observable} from "../utils";
+import {appendFilterArrays, Observable} from "../utils";
 import {defaultValues} from "../defaultValues";
 
 import {SubindicatorFilter} from "./subindicator_filter";
@@ -319,7 +319,7 @@ export class Chart extends Observable {
         let filtersToAdd = [];
         let defaultFilters = this.getDefaultFilters();
         let nonAggFilters = this.getNonAggFilters();
-        filtersToAdd = defaultFilters.concat(nonAggFilters);
+        filtersToAdd = appendFilterArrays(defaultFilters, nonAggFilters, indicators.metadata.primary_group);
 
         for (let i = 1; i < filtersToAdd.length; i++) {
             this.addFilter(filtersToAdd[i].default);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -376,3 +376,17 @@ export function getSheetName(name) {
 
     return sheetName;
 }
+
+export function appendFilterArrays(arr1, arr2, primaryGroup){
+    let filterArr = arr1.concat(arr2).filter((f) => {
+        return f.group !== primaryGroup
+    });;
+
+    filterArr = filterArr.filter((f, index, self) =>
+        index === self.findIndex((t) => (
+            t.group === f.group
+        ))
+    )
+
+    return filterArr;
+}

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -380,7 +380,7 @@ export function getSheetName(name) {
 export function appendFilterArrays(arr1, arr2, primaryGroup){
     let filterArr = arr1.concat(arr2).filter((f) => {
         return f.group !== primaryGroup
-    });;
+    });
 
     filterArr = filterArr.filter((f, index, self) =>
         index === self.findIndex((t) => (


### PR DESCRIPTION
## Description
* when a default filter group is also flagged as non-aggregatable, duplicate filters are created.
* not showing a filter for the main group even when it is flagged as non-aggregatable

includes https://github.com/OpenUpSA/wazimap-ng-ui/pull/405 and https://github.com/OpenUpSA/wazimap-ng-ui/pull/403 

## Related Issue


## How to test it locally


## Screenshots


## Changelog

### Added

### Updated
* `utils.js` to create a function that will append filter arrays together and remove the duplicates
* `mapchip.js` and `chart.js` to call the new function from `utils.js`
* `mapchip.js` to add the missing code

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
