### PR TITLE
resetting filters when selected subindicator is changed

### DIFF
--- a/src/js/profile/subindicator_filter.js
+++ b/src/js/profile/subindicator_filter.js
@@ -14,7 +14,7 @@ export class SubindicatorFilter extends Observable {
         this.groups = groups;
         this.filterRowClass = filterRowClass;
         this.defaultFilters = defaultFilters;
-        
+
         let dds = [];
         for (let i = 0; i < dropdowns.length / 2; i++) {
             let item = {};
@@ -274,6 +274,7 @@ export class SubindicatorFilter extends Observable {
             const dropdown = dropdowns[i];
             self.setOptionSelected(dropdown, DROPDOWN_MESSAGES[i], null);
         }
+        $(dropdowns[dropdowns.length - 1]).addClass('disabled');
     }
 
     setOptionSelected = (dropdown, value, callback) => {

--- a/src/js/profile/subindicator_filter.js
+++ b/src/js/profile/subindicator_filter.js
@@ -24,20 +24,20 @@ export class SubindicatorFilter extends Observable {
         }
         this.allDropdowns = dropdowns;
 
-
         const filtersAvailable = this.checkGroups(groups);
         if (filtersAvailable) {
             this.showFilterArea(filterArea);
+
+            this.resetDropdowns(dropdowns);
+            dds.forEach((dd) => {
+                let subindicatorDd = dd['subindicatorDd'];
+                let indicatorDd = dd['indicatorDd'];
+                this.setDropdownEvents(indicatorDd, subindicatorDd);
+            })
+            this.handleDefaultFilter(this.defaultFilters, dds);
         } else {
             this.hideFilterArea(filterArea);
         }
-        this.resetDropdowns(dropdowns);
-        dds.forEach((dd) => {
-            let subindicatorDd = dd['subindicatorDd'];
-            let indicatorDd = dd['indicatorDd'];
-            this.setDropdownEvents(indicatorDd, subindicatorDd);
-        })
-        this.handleDefaultFilter(this.defaultFilters, dds);
     }
 
     setDropdownEvents = (indicatorDd, subindicatorDd) => {
@@ -119,10 +119,8 @@ export class SubindicatorFilter extends Observable {
 
     hideFilterArea = (filterArea) => {
         if (!$(filterArea).hasClass('hidden')) {
-            $(filterArea).addClass('hidden')
-
+            $(filterArea).addClass('hidden');
         }
-
     }
 
     showFilterArea = (filterArea) => {


### PR DESCRIPTION
## Description
resetting filters when selected subindicator is changed

## Related Issue


## How to test it locally


## Screenshots


## Changelog

### Added

### Updated
* `subindicator_filter.js` to disable value dropdown when attribute dropdown resets

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
