### PR TITLE
Add functions to handle markdown based indicators

### DIFF
--- a/src/js/dataobjects.js
+++ b/src/js/dataobjects.js
@@ -26,10 +26,10 @@ export class IndicatorHelper {
         return indicator.metadata || {
             source: '',
             description: '',
-            url: '',
+            url: null,
             licence: {
                 name: '',
-                url: ''
+                url: null
             }
         }
     }

--- a/src/js/profile/html.js
+++ b/src/js/profile/html.js
@@ -2,7 +2,7 @@ import {Component} from "../utils";
 
 const chartContainerClass = ".indicator__chart";
 
-export class Text extends Component {
+export class Html extends Component {
     constructor(
         parent,
         data,
@@ -17,7 +17,7 @@ export class Text extends Component {
         this.addRawHtml(this._data);
     }
 
-    get html() {
+    get data() {
         return this._data;
     }
 

--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -1,5 +1,5 @@
 import {Chart} from './chart';
-import {Text} from './text';
+import {Html} from './html';
 import {Component, isNull, isEmptyString} from '../utils';
 
 let indicatorClone = null;
@@ -84,17 +84,17 @@ export class IndicatorBlock extends InfoBlock {
     }
 }
 
-export class MarkdownBlock extends InfoBlock {
+export class HtmlBlock extends InfoBlock {
     constructor(parent, formattingConfig, wrapper, title, indicatorData, detail, _isLast) {
         super(parent, formattingConfig, wrapper, title, indicatorData, detail, _isLast);
         this.wrapper = wrapper;
         this.title = title;
         this.detail = detail;
 
-        this.addMarkdown();
+        this.addHtml();
     }
-    addMarkdown() {
-        let c = new Text(this.Indicator, this.indicatorData);
+    addHtml() {
+        let c = new Html(this.Indicator, this.indicatorData);
 
         if (!isLast) {
             $(this.indicatorNode).removeClass('last');

--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -21,7 +21,7 @@ export class Indicator extends Component {
 
         isLast = _isLast;
 
-        if (indicatorData.chartConfiguration.rawText) {
+        if (indicatorData.chartConfiguration.rawHtml) {
             this.addIndicatorText(wrapper, title, indicatorData);
         }
         else {
@@ -33,17 +33,7 @@ export class Indicator extends Component {
         let indicatorNode = indicatorClone.cloneNode(true);
         $(indicatorTitleClass, indicatorNode).text(title);
         $(chartDescClass, indicatorNode).text(indicatorData.description);
-        const isLink = !isNull(indicatorData.metadata.url) && !isEmptyString(indicatorData.metadata.url);
-
-        if (isLink) {
-            let ele = $('<a></a>');
-            $(ele).text(indicatorData.metadata.source);
-            $(ele).attr('href', indicatorData.metadata.url);
-            $(ele).attr('target', '_blank');
-            $(sourceClass, indicatorNode).html(ele);
-        } else {
-            $(sourceClass, indicatorNode).text(indicatorData.metadata.source);
-        }
+        this.extractMetadata(indicatorData.metadata, indicatorNode);
 
         if (indicatorData.groups !== null && typeof indicatorData.groups !== 'undefined') {
             for (const [group, items] of Object.entries(indicatorData.groups)) {
@@ -78,17 +68,8 @@ export class Indicator extends Component {
         let indicatorNode = indicatorClone.cloneNode(true);
         $(indicatorTitleClass, indicatorNode).text(title);
         $(chartDescClass, indicatorNode).text(indicatorData.description);
-        const isLink = !isNull(indicatorData.metadata.url) && !isEmptyString(indicatorData.metadata.url);
 
-        if (isLink) {
-            let ele = $('<a></a>');
-            $(ele).text(indicatorData.metadata.source);
-            $(ele).attr('href', indicatorData.metadata.url);
-            $(ele).attr('target', '_blank');
-            $(sourceClass, indicatorNode).html(ele);
-        } else {
-            $(sourceClass, indicatorNode).text(indicatorData.metadata.source);
-        }
+        this.extractMetadata(indicatorData.metadata, indicatorNode);
 
         let c = new Text(this, indicatorNode, indicatorData);
 
@@ -97,5 +78,17 @@ export class Indicator extends Component {
         }
 
         wrapper.append(indicatorNode);
+    }
+
+    extractMetadata(metadata, indicatorNode) {
+        if (metadata.url) {
+            let ele = $('<a></a>');
+            $(ele).text(metadata.source);
+            $(ele).attr('href', metadata.url);
+            $(ele).attr('target', '_blank');
+            $(sourceClass, indicatorNode).html(ele);
+        } else {
+            $(sourceClass, indicatorNode).text(metadata.source);
+        }
     }
 }

--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -21,10 +21,14 @@ export class InfoBlock extends Component {
 
         isLast = _isLast;
 
+        this.prepareDomElements(this.indicatorNode, this.title, this.indicatorData);
+    }
+
+    prepareDomElements(indicatorNode, title, indicatorData) {
         this.indicatorNode = indicatorClone.cloneNode(true);
-        $(indicatorTitleClass, this.indicatorNode).text(this.title);
-        $(chartDescClass, this.indicatorNode).text(this.indicatorData.description);
-        this.extractMetadata(this.indicatorData.metadata, this.indicatorNode);
+        $(indicatorTitleClass, indicatorNode).text(title);
+        $(chartDescClass, indicatorNode).text(indicatorData.description);
+        this.extractMetadata(indicatorData.metadata, indicatorNode);
     }
 
     extractMetadata(metadata, indicatorNode) {

--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -1,4 +1,5 @@
 import {Chart} from './chart';
+import {Text} from './text';
 import {Component, isNull, isEmptyString} from '../utils';
 
 let indicatorClone = null;
@@ -20,7 +21,12 @@ export class Indicator extends Component {
 
         isLast = _isLast;
 
-        this.addIndicatorChart(wrapper, title, indicatorData, detail);
+        if (indicatorData.chartConfiguration.rawText) {
+            this.addIndicatorText(wrapper, title, indicatorData);
+        }
+        else {
+            this.addIndicatorChart(wrapper, title, indicatorData, detail);
+        }
     }
 
     addIndicatorChart(wrapper, title, indicatorData, detail) {
@@ -66,5 +72,30 @@ export class Indicator extends Component {
             wrapper.append(indicatorNode);
 
         }
+    }
+
+    addIndicatorText(wrapper, title, indicatorData) {
+        let indicatorNode = indicatorClone.cloneNode(true);
+        $(indicatorTitleClass, indicatorNode).text(title);
+        $(chartDescClass, indicatorNode).text(indicatorData.description);
+        const isLink = !isNull(indicatorData.metadata.url) && !isEmptyString(indicatorData.metadata.url);
+
+        if (isLink) {
+            let ele = $('<a></a>');
+            $(ele).text(indicatorData.metadata.source);
+            $(ele).attr('href', indicatorData.metadata.url);
+            $(ele).attr('target', '_blank');
+            $(sourceClass, indicatorNode).html(ele);
+        } else {
+            $(sourceClass, indicatorNode).text(indicatorData.metadata.source);
+        }
+
+        let c = new Text(this, indicatorNode, indicatorData);
+
+        if (!isLast) {
+            $(indicatorNode).removeClass('last');
+        }
+
+        wrapper.append(indicatorNode);
     }
 }

--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -16,19 +16,20 @@ export class InfoBlock extends Component {
         this.groups = [];
         this.indicatorData = indicatorData;
         this.formattingConfig = formattingConfig;
+        this.title = title;
 
         indicatorClone = $(indicatorClass)[0].cloneNode(true);
 
         isLast = _isLast;
 
-        this.prepareDomElements(this.indicatorNode, this.title, this.indicatorData);
+        this.prepareDomElements(this.title, this.indicatorData);
     }
 
-    prepareDomElements(indicatorNode, title, indicatorData) {
+    prepareDomElements(title, indicatorData) {
         this.indicatorNode = indicatorClone.cloneNode(true);
-        $(indicatorTitleClass, indicatorNode).text(title);
-        $(chartDescClass, indicatorNode).text(indicatorData.description);
-        this.extractMetadata(indicatorData.metadata, indicatorNode);
+        $(indicatorTitleClass, this.indicatorNode).text(title);
+        $(chartDescClass, this.indicatorNode).text(indicatorData.description);
+        this.extractMetadata(indicatorData.metadata, this.indicatorNode);
     }
 
     extractMetadata(metadata, indicatorNode) {
@@ -46,7 +47,6 @@ export class InfoBlock extends Component {
 
 export class IndicatorBlock extends InfoBlock {
     constructor(parent, formattingConfig, wrapper, title, indicatorData, detail, _isLast) {
-    //constructor(wrapper, title, indicatorData, detail) {
         super(parent, formattingConfig, wrapper, title, indicatorData, detail, _isLast);
         this.wrapper = wrapper;
         this.title = title;

--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -71,7 +71,7 @@ export class Indicator extends Component {
 
         this.extractMetadata(indicatorData.metadata, indicatorNode);
 
-        let c = new Text(this, indicatorNode, indicatorData);
+        let c = new Text(this, indicatorData.html);
 
         if (!isLast) {
             $(indicatorNode).removeClass('last');

--- a/src/js/profile/indicator.js
+++ b/src/js/profile/indicator.js
@@ -10,7 +10,7 @@ const indicatorTitleClass = '.profile-indicator__title h4';
 const chartDescClass = '.profile-indicator__chart_description p';
 const sourceClass = '.data-source';
 
-export class Indicator extends Component {
+export class InfoBlock extends Component {
     constructor(parent, formattingConfig, wrapper, title, indicatorData, detail, _isLast) {
         super(parent);
         this.groups = [];
@@ -21,63 +21,10 @@ export class Indicator extends Component {
 
         isLast = _isLast;
 
-        if (indicatorData.chartConfiguration.rawHtml) {
-            this.addIndicatorText(wrapper, title, indicatorData);
-        }
-        else {
-            this.addIndicatorChart(wrapper, title, indicatorData, detail);
-        }
-    }
-
-    addIndicatorChart(wrapper, title, indicatorData, detail) {
-        let indicatorNode = indicatorClone.cloneNode(true);
-        $(indicatorTitleClass, indicatorNode).text(title);
-        $(chartDescClass, indicatorNode).text(indicatorData.description);
-        this.extractMetadata(indicatorData.metadata, indicatorNode);
-
-        if (indicatorData.groups !== null && typeof indicatorData.groups !== 'undefined') {
-            for (const [group, items] of Object.entries(indicatorData.groups)) {
-                this.groups.push(group);
-            }
-        }
-
-
-        const configuration = detail.indicators[title].chartConfiguration;
-        const indicators = detail.indicators;
-
-        let hasValues = this.indicatorData.data.some(function(e) { return e.count > 0 });
-
-        if (hasValues) {
-            let c = new Chart(this, configuration, indicatorData, this.groups, indicatorNode, title);
-            this.bubbleEvents(c, [
-                'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
-                'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
-                'point_tray.subindicator_filter.filter'
-            ]);
-
-            if (!isLast) {
-                $(indicatorNode).removeClass('last');
-            }
-
-            wrapper.append(indicatorNode);
-
-        }
-    }
-
-    addIndicatorText(wrapper, title, indicatorData) {
-        let indicatorNode = indicatorClone.cloneNode(true);
-        $(indicatorTitleClass, indicatorNode).text(title);
-        $(chartDescClass, indicatorNode).text(indicatorData.description);
-
-        this.extractMetadata(indicatorData.metadata, indicatorNode);
-
-        let c = new Text(this, indicatorData.html);
-
-        if (!isLast) {
-            $(indicatorNode).removeClass('last');
-        }
-
-        wrapper.append(indicatorNode);
+        this.indicatorNode = indicatorClone.cloneNode(true);
+        $(indicatorTitleClass, this.indicatorNode).text(this.title);
+        $(chartDescClass, this.indicatorNode).text(this.indicatorData.description);
+        this.extractMetadata(this.indicatorData.metadata, this.indicatorNode);
     }
 
     extractMetadata(metadata, indicatorNode) {
@@ -90,5 +37,65 @@ export class Indicator extends Component {
         } else {
             $(sourceClass, indicatorNode).text(metadata.source);
         }
+    }
+}
+
+export class IndicatorBlock extends InfoBlock {
+    constructor(parent, formattingConfig, wrapper, title, indicatorData, detail, _isLast) {
+    //constructor(wrapper, title, indicatorData, detail) {
+        super(parent, formattingConfig, wrapper, title, indicatorData, detail, _isLast);
+        this.wrapper = wrapper;
+        this.title = title;
+        this.detail = detail;
+        this.addIndicator();
+    }
+    addIndicator() {
+
+        if (this.indicatorData.groups !== null && typeof this.indicatorData.groups !== 'undefined') {
+            for (const [group, items] of Object.entries(this.indicatorData.groups)) {
+                this.groups.push(group);
+            }
+        }
+
+
+        const configuration = this.detail.indicators[this.title].chartConfiguration;
+        const indicators = this.detail.indicators;
+
+        let hasValues = this.indicatorData.data.some(function(e) { return e.count > 0 });
+
+        if (hasValues) {
+            let c = new Chart(this.Indicator, configuration, this.indicatorData, this.groups, this.indicatorNode, this.title);
+            this.bubbleEvents(c, [
+                'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
+                'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
+                'point_tray.subindicator_filter.filter'
+            ]);
+
+            if (!isLast) {
+                $(this.indicatorNode).removeClass('last');
+            }
+
+            this.wrapper.append(this.indicatorNode);
+        }
+    }
+}
+
+export class MarkdownBlock extends InfoBlock {
+    constructor(parent, formattingConfig, wrapper, title, indicatorData, detail, _isLast) {
+        super(parent, formattingConfig, wrapper, title, indicatorData, detail, _isLast);
+        this.wrapper = wrapper;
+        this.title = title;
+        this.detail = detail;
+
+        this.addMarkdown();
+    }
+    addMarkdown() {
+        let c = new Text(this.Indicator, this.indicatorData);
+
+        if (!isLast) {
+            $(this.indicatorNode).removeClass('last');
+        }
+
+        this.wrapper.append(this.indicatorNode);
     }
 }

--- a/src/js/profile/subcategory.js
+++ b/src/js/profile/subcategory.js
@@ -1,5 +1,5 @@
 import {IndicatorBlock} from "./indicator";
-import {MarkdownBlock} from "./indicator";
+import {HtmlBlock} from "./indicator";
 import {Component, formatNumericalValue} from "../utils";
 
 let isFirst = false;
@@ -57,7 +57,7 @@ export class Subcategory extends Component {
                 if (typeof indicatorData.data !== 'undefined') {
                     let isLast = index === lastIndex;
                     if (indicatorData.html) {
-                        let i = new MarkdownBlock(this, formattingConfig, wrapper, title, indicatorData, detail, isLast);
+                        let i = new HtmlBlock(this, formattingConfig, wrapper, title, indicatorData, detail, isLast);
                     } else {
                         let i = new IndicatorBlock(this, formattingConfig, wrapper, title, indicatorData, detail, isLast);
                         this.bubbleEvents(i, [

--- a/src/js/profile/subcategory.js
+++ b/src/js/profile/subcategory.js
@@ -56,12 +56,16 @@ export class Subcategory extends Component {
             for (const [title, indicatorData] of Object.entries(detail.indicators)) {
                 if (typeof indicatorData.data !== 'undefined') {
                     let isLast = index === lastIndex;
-                    let i = new IndicatorBlock(this, formattingConfig, wrapper, title, indicatorData, detail, isLast);
-                    this.bubbleEvents(i, [
-                        'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
-                        'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
-                        'point_tray.subindicator_filter.filter'
-                    ]);
+                    if (indicatorData.html) {
+                        let i = new MarkdownBlock(this, formattingConfig, wrapper, title, indicatorData, detail, isLast);
+                    } else {
+                        let i = new IndicatorBlock(this, formattingConfig, wrapper, title, indicatorData, detail, isLast);
+                        this.bubbleEvents(i, [
+                            'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
+                            'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
+                            'point_tray.subindicator_filter.filter'
+                        ]);
+                    }
                     index++;
                 } else {
                     $(wrapper).find(descriptionTextClass).text('No data available for this indicator for this geographic area');

--- a/src/js/profile/subcategory.js
+++ b/src/js/profile/subcategory.js
@@ -1,4 +1,5 @@
-import {Indicator} from "./indicator";
+import {IndicatorBlock} from "./indicator";
+import {MarkdownBlock} from "./indicator";
 import {Component, formatNumericalValue} from "../utils";
 
 let isFirst = false;
@@ -55,7 +56,7 @@ export class Subcategory extends Component {
             for (const [title, indicatorData] of Object.entries(detail.indicators)) {
                 if (typeof indicatorData.data !== 'undefined') {
                     let isLast = index === lastIndex;
-                    let i = new Indicator(this, formattingConfig, wrapper, title, indicatorData, detail, isLast);
+                    let i = new IndicatorBlock(this, formattingConfig, wrapper, title, indicatorData, detail, isLast);
                     this.bubbleEvents(i, [
                         'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
                         'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',

--- a/src/js/profile/text.js
+++ b/src/js/profile/text.js
@@ -12,7 +12,7 @@ export class Text extends Component {
 
         const chartContainer = $(chartContainerClass);
         this.container = chartContainer[0];
-        this.containerParent = $(this.container).closest('.profile-indicator');
+        this.containerParent = $(this.container).closest('.profile-indicator__chart_body');
 
         this.addRawHtml(this._data);
     }

--- a/src/js/profile/text.js
+++ b/src/js/profile/text.js
@@ -1,0 +1,20 @@
+import {Component} from "../utils";
+
+export class Text extends Component {
+    constructor(
+        parent,
+        data,
+    ) {
+        super(parent);
+        this.data = data;
+        
+        this.addRawText(data);
+    }
+
+    addRawText = (data) => {
+        $(".bar-chart", this.container).remove();
+        $(".profile-indicator__filters-wrapper", this.container).remove();
+        
+        // Display data
+    };
+}

--- a/src/js/profile/text.js
+++ b/src/js/profile/text.js
@@ -1,5 +1,7 @@
 import {Component} from "../utils";
 
+const chartContainerClass = ".indicator__chart";
+
 export class Text extends Component {
     constructor(
         parent,
@@ -7,6 +9,10 @@ export class Text extends Component {
     ) {
         super(parent);
         this._data = data;
+
+        const chartContainer = $(chartContainerClass);
+        this.container = chartContainer[0];
+        this.containerParent = $(this.container).closest('.profile-indicator');
 
         this.addRawHtml(this._data);
     }
@@ -19,6 +25,12 @@ export class Text extends Component {
         $(".bar-chart").remove();
         $(".profile-indicator__filters-wrapper").remove();
 
-        $(".indicator__chart").append(data);
+        this.containerParent.find('.indicator__chart').remove();
+
+        this.rawHtml = document.createElement('div');
+        $(this.rawHtml).addClass('profile-indicator__html');
+        $(this.rawHtml).append(data.html);
+
+        this.containerParent.append(this.rawHtml);
     };
 }

--- a/src/js/profile/text.js
+++ b/src/js/profile/text.js
@@ -24,6 +24,8 @@ export class Text extends Component {
     addRawHtml = (data) => {
         $(".bar-chart").remove();
         $(".profile-indicator__filters-wrapper").remove();
+        $(".profile-indicator__chart_footer").remove();
+        $(".profile-indicator__options").remove();
 
         this.containerParent.find('.indicator__chart').remove();
 

--- a/src/js/profile/text.js
+++ b/src/js/profile/text.js
@@ -6,15 +6,19 @@ export class Text extends Component {
         data,
     ) {
         super(parent);
-        this.data = data;
-        
-        this.addRawText(data);
+        this._data = data;
+
+        this.addRawHtml(this._data);
     }
 
-    addRawText = (data) => {
-        $(".bar-chart", this.container).remove();
-        $(".profile-indicator__filters-wrapper", this.container).remove();
+    get html() {
+        return this._data;
+    }
+
+    addRawHtml = (data) => {
+        $(".bar-chart").remove();
+        $(".profile-indicator__filters-wrapper").remove();
         
-        // Display data
+        $(".indicator__chart").append("<p>placeholder</p>");
     };
 }

--- a/src/js/profile/text.js
+++ b/src/js/profile/text.js
@@ -18,7 +18,7 @@ export class Text extends Component {
     addRawHtml = (data) => {
         $(".bar-chart").remove();
         $(".profile-indicator__filters-wrapper").remove();
-        
-        $(".indicator__chart").append("<p>placeholder</p>");
+
+        $(".indicator__chart").append(data);
     };
 }


### PR DESCRIPTION
## Description

Adding initial functions to handle markdown (HTML as far as the frontend is concerned) based indicators

subcategory.js expects indicatorData.html to be set to display an HTML block instead of an indicator


## Related Issue
https://trello.com/c/XDzZvYXd/802-rich-text-indicator-as-a-user-i-would-like-to-find-qualitative-data-like-audit-outcomes-and-links-to-important-documents-specifi

## How to test it locally


## Screenshots


## Changelog

### Added
Markdown indicators
### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
