### PR TITLE
fixing the bug that breaks the map when moving between different indicators

### DIFF
--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -55,7 +55,7 @@ function loadAndDisplayChoropleth(payload, mapcontrol, showMapchip = false, chil
     const filter = ps.subindicator.filter;
     let data = ps.subindicator.data
     if (childData) {
-        data.originalChildData = (typeof data.originalChildData !== 'undefined') ? data.originalChildData : data.child_data;
+        data.originalChildData = (typeof data.originalChildData !== 'undefined' && data.originalChildData !== null) ? data.originalChildData : data.child_data;
         data.child_data = childData;
     }
     mapcontrol.handleChoropleth(data, method, selectedSubindicator, indicatorTitle, showMapchip, filter);

--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -10,7 +10,7 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
     //let the choropleth persist
     controller.on('profile.loaded', payload => controller.handleNewProfileChoropleth())
     controller.on('mapchip.removed', payload => mapcontrol.choropleth.reset(true));
-    controller.on('data_mapper_menu.nodata', payload => mapchip.removeMapChip()) 
+    controller.on('data_mapper_menu.nodata', payload => mapchip.removeMapChip())
     controller.bubbleEvents(mapcontrol, ['map.choropleth.display', 'map.choropleth.reset']);
 
     controller.on('mapchip.choropleth.filtered', payload => {
@@ -55,7 +55,7 @@ function loadAndDisplayChoropleth(payload, mapcontrol, showMapchip = false, chil
     const filter = ps.subindicator.filter;
     let data = ps.subindicator.data
     if (childData) {
-        data.originalChildData = data.child_data;
+        data.originalChildData = (typeof data.originalChildData !== 'undefined') ? data.originalChildData : data.child_data;
         data.child_data = childData;
     }
     mapcontrol.handleChoropleth(data, method, selectedSubindicator, indicatorTitle, showMapchip, filter);


### PR DESCRIPTION
## Description
checking and fixing the bug that breaks the map when moving between different indicators

## Related Issue
https://trello.com/c/X9xKYyF0/819-the-map-broke-when-moving-between-different-indicators

## How to test it locally
1. go to NEET NEET
2. change age to 20-24
3. add gender filter to female
go to Employment > employment status > employed
4. go back to NEET > NEET
5. confirm that the choropleth is working

## Screenshots


## Changelog

### Added

### Updated
* `setup/choropleth.js` to modify `originalChildData` only when it is undefined

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
