### PR TITLE
recalculate tooltip position using window height

### DIFF
--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -70,6 +70,9 @@ export class Chart extends Component {
                 x = +event.pageX - offsetX - tooltipBox.width;
             }
             let y = event.pageY + offsetY;
+            if (y < window.innerHeight) {
+              y = window.innerHeight + offsetY;
+            }
             if (y + tooltipBox.height > window.innerHeight) {
                 y = +event.pageY - offsetY - tooltipBox.height;
             }
@@ -111,7 +114,7 @@ export class Chart extends Component {
             const {x, y} = calculatePosition(
                 event,
                 this.el.getBoundingClientRect(),
-                10, 10
+                0, 10
             );
             this.el.setAttribute('style', `top: ${y}px; left: ${x}px; z-index: 999;`);
         }


### PR DESCRIPTION
## Description

We were using the mouse position and the defined offset values to calculate the placement of the tooltip, this is achieved by getting the value provided by `event.pageH`
It happens that the topmost chart does not have a high enough mouse y-coordinate for the best tooltip placement.

A remedy for this case is to ensure that if the mouse coordinate is not sufficient, we switch to using the window innerHeight.
It makes sense to only consider doing this for the height because once the page is loaded, the width remains constant but the height is dependent on the DOM scroll position.

## Related Issue

Trello: https://trello.com/c/nwZZhSTs/786-tooltip-point-is-confused-when-mouse-is-at-the-top-of-the-chart-est-2-3-hours

## How to test it locally

Open the rich data panel and hover over the first chart, the tooltip should now be above the cursor.

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
