### PR TITLE
show profile indicator description on mapchip

### DIFF
--- a/src/js/elements/mapchip.js
+++ b/src/js/elements/mapchip.js
@@ -40,7 +40,7 @@ export class MapChip extends Component {
         $(mapOptionsClass).show();  //webflow.js adds display:none when clicked on x
         $(mapOptionsClass).find('.filters__header_close').on('click', () => this.removeMapChip());
 
-        $('.map-options__context .map-option__context_text div').text(args.description);
+        $('.map-options__context .map-option__context_text div').text(args.data.description);
         this.handleChoroplethFilter(args);
     }
 


### PR DESCRIPTION
## Description

The description on map chip on data mapper should come from profile indicator as with rich data view, not from the dataset. 

## Related Issue


## How to test it locally

I located a profile indicator with no description and the map chip does not show any description.

![Screenshot from 2021-06-25 10-30-41](https://user-images.githubusercontent.com/6994982/123387572-9c60b800-d5a0-11eb-89e0-75bb69de3799.png)

I went to the staging admin panel and added a test description on the profile indicator.
Example: https://staging.wazimap-ng.openup.org.za/admin/profile/profileindicator/?q=Population+By+Gender&profile__name=Youth+Explorer

The description shows up on the map chip as expected.

![Screenshot from 2021-06-25 10-29-58](https://user-images.githubusercontent.com/6994982/123387751-cade9300-d5a0-11eb-9773-9e684f7f81aa.png)


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
