### PR TITLE
Add a notice to mapchip in case a geography returns NaN

### DIFF
--- a/src/js/elements/mapchip.js
+++ b/src/js/elements/mapchip.js
@@ -139,27 +139,34 @@ export class MapChip extends Component {
     }
 
     showLegend(colors, intervals) {
-        if (colors.length != intervals.length)
-            throw "Expected the number of intervals to be the same as the number of colours."
+        if (isNaN(intervals[0])) {
+            $('.map-options__legend_wrap').text("No data available for this indicator for this geographic area");
+            $('.map-options__legend_label').addClass('hidden');
+        }
+        else {
+            $('.map-options__legend_label').removeClass('hidden');
+            if (colors.length != intervals.length)
+                throw "Expected the number of intervals to be the same as the number of colours."
 
-        const legend = $(this.clonedLegend);
-        const fmt = d3format(".1%")
+            const legend = $(this.clonedLegend);
+            const fmt = d3format(".1%")
 
-        $(mapOptionsClass).find('.map-options__legend_wrap').html('');
+            $(mapOptionsClass).find('.map-options__legend_wrap').html('');
 
-        for (let i = 0; i < intervals.length; i++) {
-            const interval = intervals[i];
-            const item = this.clonedLegendBlock.cloneNode(true);
-            const label = interval;
+            for (let i = 0; i < intervals.length; i++) {
+                const interval = intervals[i];
+                const item = this.clonedLegendBlock.cloneNode(true);
+                const label = interval;
 
-            if (i >= lightStart) {
-                $(item).addClass('light');
+                if (i >= lightStart) {
+                    $(item).addClass('light');
+                }
+
+                $('.truncate', item).text(label);
+                $(item).css('background-color', colors[i]);
+                $(item).css('opacity', this.legendColors.opacity);
+                $(mapOptionsClass).find('.map-options__legend_wrap').append(item);
             }
-
-            $('.truncate', item).text(label);
-            $(item).css('background-color', colors[i]);
-            $(item).css('opacity', this.legendColors.opacity);
-            $(mapOptionsClass).find('.map-options__legend_wrap').append(item);
         }
     }
 


### PR DESCRIPTION
## Description

There have been various cases where a geography does not return data, whether by error or the data does not exist. This change will show a notice to the user instead of "Nan" values when this happens

## Related Issue
https://trello.com/c/A7Es2N7g/811-nan-on-data-mapper-legend-when-none-child-geographies-have-data-for-the-selected-subindicator-2-3-hours

## How to test it locally
On SANEF goto data mapper > financial performance > spending of capital budget > % of budget over-spent > 2017-2018

## Screenshots
![image](https://user-images.githubusercontent.com/9511724/123406474-404f6100-d5ab-11eb-93a0-b8f9b9036051.png)


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
