### PR TITLE
Do not display subindicators if they have no data

### DIFF
--- a/src/js/elements/menu.js
+++ b/src/js/elements/menu.js
@@ -1,5 +1,5 @@
 import {SubIndicator} from '../dataobjects'
-import {checkIfSubIndicatorHasData, checkIfSubCategoryHasChildren, checkIfCategoryHasChildren, Component} from '../utils'
+import {checkIfSubCategoryHasChildren, checkIfCategoryHasChildren, Component} from '../utils'
 
 const hideondeployClsName = 'hideondeploy';
 const parentContainer = $(".data-mapper-content__list");
@@ -49,7 +49,7 @@ export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
         if (groups !== null && typeof groups.subindicators !== 'undefined') {
 
             groups.subindicators.forEach((subindicator) => {
-                let display = checkIfSubIndicatorHasData(subindicator, indicatorDetail);
+                let display = subindicatorHasData(subindicator, indicatorDetail);
 
                 if (display) {
                     const newSubIndicatorElement = indicatorItemTemplate.cloneNode(true);
@@ -134,6 +134,20 @@ export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
 
     function resetActive() {
         $(".menu__link_h4--active", parentContainer).removeClass("menu__link_h4--active");
+    }
+
+    function subindicatorHasData(subindicator, detail) {
+        let hasData = false;
+        for (const [geography, data] of Object.entries(detail.child_data)) {
+            data.forEach((indicatorDataPoint) => {
+                for (const [title, value] of Object.entries(indicatorDataPoint)) {
+                    if (subindicator == value) {
+                        hasData = true;
+                    }
+                }
+            })
+        }
+        return hasData;
     }
 
     $(".data-menu__category").remove();

--- a/src/js/elements/menu.js
+++ b/src/js/elements/menu.js
@@ -1,5 +1,5 @@
 import {SubIndicator} from '../dataobjects'
-import {checkIfSubCategoryHasChildren, checkIfCategoryHasChildren, Component} from '../utils'
+import {checkIfSubIndicatorHasData, checkIfSubCategoryHasChildren, checkIfCategoryHasChildren, Component} from '../utils'
 
 const hideondeployClsName = 'hideondeploy';
 const parentContainer = $(".data-mapper-content__list");
@@ -41,39 +41,44 @@ function subindicatorsInIndicator(indicator) {
 
 // TODO this entire file needs to be refactored to use thhe observer pattern
 export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
-    function addSubIndicators(wrapper, category, subcategory, indicator, groups, indicators, choropleth_method, indicatorId) {
+    function addSubIndicators(wrapper, category, subcategory, indicator, groups, indicators, indicatorDetail) {
 
         $(".data-category__h3", wrapper).remove();
         $(".data-category__h4", wrapper).remove();
 
         if (groups !== null && typeof groups.subindicators !== 'undefined') {
+
             groups.subindicators.forEach((subindicator) => {
-                const newSubIndicatorElement = indicatorItemTemplate.cloneNode(true);
-                $(".truncate", newSubIndicatorElement).text(subindicator);
-                $(newSubIndicatorElement).attr('title', subindicator);
+                let display = checkIfSubIndicatorHasData(subindicator, indicatorDetail);
 
-                wrapper.append(newSubIndicatorElement);
+                if (display) {
+                    const newSubIndicatorElement = indicatorItemTemplate.cloneNode(true);
+                    $(".truncate", newSubIndicatorElement).text(subindicator);
+                    $(newSubIndicatorElement).attr('title', subindicator);
 
-                const parents = {
-                    category: category,
-                    subcategory: subcategory,
-                    indicator: indicator
+                    wrapper.append(newSubIndicatorElement);
+
+                    const parents = {
+                        category: category,
+                        subcategory: subcategory,
+                        indicator: indicator
+                    }
+
+                    $(newSubIndicatorElement).on("click", (el) => {
+                        setActive(el);
+                        if (subindicatorCallback != undefined)
+                            subindicatorCallback({
+                                el: el,
+                                data: data,
+                                indicatorTitle: indicator,
+                                selectedSubindicator: subindicator,
+                                indicators: indicators,
+                                parents: parents,
+                                choropleth_method: indicatorDetail.choropleth_method,
+                                indicatorId: indicatorDetail.id
+                            })
+                    });
                 }
-
-                $(newSubIndicatorElement).on("click", (el) => {
-                    setActive(el);
-                    if (subindicatorCallback != undefined)
-                        subindicatorCallback({
-                            el: el,
-                            data: data,
-                            indicatorTitle: indicator,
-                            selectedSubindicator: subindicator,
-                            indicators: indicators,
-                            parents: parents,
-                            choropleth_method: choropleth_method,
-                            indicatorId: indicatorId
-                        })
-                });
             });
         }
     }
@@ -96,7 +101,7 @@ export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
             const childWrapper = $(newIndicator).find('.data-category__h3_wrapper');
 
             let subindicators = detail.metadata.groups.filter((group) => group.name === detail.metadata.primary_group)[0];
-            addSubIndicators(childWrapper, category, subcategory, indicator, subindicators, indicators, detail.choropleth_method, detail.id);
+            addSubIndicators(childWrapper, category, subcategory, indicator, subindicators, indicators, detail);
         }
     }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -345,6 +345,21 @@ export function checkIfSubCategoryHasChildren(subcategory, detail) {
     return hasChildren;
 }
 
+export function checkIfSubIndicatorHasData(subindicator, detail) {
+    let hasData = false;
+    for (const [geography, data] of Object.entries(detail.child_data)) {
+        data.forEach((indicatorDataPoint) => {
+            for (const [title, value] of Object.entries(indicatorDataPoint)) {
+                if (subindicator == value) {
+                    hasData = true;
+                }
+            }
+        })
+    }
+
+    return hasData;
+}
+
 export function filterAndSumGeoCounts(childData, primaryGroup, selectedSubindicator) {
     let sumData = {};
     Object.entries(childData).map(([code, data]) => {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -345,21 +345,6 @@ export function checkIfSubCategoryHasChildren(subcategory, detail) {
     return hasChildren;
 }
 
-export function checkIfSubIndicatorHasData(subindicator, detail) {
-    let hasData = false;
-    for (const [geography, data] of Object.entries(detail.child_data)) {
-        data.forEach((indicatorDataPoint) => {
-            for (const [title, value] of Object.entries(indicatorDataPoint)) {
-                if (subindicator == value) {
-                    hasData = true;
-                }
-            }
-        })
-    }
-
-    return hasData;
-}
-
 export function filterAndSumGeoCounts(childData, primaryGroup, selectedSubindicator) {
     let sumData = {};
     Object.entries(childData).map(([code, data]) => {


### PR DESCRIPTION
## Description

In some cases subindicators do not have data for all geographies. When the user happens to view an an area e.g. a district, where no geographies have data, the subindicator was still added to the menu and when selected displayed NaN values on the mapchip

## Related Issue
https://trello.com/c/A7Es2N7g/811-nan-on-data-mapper-legend-when-none-child-geographies-have-data-for-the-selected-subindicator-2-3-hours

## How to test it locally
Please see the screen shot for example

## Screenshots
![image](https://user-images.githubusercontent.com/9511724/123444193-ea90ae00-d5d6-11eb-9444-58925ba7f355.png)


## Changelog

### Added

### Updated
Subindicators without data are no longer displayed

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
