### PR TITLE
persisting choropleth while switching from main place to ward

### DIFF
--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -41,6 +41,9 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
         mapchip.onSubIndicatorChange(args);
     });
 
+    controller.on('redraw', payload => {
+        controller.handleNewProfileChoropleth()
+    })
 }
 
 function loadAndDisplayChoropleth(payload, mapcontrol, showMapchip = false, childData = null) {


### PR DESCRIPTION
## Description
Preventing choropleth dissappearing when switching between mainplace and ward.

## Related Issue
https://trello.com/c/EyCmOA5w/810-map-isnt-coloured-when-i-switch-from-main-place-to-ward-breakdown-timebox-05

## How to test it locally
* navigate to a geography that has both wards and mainplaces
* open data mapper
* select a subindicator
* switch to wards
* confirm that the choropleth is displayed

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/123777689-21b5d680-d8d9-11eb-860e-3bbd1103672e.png)
![image](https://user-images.githubusercontent.com/53019884/123777716-27abb780-d8d9-11eb-824f-4d2dce2de008.png)


## Changelog

### Added

### Updated
* `setup/choropleth.js` to trigger controller to display choropleth on redraw event. redraw event is triggered when the geography type is switched

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
