### PR TITLE
adding link to Google maps in the facility modal

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -738,6 +738,18 @@
             </svg></div>
         </div>
       </div>
+      <a href="#" class="facility-info__view-google-map hidden w-inline-block">
+        <div class="facility-info__google-map-icon">
+          <div class="svg-icon w-embed"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewbox="0 0 150 150">
+              <path fill="#1a73e8" d="M89.77,10.4c-4.4-1.39-9.08-2.15-13.94-2.15c-14.18,0-26.87,6.41-35.33,16.48l21.8,18.34L89.77,10.4z"></path>
+              <path fill="#ea4335" d="M40.49,24.73c-6.74,8.02-10.81,18.37-10.81,29.66c0,8.68,1.73,15.71,4.57,22.01l28.04-33.33L40.49,24.73z"></path>
+              <path fill="#4285f4" d="M75.83,36.75c9.75,0,17.65,7.9,17.65,17.65c0,4.34-1.57,8.32-4.17,11.39c0,0,13.94-16.58,27.47-32.66   c-5.59-10.75-15.28-19.02-27-22.73L62.29,43.07C65.53,39.2,70.39,36.75,75.83,36.75"></path>
+              <path fill="#fbbc04" d="M75.83,72.04c-9.75,0-17.65-7.9-17.65-17.65c0-4.31,1.55-8.26,4.11-11.33L34.25,76.4   c4.79,10.63,12.76,19.16,20.97,29.91L89.3,65.79C86.07,69.61,81.23,72.04,75.83,72.04"></path>
+              <path fill="#34a853" d="M88.63,117.37c15.39-24.07,33.34-35,33.34-62.98c0-7.67-1.88-14.9-5.19-21.26l-61.55,73.18   c2.61,3.42,5.24,7.06,7.81,11.07c9.36,14.46,6.76,23.13,12.8,23.13C81.86,140.51,79.27,131.83,88.63,117.37"></path>
+            </svg></div>
+        </div>
+        <div class="facility-info__google-map-text">View location in Google Maps</div>
+      </a>
       <div class="facility-info__content">
         <div class="facility-info__items">
           <div class="facility-info__item last">

--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -26,9 +26,6 @@ let tooltipRowItem = null;
 let facilityItem = null;
 let facilityRowItem = null;
 
-let googleMapsButton = null;
-let googleMapsButtonClsName = 'facility-info__view-google-map';
-
 let activeMarkers = [];
 let activePoints = [];  //the visible points on the map
 
@@ -45,6 +42,8 @@ export class PointData extends Component {
         this.map = _map;
         this.profileId = profileId;
 
+        this.googleMapsButton = null;
+
         this.markerLayer = this.genLayer();
         this.categoryLayers = {};
 
@@ -52,13 +51,15 @@ export class PointData extends Component {
     }
 
     prepareDomElements = () => {
+        let googleMapsButtonClsName = 'facility-info__view-google-map';
+
         tooltipItem = $('.' + tooltipClsName)[0].cloneNode(true);
         tooltipRowItem = $('.' + tooltipRowClsName)[0].cloneNode(true);
         facilityRowItem = $('.' + facilityRowClsName)[0].cloneNode(true);
         facilityItem = $('.' + facilityClsName);
         pointLegend = $('.' + pointLegendWrapperClsName);
         pointLegendItem = $('.' + pointLegendItemClsName)[0].cloneNode(true);
-        googleMapsButton = $('.' + googleMapsButtonClsName);
+        this.googleMapsButton = $('.' + googleMapsButtonClsName);
 
         $(pointLegend).empty();
         $('.facility-info__close').on('click', () => this.hideInfoWindows());
@@ -283,8 +284,8 @@ export class PointData extends Component {
         this.appendPointData(point, facilityItem, facilityRowItem, facilityItemsClsName, 'facility-info__item_label', 'facility-info__item_value');
 
         let gMapsUrl = `https://www.google.com/maps/search/?api=1&query=${point.y},${point.x}`;
-        googleMapsButton.removeClass('hidden');
-        googleMapsButton.attr('href', gMapsUrl);
+        this.googleMapsButton.removeClass('hidden');
+        this.googleMapsButton.attr('href', gMapsUrl);
 
         $('.facility-info').css('display', 'flex');
     }

--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -286,6 +286,7 @@ export class PointData extends Component {
         let gMapsUrl = `https://www.google.com/maps/search/?api=1&query=${point.y},${point.x}`;
         this.googleMapsButton.removeClass('hidden');
         this.googleMapsButton.attr('href', gMapsUrl);
+        this.googleMapsButton.attr('target', '_blank');
 
         $('.facility-info').css('display', 'flex');
     }

--- a/src/js/map/point_data.js
+++ b/src/js/map/point_data.js
@@ -26,6 +26,9 @@ let tooltipRowItem = null;
 let facilityItem = null;
 let facilityRowItem = null;
 
+let googleMapsButton = null;
+let googleMapsButtonClsName = 'facility-info__view-google-map';
+
 let activeMarkers = [];
 let activePoints = [];  //the visible points on the map
 
@@ -55,6 +58,7 @@ export class PointData extends Component {
         facilityItem = $('.' + facilityClsName);
         pointLegend = $('.' + pointLegendWrapperClsName);
         pointLegendItem = $('.' + pointLegendItemClsName)[0].cloneNode(true);
+        googleMapsButton = $('.' + googleMapsButtonClsName);
 
         $(pointLegend).empty();
         $('.facility-info__close').on('click', () => this.hideInfoWindows());
@@ -277,6 +281,10 @@ export class PointData extends Component {
     showFacilityModal = (point) => {
         $('.facility-info__title').text(point.name);
         this.appendPointData(point, facilityItem, facilityRowItem, facilityItemsClsName, 'facility-info__item_label', 'facility-info__item_value');
+
+        let gMapsUrl = `https://www.google.com/maps/search/?api=1&query=${point.y},${point.x}`;
+        googleMapsButton.removeClass('hidden');
+        googleMapsButton.attr('href', gMapsUrl);
 
         $('.facility-info').css('display', 'flex');
     }


### PR DESCRIPTION
## Description
adding a view location in Google Maps link in the facility modal. 
https://github.com/OpenUpSA/wazimap-ng-ui/pull/271

## Related Issue
https://trello.com/c/4ZXzJiCT/641-add-link-to-google-maps-in-the-facility-modal

## How to test it locally
* on the point mapper click on any category
* wait until the point markers are created on the map
* click on a point marker 
* on the tooltip click on `Show More` button to view the facility modal
* confirm that in the facility modal, we now have the Google Maps link and it redirects to the correct coordinates


## Screenshots
![image](https://user-images.githubusercontent.com/53019884/123856409-bba56f80-d929-11eb-84c3-541606627f0c.png)


## Changelog

### Added

### Updated
* `index.html` and `wazimap-ng-v1.webflow.css` to apply design changes
* `point_data.js ` to modifiy `href` property of the link button

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
