### PR TITLE
hiding filters when there are no groups to filter by

### DIFF
--- a/src/js/elements/subindicator_filter/filter_controller.js
+++ b/src/js/elements/subindicator_filter/filter_controller.js
@@ -106,6 +106,12 @@ export class FilterController extends Component {
         })
     }
 
+    setFilterVisibility(){
+        if (this.model.dataFilterModel.availableFilters.length <= 0) {
+            $(this.container).addClass('hidden');
+        }
+    }
+
     addInitialFilterRow(dataFilterModel) {
         let isDefault = true;
         let isExtra = false;
@@ -218,6 +224,7 @@ export class FilterController extends Component {
 
         this.checkAndAddNonAggregatableGroups();
         this.checkAndAddDefaultFilterGroups();
+        this.setFilterVisibility();
         this.addInitialFilterRow(dataFilterModel);
     }
 


### PR DESCRIPTION
## Description
hiding filters and filter buttons when there are no groups to filter by

## Related Issue


## How to test it locally


## Screenshots
![image](https://user-images.githubusercontent.com/53019884/128021486-fbd5e5bf-bd41-454e-a9b7-d26e941985f2.png)


## Changelog

### Added

### Updated
* `src/js/elements/subindicator_filter/filter_controller.js` to check if there are groups to filter by

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
