### PR TITLE
Render HTML in description fields

### DIFF
--- a/__tests__/elements/mapchip.test.js
+++ b/__tests__/elements/mapchip.test.js
@@ -1,0 +1,41 @@
+import { screen, fireEvent, getByText } from '@testing-library/dom'
+
+import {MapChip} from "../../src/js/elements/mapchip/mapchip.js";
+import {Component} from '../../src/js/utils';
+
+import html from '../../src/index.html';
+
+describe('Check mapchip HTML description', () => {
+    document.body.innerHTML = html;
+
+    const mapchip_args = {
+        "data": {
+            "description": "<p>An HTML description</p>",
+            "metadata": { 
+                "primary_group": "age group",
+                "groups": []
+            },
+            "chartConfiguration": {
+                "filter": {
+                    "defaults": []
+                }
+            }
+        }
+    }
+    const mapchip_colors = { "colors": [] }
+    let descriptionField;
+
+    beforeEach(() => {
+      descriptionField = document.querySelector('.map-option__context_text');
+    })
+
+    test('Description is visible and renders HTML tags', () => {
+      let component = new Component();
+      let mc = new MapChip(component, mapchip_colors)
+      mc.show();
+      mc.description = mapchip_args.data.description;
+      
+      expect(descriptionField).toBeVisible();
+      expect(descriptionField.textContent.trim()).toBe('An HTML description')
+    })
+})

--- a/__tests__/elements/mapchip.test.js
+++ b/__tests__/elements/mapchip.test.js
@@ -10,7 +10,7 @@ describe('Check mapchip HTML description', () => {
 
     const mapchip_args = {
         "data": {
-            "description": "<p>An HTML description</p>",
+            "description": "<p>An <strong>HTML</strong> description</p>",
             "metadata": { 
                 "primary_group": "age group",
                 "groups": []
@@ -23,19 +23,17 @@ describe('Check mapchip HTML description', () => {
         }
     }
     const mapchip_colors = { "colors": [] }
-    let descriptionField;
-
-    beforeEach(() => {
-      descriptionField = document.querySelector('.map-option__context_text');
-    })
 
     test('Description is visible and renders HTML tags', () => {
       let component = new Component();
       let mc = new MapChip(component, mapchip_colors)
       mc.show();
       mc.description = mapchip_args.data.description;
+
+      let descriptionField = document.querySelector('.map-option__context_text');
+      let htmlTag = descriptionField.textContent.trim();
       
       expect(descriptionField).toBeVisible();
-      expect(descriptionField.textContent.trim()).toBe('An HTML description')
+      expect(htmlTag).toBe('An HTML description')
     })
 })

--- a/__tests__/profile/rich_data.test.js
+++ b/__tests__/profile/rich_data.test.js
@@ -1,0 +1,53 @@
+import {screen, fireEvent, getByText} from '@testing-library/dom'
+
+import { Category } from "../../src/js/profile/category.js";
+import {Component} from '../../src/js/utils';
+
+import html from '../../src/index.html';
+
+describe('Rich data panel tests', () => {
+    document.body.innerHTML = html;
+
+    const formattingConfig = {}
+    const profileWrapperClass = '.rich-data-content';
+    const categoryName = "Test category";
+    const categoryDetail = {
+        "description": "<p>An <strong>HTML</strong> description</p>",
+        "subcategories": {
+            "Mock subcategory": {
+                "description": "<p>A subcategory description</p>",
+                "indicators": {
+                    "Mock indicator": {
+                        "data": [{
+                            "age": "1"
+                        }]
+                    }
+                }
+            }
+        }
+    };
+    
+    const profileWrapper = $(profileWrapperClass);
+    const id = "category-1";
+    const removePrevCategories = true;
+    const isFirst = true;
+
+    let component = new Component();
+    let category = new Category(component, formattingConfig, categoryName, categoryDetail, profileWrapper, id, removePrevCategories, isFirst)
+
+    test('Category description is visible and renders HTML tags', () => {
+        let categoryField = document.querySelector('.category-header__description');
+        let htmlTag = categoryField.textContent.trim();
+
+        expect(categoryField).toBeVisible();
+        expect(htmlTag).toBe('An HTML description')
+    })
+    
+    test('Subcategory description is visible and renders HTML tags', () => {
+        let subcategoryField = document.querySelector('.sub-category-header__description');
+        let htmlTag = subcategoryField.textContent.trim();
+
+        expect(subcategoryField).toBeVisible();
+        expect(htmlTag).toBe('A subcategory description')
+    })
+})

--- a/__tests__/profile/rich_data.test.js
+++ b/__tests__/profile/rich_data.test.js
@@ -20,13 +20,17 @@ describe('Rich data panel tests', () => {
                     "Mock indicator": {
                         "data": [{
                             "age": "1"
-                        }]
+                        }],
+                        "metadata": {},
+                        "groups": {},
+                        "description": "<p>An indicator description</p>",
+                        "type": "indicator"
                     }
                 }
             }
         }
     };
-    
+
     const profileWrapper = $(profileWrapperClass);
     const id = "category-1";
     const removePrevCategories = true;
@@ -36,18 +40,21 @@ describe('Rich data panel tests', () => {
     let category = new Category(component, formattingConfig, categoryName, categoryDetail, profileWrapper, id, removePrevCategories, isFirst)
 
     test('Category description is visible and renders HTML tags', () => {
-        let categoryField = document.querySelector('.category-header__description');
-        let htmlTag = categoryField.textContent.trim();
-
-        expect(categoryField).toBeVisible();
-        expect(htmlTag).toBe('An HTML description')
+        checkHTMLIsRendered('.category-header__description', 'An HTML description');
     })
-    
+
     test('Subcategory description is visible and renders HTML tags', () => {
-        let subcategoryField = document.querySelector('.sub-category-header__description');
-        let htmlTag = subcategoryField.textContent.trim();
-
-        expect(subcategoryField).toBeVisible();
-        expect(htmlTag).toBe('A subcategory description')
+        checkHTMLIsRendered('.sub-category-header__description', 'A subcategory description');
     })
+
+    test('Indicator description is visible and renders HTML tags', () => {
+        checkHTMLIsRendered('.profile-indicator__chart_description', 'An indicator description');
+    })
+
+    function checkHTMLIsRendered(elementClass, description) {
+        let descriptionElement = document.querySelector(elementClass);
+        let htmlTag = descriptionElement.textContent.trim();
+        expect(descriptionElement).toBeVisible();
+        expect(htmlTag).toBe(description)
+    }
 })

--- a/package.json
+++ b/package.json
@@ -52,7 +52,9 @@
     "jest": "^26.4.2",
     "miragejs": "^0.1.41",
     "parcel": "1.12.4",
-    "parcel-bundler": "1.12.5"
+    "parcel-bundler": "1.12.5",
+    "html-loader-jest": "0.2.1",
+    "jest-transform-stub": "2.0.0"
   },
   "scripts": {
     "start": "parcel ./src/index.html",
@@ -84,6 +86,15 @@
     "testPathIgnorePatterns": [
       "/__tests__/integration/",
       "/node_modules/"
-    ]
+    ],
+    "moduleFileExtensions": [
+      "js",
+      "html"
+    ],
+    "transform": {
+      "^.+\\.js$": "babel-jest",
+      ".+\\.(css|styl|less|sass|scss|png|jpg|gif|ttf|woff|woff2)$": "jest-transform-stub",
+      "^.+\\.html$": "html-loader-jest"
+    }
   }
 }

--- a/src/js/elements/mapchip/mapchip.js
+++ b/src/js/elements/mapchip/mapchip.js
@@ -39,7 +39,7 @@ export class MapChip extends Component {
     }
 
     set description(text) {
-        $(this._descriptionArea).text(text)
+        $(this._descriptionArea).html(text)
     }
 
     prepareDomElements() {

--- a/src/js/profile/blocks/indicator.js
+++ b/src/js/profile/blocks/indicator.js
@@ -41,7 +41,7 @@ export class Indicator extends ContentBlock {
 
     prepareDomElements() {
         $(indicatorTitleClass, this.container).text(this.title);
-        $(chartDescClass, this.container).text(this.description);
+        $(chartDescClass, this.container).html(this.description);
 
         const isLink = !isNull(this.metadata.url);
         if (isLink)

--- a/src/js/profile/category.js
+++ b/src/js/profile/category.js
@@ -45,7 +45,7 @@ export class Category extends Component {
         $(newCategorySection).append(indicatorHeader);
 
         $(categoryTitleClass, newCategorySection).text(category);
-        $(descriptionTextClass, newCategorySection).text(detail.description);
+        $(descriptionTextClass, newCategorySection).html(detail.description);
 
         if (detail.description === '') {
             $(descriptionClass, newCategorySection).addClass('hidden');

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -1,4 +1,4 @@
-import {format as d3format} from "d3-format/src/defaultLocale";
+import {format as d3format} from "d3-format";
 import {select as d3select} from "d3-selection";
 
 import {appendFilterArrays, Component} from "../utils";

--- a/src/js/profile/subcategory.js
+++ b/src/js/profile/subcategory.js
@@ -47,7 +47,7 @@ export class Subcategory extends Component {
         }
 
         $(subcategoryTitleClass, scHeader).text(subcategory);
-        $(descriptionTextClass, scHeader).text(detail.description);
+        $(descriptionTextClass, scHeader).html(detail.description);
 
         if (detail.description === '') {
             $(descriptionClass, scHeader).addClass('hidden');

--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -45,7 +45,7 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
             indicatorTitle: args.indicatorTitle,
             selectedSubindicator: args.selectedSubindicator,
             childData: args.data.child_data,
-            description: args.description,
+            description: args.data.description,
             chartConfiguration: args.data.chartConfiguration,
             filter: args.filter,
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1779,6 +1779,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
 
+ast-types@0.9.6:
+  version "0.9.6"
+  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.9.6.tgz#102c9e9e9005d3e7e3829bf0c4fa24ee862ee9b9"
+  integrity sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=
+
 async-each@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
@@ -1976,6 +1981,11 @@ bcrypt-pbkdf@^1.0.0:
 becke-ch--regex--s0-0-v1--base--pl--lib@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/becke-ch--regex--s0-0-v1--base--pl--lib/-/becke-ch--regex--s0-0-v1--base--pl--lib-1.4.0.tgz#429ceebbfa5f7e936e78d73fbdc7da7162b20e20"
+
+big.js@^5.2.2:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
+  integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -2359,6 +2369,14 @@ callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
 
+camel-case@3.0.x:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
+  integrity sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=
+  dependencies:
+    no-case "^2.2.0"
+    upper-case "^1.1.1"
+
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
@@ -2529,6 +2547,13 @@ class-utils@^0.3.5:
     define-property "^0.2.5"
     isobject "^3.0.0"
     static-extend "^0.1.1"
+
+clean-css@4.2.x:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-4.2.3.tgz#507b5de7d97b48ee53d84adb0160ff6216380f78"
+  integrity sha512-VcMWDN54ZN/DS+g58HYL5/n4Zrqe8vHJpGA8KdgUXFU4fuP/aHNw8eld9SyEIyabIMJX/0RaY/fplOo5hYLSFA==
+  dependencies:
+    source-map "~0.6.0"
 
 cli-cursor@^1.0.2:
   version "1.0.2"
@@ -2707,6 +2732,10 @@ commander@2, commander@^2.11.0, commander@^2.19.0, commander@^2.20.0, commander@
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
 
+commander@2.17.x, commander@~2.17.1:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+
 commander@^4.0.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
@@ -2725,9 +2754,10 @@ commander@~2.14.1:
   version "2.14.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.14.1.tgz#2235123e37af8ca3c65df45b026dbd357b01b9aa"
 
-commander@~2.17.1:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+commander@~2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
+  integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
 
 common-tags@^1.8.0:
   version "1.8.0"
@@ -3765,6 +3795,11 @@ emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
 
+emojis-list@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
+  integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
 encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
@@ -3851,6 +3886,14 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
     d "^1.0.1"
     ext "^1.1.2"
 
+es6-templates@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/es6-templates/-/es6-templates-0.2.3.tgz#5cb9ac9fb1ded6eb1239342b81d792bbb4078ee4"
+  integrity sha1-XLmsn7He1usSOTQrgdeSu7QHjuQ=
+  dependencies:
+    recast "~0.11.12"
+    through "~2.3.6"
+
 escalade@^3.0.2, escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
@@ -3900,7 +3943,7 @@ escodegen@~1.9.0:
   optionalDependencies:
     source-map "~0.6.1"
 
-esprima@^3.1.3:
+esprima@^3.1.3, esprima@~3.1.0:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-3.1.3.tgz#fdca51cee6133895e3c88d535ce49dbff62a4633"
 
@@ -4112,7 +4155,7 @@ fast-safe-stringify@^2.0.7:
   version "2.0.7"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz#124aa885899261f68aedb42a7c080de9da608743"
 
-fastparse@^1.1.2:
+fastparse@^1.1.1, fastparse@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/fastparse/-/fastparse-1.1.2.tgz#91728c5a5942eced8531283c79441ee4122c35a9"
 
@@ -4498,6 +4541,11 @@ hash.js@^1.0.0, hash.js@^1.0.3:
     inherits "^2.0.3"
     minimalistic-assert "^1.0.1"
 
+he@1.2.x:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
+  integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
+
 hex-color-regex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/hex-color-regex/-/hex-color-regex-1.1.0.tgz#4c06fccb4602fe2602b3c93df82d7e7dbf1a8a8e"
@@ -4538,6 +4586,37 @@ html-encoding-sniffer@^2.0.1:
 html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
+
+html-loader-jest@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/html-loader-jest/-/html-loader-jest-0.2.1.tgz#1803c2bcd9e41ccc738a0979cc6de0acbabac3f8"
+  integrity sha512-Sq9eDpsr/8kI+kyiQAL8jawa+aGRphANCeIeoLyU05DEfHd9vCi4Zz8AXUQTbqnF0TRGfVn9qN69/ox378kyGg==
+  dependencies:
+    html-loader "^0.5.1"
+
+html-loader@^0.5.1:
+  version "0.5.5"
+  resolved "https://registry.yarnpkg.com/html-loader/-/html-loader-0.5.5.tgz#6356dbeb0c49756d8ebd5ca327f16ff06ab5faea"
+  integrity sha512-7hIW7YinOYUpo//kSYcPB6dCKoceKLmOwjEMmhIobHuWGDVl0Nwe4l68mdG/Ru0wcUxQjVMEoZpkalZ/SE7zog==
+  dependencies:
+    es6-templates "^0.2.3"
+    fastparse "^1.1.1"
+    html-minifier "^3.5.8"
+    loader-utils "^1.1.0"
+    object-assign "^4.1.1"
+
+html-minifier@^3.5.8:
+  version "3.5.21"
+  resolved "https://registry.yarnpkg.com/html-minifier/-/html-minifier-3.5.21.tgz#d0040e054730e354db008463593194015212d20c"
+  integrity sha512-LKUKwuJDhxNa3uf/LPR/KVjm/l3rBqtYeCOAekvG8F1vItxMUpueGd94i/asDDr8/1u7InxzFA5EeGjhhG5mMA==
+  dependencies:
+    camel-case "3.0.x"
+    clean-css "4.2.x"
+    commander "2.17.x"
+    he "1.2.x"
+    param-case "2.1.x"
+    relateurl "0.2.x"
+    uglify-js "3.4.x"
 
 html-tags@^1.0.0:
   version "1.2.0"
@@ -5399,6 +5478,11 @@ jest-snapshot@^26.6.2:
     pretty-format "^26.6.2"
     semver "^7.3.2"
 
+jest-transform-stub@2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jest-transform-stub/-/jest-transform-stub-2.0.0.tgz#19018b0851f7568972147a5d60074b55f0225a7d"
+  integrity sha512-lspHaCRx/mBbnm3h4uMMS3R5aZzMwyNpNIJLXj4cEsV0mIUtS4IjYJLSoyjRCtnxb6RIGJ4NL2quZzfIeNhbkg==
+
 jest-util@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.2.tgz#907535dbe4d5a6cb4c47ac9b926f6af29576cbc1"
@@ -5747,6 +5831,15 @@ listr@^0.14.3:
     listr-verbose-renderer "^0.5.0"
     p-map "^2.0.0"
     rxjs "^6.3.3"
+
+loader-utils@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.4.0.tgz#c579b5e34cb34b1a74edc6c1fb36bfa371d5a613"
+  integrity sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==
+  dependencies:
+    big.js "^5.2.2"
+    emojis-list "^3.0.0"
+    json5 "^1.0.1"
 
 locate-path@^5.0.0:
   version "5.0.0"
@@ -6551,6 +6644,13 @@ papaparse@^5.3.0:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.3.1.tgz#770b7a9124d821d4b2132132b7bd7dce7194b5b1"
 
+param-case@2.1.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/param-case/-/param-case-2.1.1.tgz#df94fd8cf6531ecf75e6bef9a0858fbc72be2247"
+  integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
+  dependencies:
+    no-case "^2.2.0"
+
 parcel-bundler@1.12.5:
   version "1.12.5"
   resolved "https://registry.yarnpkg.com/parcel-bundler/-/parcel-bundler-1.12.5.tgz#91f7de1c1fbfe5111616d3211c749c85c4d8acf0"
@@ -7189,7 +7289,7 @@ printj@~1.1.0, printj@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
 
-private@^0.1.6:
+private@^0.1.6, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
 
@@ -7363,6 +7463,16 @@ readdirp@~3.5.0:
   dependencies:
     picomatch "^2.2.1"
 
+recast@~0.11.12:
+  version "0.11.23"
+  resolved "https://registry.yarnpkg.com/recast/-/recast-0.11.23.tgz#451fd3004ab1e4df9b4e4b66376b2a21912462d3"
+  integrity sha1-RR/TAEqx5N+bTktmN2sqIZEkYtM=
+  dependencies:
+    ast-types "0.9.6"
+    esprima "~3.1.0"
+    private "~0.1.5"
+    source-map "~0.5.0"
+
 rechoir@^0.6.2:
   version "0.6.2"
   resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
@@ -7444,7 +7554,7 @@ regjsparser@^0.6.4:
   dependencies:
     jsesc "~0.5.0"
 
-relateurl@^0.2.7:
+relateurl@0.2.x, relateurl@^0.2.7:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
@@ -7925,11 +8035,11 @@ source-map@0.5.6:
   version "0.5.6"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.6.tgz#75ce38f52bf0733c5a7f0c118d81334a2bb5f412"
 
-source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@0.6.1, source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
-source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.3:
+source-map@^0.5.0, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.3:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 
@@ -8368,7 +8478,7 @@ through2@^2.0.0, through2@~2.0.3:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-"through@>=2.2.7 <3", through@^2.3.8:
+"through@>=2.2.7 <3", through@^2.3.8, through@~2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
@@ -8558,6 +8668,14 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
+uglify-js@3.4.x:
+  version "3.4.10"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.4.10.tgz#9ad9563d8eb3acdfb8d38597d2af1d815f6a755f"
+  integrity sha512-Y2VsbPVs0FIshJztycsO2SfPk7/KAF/T72qzv9u5EpQ4kB2hQoHlhNQTsNyy6ul7lQtqJN/AoWeS23OzEiEFxw==
+  dependencies:
+    commander "~2.19.0"
+    source-map "~0.6.1"
+
 umd@^3.0.0:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/umd/-/umd-3.0.3.tgz#aa9fe653c42b9097678489c01000acb69f0b26cf"
@@ -8673,7 +8791,7 @@ upath@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
 
-upper-case@^1.0.3:
+upper-case@^1.0.3, upper-case@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 


### PR DESCRIPTION
## Description

These changes will render HTML elements for descriptions from the backend

## Related Issue
https://trello.com/c/E9XN4wrh/803-rich-text-descriptions-as-a-user-i-would-like-to-be-able-to-click-links-in-descriptions-and-read-them-easily-so-that-i-can-more

## How to test it locally


## Screenshots


## Changelog

### Added
Description fields can now display HTML set by data admins

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
