### PR TITLE
Add DOM check for HTML description tags and fix CI

### DIFF
--- a/__tests__/elements/mapchip.test.js
+++ b/__tests__/elements/mapchip.test.js
@@ -34,6 +34,7 @@ describe('Check mapchip HTML description', () => {
       let htmlTag = descriptionField.textContent.trim();
       
       expect(descriptionField).toBeVisible();
+      expect(descriptionField.innerHTML).toContain("<strong>");
       expect(htmlTag).toBe('An HTML description')
     })
 })

--- a/__tests__/profile/rich_data.test.js
+++ b/__tests__/profile/rich_data.test.js
@@ -12,18 +12,19 @@ describe('Rich data panel tests', () => {
     const profileWrapperClass = '.rich-data-content';
     const categoryName = "Test category";
     const categoryDetail = {
-        "description": "<p>An <strong>HTML</strong> description</p>",
+        "description": "<p>A <strong>category</strong> description</p>",
         "subcategories": {
             "Mock subcategory": {
-                "description": "<p>A subcategory description</p>",
+                "description": "<p>A <strong>subcategory</strong> description</p>",
                 "indicators": {
                     "Mock indicator": {
                         "data": [{
                             "age": "1"
                         }],
+                        "content_type": "indicator",
                         "metadata": {},
-                        "groups": {},
-                        "description": "<p>An indicator description</p>",
+                        "groups": [],
+                        "description": "<p>An <strong>indicator</strong> description</p>",
                         "type": "indicator"
                     }
                 }
@@ -40,7 +41,7 @@ describe('Rich data panel tests', () => {
     let category = new Category(component, formattingConfig, categoryName, categoryDetail, profileWrapper, id, removePrevCategories, isFirst)
 
     test('Category description is visible and renders HTML tags', () => {
-        checkHTMLIsRendered('.category-header__description', 'An HTML description');
+        checkHTMLIsRendered('.category-header__description', 'A category description');
     })
 
     test('Subcategory description is visible and renders HTML tags', () => {
@@ -55,6 +56,7 @@ describe('Rich data panel tests', () => {
         let descriptionElement = document.querySelector(elementClass);
         let htmlTag = descriptionElement.textContent.trim();
         expect(descriptionElement).toBeVisible();
+        expect(descriptionElement.innerHTML).toContain("<strong>");
         expect(htmlTag).toBe(description)
     }
 })


### PR DESCRIPTION
## Description

A small patch to fix CI and also add a check that HTML tags from descriptions are appended to the DOM

## Related Issue
https://trello.com/c/3O5vlF3y/879-ci-patch

## How to test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
