### PR TITLE
toggling between profile indicators

### DIFF
--- a/src/js/elements/mapchip/add_filter_button.js
+++ b/src/js/elements/mapchip/add_filter_button.js
@@ -20,7 +20,7 @@ export class AddFilterButton extends Component {
     }
 
     prepareEvents() {
-        this.button.on('click', () => this.triggerEvent(AddFilterButton.EVENTS.clicked));
+        this.button.off('click').on('click', () => this.triggerEvent(AddFilterButton.EVENTS.clicked));
     }
 
     disable() {

--- a/src/js/elements/mapchip/mapchip.js
+++ b/src/js/elements/mapchip/mapchip.js
@@ -16,7 +16,6 @@ export class MapChip extends Component {
 
         this.prepareDomElements();
 
-        this._filterController = new FilterController(this, this._filtersContainer);
         this._legend = new Legend(this, this._legendContainer, legendColors);
 
         this.prepareUIEvents();
@@ -99,12 +98,13 @@ export class MapChip extends Component {
             return;
         }
 
+        this._filterController = new FilterController(this, this._filtersContainer);
         const previouslySelectedFilters = params.filter;
 
         let dataFilterModel = new DataFilterModel(params.groups, params.chartConfiguration.filter, previouslySelectedFilters, params.primaryGroup, params.childData);
         this.setTitle(params.indicatorTitle, params.selectedSubindicator);
         this.description = params.description;
-        
+
         this.show();
         if (this._filterController.filterCallback === null) {
             this._filterController.filterCallback = this.applyFilter;

--- a/src/js/elements/subindicator_filter/filter_controller.js
+++ b/src/js/elements/subindicator_filter/filter_controller.js
@@ -97,6 +97,10 @@ export class FilterController extends Component {
     prepareDomElements() {
         this._rowContainer = $(this.container).find(this._elements.filterRowClass)[0];
         $(this._rowContainer).hide();
+
+        while ($(this.container).find(this._elements.filterRowClass).length > 1) {
+            $(this.container).find(this._elements.filterRowClass)[1].remove();
+        }
     }
 
     prepareEvents() {
@@ -106,9 +110,11 @@ export class FilterController extends Component {
         })
     }
 
-    setFilterVisibility(){
+    setFilterVisibility() {
         if (this.model.dataFilterModel.availableFilters.length <= 0) {
             $(this.container).addClass('hidden');
+        } else {
+            $(this.container).removeClass('hidden');
         }
     }
 
@@ -211,6 +217,7 @@ export class FilterController extends Component {
 
     setDataFilterModel(dataFilterModel) {
         this.reset();
+
         this.model.dataFilterModel = dataFilterModel;
 
         this.model.dataFilterModel.on(DataFilterModel.EVENTS.updated, () => {


### PR DESCRIPTION
## Description
investigating why the choropleth breaks when toggling between the profile indicators.

turns out when a new subindicator is selected, we're still trying to use the filtered data of the previous subindicator. 

## Related Issue
https://trello.com/c/FYMLJcwi/881-everything-is-zery-when-toggling-between-two-different-profile-indicators

## How to test it locally
* Go to Sanef profile
* Open data mapper
* Select black african under demographics > 2016 community survey
* See map choropleth normally
* Select indian under demographics > 2011 census
* Confirm that the choropleth is correct

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/128645786-9b2fe881-35b6-466b-8f51-36da489990f7.png)


## Changelog

### Added

### Updated
* `mapchip.js` to initialize filterController everytime a subindicator is selected. this will ensure the data is renewed.

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design matches the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
