### PR TITLE
Unit testing visibility of the filter area

### DIFF
--- a/__tests__/elements/subindicator_filter/filter_controller.test.js
+++ b/__tests__/elements/subindicator_filter/filter_controller.test.js
@@ -87,22 +87,20 @@ describe('Filter controller', () => {
         let indicatorDd = $(`.map-options__filters_content .map-options__filter-row .dropdown-menu__selected-item .truncate:contains("age")`);
         expect(indicatorDd.length).toBe(0);
     })
+})
 
-    test('Hides filters when there are no groups to filter by', () => {
-        params.groups = [];
-        let component = new Component();
-        let mc = new MapChip(component, mapchip_colors);
+describe('Visibility of the filter area', () => {
+    beforeEach(() => {
+        document.body.innerHTML = html;
 
-        mc.onSubIndicatorChange(params);
-        let filterArea = document.querySelector('.map-options__filters_content');
-
-        expect(filterArea).toHaveClass('hidden');
+        let td = new TestData();
+        params = td.filterData;
     })
 
-    test('Does not hide filters when there are groups to filter by', () => {
+    test('Filters are visible when there are groups to filter by', () => {
         params.groups = [
             {
-                subindicators: ["30-35", "20-24", "15-24 (Intl)", "15-35 (ZA)", "15-19", "25-29"],
+                subindicators: ["30-35", "20-24", "15-24 (Intl)", "14-35 (ZA)", "15-19", "25-29"],
                 dataset: 241,
                 name: "age",
                 can_aggregate: true,
@@ -133,8 +131,75 @@ describe('Filter controller', () => {
         let mc = new MapChip(component, mapchip_colors);
 
         mc.onSubIndicatorChange(params);
+        const isVisible = mc.filterController.shouldFiltersBeVisible();
         let filterArea = document.querySelector('.map-options__filters_content');
 
+        expect(isVisible).toBe(true);
+        expect(filterArea).not.toHaveClass('hidden');
+    })
+
+    test('Filters are hidden when there are no groups to filter by', () => {
+        params.groups = [];
+        let component = new Component();
+        let mc = new MapChip(component, mapchip_colors);
+
+        mc.onSubIndicatorChange(params);
+        const isVisible = mc.filterController.shouldFiltersBeVisible();
+        let filterArea = document.querySelector('.map-options__filters_content');
+
+        expect(isVisible).toBe(false);
+        expect(filterArea).toHaveClass('hidden');
+    })
+
+    test('Filters are visible when all the groups are non-aggregatable', () => {
+        params.groups = [{
+            subindicators: ["Female", "Male"],
+            dataset: 241,
+            name: "gender",
+            can_aggregate: false,
+            can_filter: true
+        }];
+        let component = new Component();
+        let mc = new MapChip(component, mapchip_colors);
+
+        mc.onSubIndicatorChange(params);
+        const isVisible = mc.filterController.shouldFiltersBeVisible();
+        const currentIndicatorValue = mc.filterController.model.filterRows[0].model.currentIndicatorValue;
+        let filterArea = document.querySelector('.map-options__filters_content');
+
+        expect(isVisible).toBe(true);
+        expect(currentIndicatorValue).toBe('gender');
+        expect(filterArea).not.toHaveClass('hidden');
+    })
+
+    test('Filters are visible when all the groups are default filter', () => {
+        params.groups = [{
+            subindicators: ["Female", "Male"],
+            dataset: 241,
+            name: "gender",
+            can_aggregate: true,
+            can_filter: true
+        }];
+
+        params.chartConfiguration.filter = {
+            defaults: [{
+                name: 'gender',
+                value: 'Male'
+            }]
+        }
+
+        let component = new Component();
+        let mc = new MapChip(component, mapchip_colors);
+
+        mc.onSubIndicatorChange(params);
+        const isVisible = mc.filterController.shouldFiltersBeVisible();
+        const currentIndicatorValue = mc.filterController.model.filterRows[0].model.currentIndicatorValue;
+        const currentSubindicatorValue = mc.filterController.model.filterRows[0].model.currentSubindicatorValue;
+        let filterArea = document.querySelector('.map-options__filters_content');
+
+        expect(isVisible).toBe(true);
+        expect(currentIndicatorValue).toBe('gender');
+        expect(currentSubindicatorValue).toBe('Male');
         expect(filterArea).not.toHaveClass('hidden');
     })
 })

--- a/src/js/elements/mapchip/mapchip.js
+++ b/src/js/elements/mapchip/mapchip.js
@@ -41,6 +41,10 @@ export class MapChip extends Component {
         $(this._descriptionArea).html(text)
     }
 
+    get filterController(){
+        return this._filterController;
+    }
+
     prepareDomElements() {
         this._container = $(mapChipBlockClass)[0];
         this._closeButton = $(this.container).find('.filters__header_close')

--- a/src/js/elements/subindicator_filter/filter_controller.js
+++ b/src/js/elements/subindicator_filter/filter_controller.js
@@ -111,12 +111,22 @@ export class FilterController extends Component {
     }
 
     setFilterVisibility() {
+        const isVisible = this.shouldFiltersBeVisible();
+
+        if (isVisible) {
+            $(this.container).removeClass('hidden');
+        } else {
+            $(this.container).addClass('hidden');
+        }
+    }
+
+    shouldFiltersBeVisible() {
         const nonAggregatableGroups = this.model.dataFilterModel.nonAggregatableGroups;
         const defaultGroups = this.model.dataFilterModel.defaultFilterGroups;
         if (nonAggregatableGroups.length <= 0 && defaultGroups.length <= 0 && this.model.dataFilterModel.availableFilters.length <= 0) {
-            $(this.container).addClass('hidden');
+            return false;
         } else {
-            $(this.container).removeClass('hidden');
+            return true;
         }
     }
 


### PR DESCRIPTION
## Description
added unit tests to confirm that the filter area is getting displayed / hidden correctly depending on the data supplied.

## Related Issue
https://tree.taiga.io/project/jbothma-wazimap-ng/task/680

## How is it tested automatically?
this PR only adds unit tests - there are no new functionality to be tested automatically

## How should a reviewer test it locally
* run `yarn test`
* check if the newly added unit tests are passing

## Screenshots


## Changelog

### Added

### Updated
* `__tests__/elements/subindicator_filter/filter_controller.test.js` to add unit tests
* `src/js/elements/mapchip/mapchip.js` created a getter function to wrap `_filterController`
* `src/js/elements/subindicator_filter/filter_controller.js` refactored `setFilterVisibility()` function to use `shouldFiltersBeVisible()`

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
