### PR TITLE
Fix typo breaking rich data blocks and add test

### DIFF
--- a/__tests__/profile/rich_data-rich-text.test.js
+++ b/__tests__/profile/rich_data-rich-text.test.js
@@ -5,26 +5,25 @@ import {Component} from '../../src/js/utils';
 
 import html from '../../src/index.html';
 
-describe('Rich data panel tests', () => {
+describe('Rich data panel HTML indicator test', () => {
     document.body.innerHTML = html;
 
     const formattingConfig = {}
     const profileWrapperClass = '.rich-data-content';
     const categoryName = "Test category";
     const categoryDetail = {
-        "description": "<p>A <strong>category</strong> description</p>",
+        "description": "mock category description",
         "subcategories": {
             "Mock subcategory": {
-                "description": "<p>A <strong>subcategory</strong> description</p>",
+                "description": "mock subcategory description",
                 "indicators": {
                     "Mock indicator": {
-                        "data": [{
-                            "age": "1"
-                        }],
-                        "content_type": "indicator",
+                        "data": [{contents: "<b>bold stuff</b>"}, {contents: "<em>emphasised stuf</em>"}],
+                        "content_type": "html",
+                        "dataset_content_type": "qualitative",
                         "metadata": {},
                         "groups": [],
-                        "description": "<p>An <strong>indicator</strong> description</p>",
+                        "description": "mock indicator description",
                         "type": "indicator"
                     }
                 }
@@ -40,23 +39,29 @@ describe('Rich data panel tests', () => {
     let component = new Component();
     let category = new Category(component, formattingConfig, categoryName, categoryDetail, profileWrapper, id, removePrevCategories, isFirst)
 
+    test('HTML content is shown', () => {
+      checkContent(
+        '.profile-indicator__chart_body',
+        '<div><b>bold stuff</b></div><div><em>emphasised stuf</em></div>'
+      )
+    })
+
+
     test('Category description is visible and renders HTML tags', () => {
-        checkHTMLIsRendered('.category-header__description', 'A category description');
+        checkContent('.category-header__description', '<p>mock category description</p>');
     })
 
     test('Subcategory description is visible and renders HTML tags', () => {
-        checkHTMLIsRendered('.sub-category-header__description', 'A subcategory description');
+        checkContent('.sub-category-header__description', '<p>mock subcategory description</p>');
     })
 
     test('Indicator description is visible and renders HTML tags', () => {
-        checkHTMLIsRendered('.profile-indicator__chart_description', 'An indicator description');
+        checkContent('.profile-indicator__chart_description', '<p>mock indicator description</p>');
     })
 
-    function checkHTMLIsRendered(elementClass, description) {
-        let descriptionElement = document.querySelector(elementClass);
-        let htmlTag = descriptionElement.textContent.trim();
-        expect(descriptionElement).toBeVisible();
-        expect(descriptionElement.innerHTML).toContain("<strong>");
-        expect(htmlTag).toBe(description)
+    function checkContent(elementClass, description) {
+        let element = document.querySelector(elementClass);
+        expect(element).toBeVisible();
+      expect(element.innerHTML.trim()).toBe(description);
     }
-});
+})

--- a/src/js/profile/blocks/html_block.js
+++ b/src/js/profile/blocks/html_block.js
@@ -12,13 +12,13 @@ export class HTMLBlock extends ContentBlock {
     }
 
     get html() {
-        return this.indicator.data[0].content;
+      return this.indicator.data.map(item => `<div>${item.contents}</div>`);
     }
 
 
     prepareDomElements() {
         super.prepareDomElements();
-        
+
         $(filtersClass, this.container).remove();
         $(bodyClass, this.container).html(this.html);
         $(hamburgerClass, this.container).remove();

--- a/src/js/profile/subcategory.js
+++ b/src/js/profile/subcategory.js
@@ -67,7 +67,7 @@ export class Subcategory extends Component {
         return block;
     }
 
-    addHTMLBlock(container, indicator, title, html, isLast) {
+    addHTMLBlock(container, indicator, title, isLast) {
         let block = new HTMLBlock(this, container, indicator, title, isLast)
 
         return block;
@@ -92,11 +92,11 @@ export class Subcategory extends Component {
                     } else if (indicator.content_type == ContentBlock.BLOCK_TYPES.HTMLBlock) {
                         block = this.addHTMLBlock(indicatorContainer, indicator, title, isLast);
                     }
-                    
+
                     this._indicators.push(block);
 
-                    
-                    
+
+
                     index++;
                 } else {
                     $(wrapper).find(descriptionTextClass).text('No data available for this indicator for this geographic area');


### PR DESCRIPTION
## Description

Fix rendering of qualitative indicators: frontend was expecting indicator.data[0].content when the property with the content is actually `contents` with an s.

## Related Issue

https://tree.taiga.io/project/jbothma-wazimap-ng/task/679

## How is it tested automatically?

Adding __tests__/profile/rich_data-rich-text.test.js

Relies on backend API tested in wazimap-ng/tests/profile/serializers/test_indicator_data_serializer.py class TestQualitativeData

## How should a reviewer test it locally

Try the prod backend, sandbox or https://github.com/OpenUpSA/wazimap-ng-ui/pull/477 frontend, SANEF sandbox profile, election > 2016 > 2016 councillors

## Screenshots

![Screenshot_2021-09-27_12-47-56](https://user-images.githubusercontent.com/235801/134894604-34ce38a3-5f90-417f-aced-36834ff45bf0.png)


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
