### PR TITLE
Always use the template indicator for new instances

### DIFF
--- a/src/js/profile/subcategory.js
+++ b/src/js/profile/subcategory.js
@@ -2,6 +2,7 @@ import {Indicator} from "./blocks/indicator";
 import {Component, formatNumericalValue} from "../utils";
 import {ContentBlock} from "./blocks/content_block";
 import {HTMLBlock} from "./blocks/html_block";
+import {assertNTemplates} from "../utils";
 
 let isFirst = false;
 let scHeaderClone = null;
@@ -13,7 +14,7 @@ const keyMetricWrapperClass = '.sub-category-header__key-metrics_wrap';
 const keyMetricClass = '.key-metric';
 const descriptionTextClass = '.sub-category-header__description p';
 const descriptionClass = '.sub-category-header__description';
-const indicatorClass = '.profile-indicator';
+const indicatorClass = '.styles .profile-indicator';
 
 export class Subcategory extends Component {
     constructor(parent, formattingConfig, wrapper, subcategory, detail, isFirst, geography) {
@@ -90,13 +91,16 @@ export class Subcategory extends Component {
         let index = 0;
         let lastIndex = Object.entries(detail.indicators).length - 1;
         let isEmpty = JSON.stringify(detail.indicators) === JSON.stringify({});
+        const $template = $(indicatorClass);
+        assertNTemplates(2, $template);
 
         if (!isEmpty) {
             for (const [title, indicator] of Object.entries(detail.indicators)) {
                 if (typeof indicator.data !== 'undefined') {
                     let isLast = index === lastIndex;
                     let block = null;
-                    let indicatorContainer = $(indicatorClass)[0].cloneNode(true);
+
+                    let indicatorContainer = $template[0].cloneNode(true);
                     $(wrapper).append(indicatorContainer);
                     let metadata = indicator.metadata;
                     if (indicator.content_type === ContentBlock.BLOCK_TYPES.Indicator) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -163,10 +163,10 @@ export class Component extends Observable {
         super()
 
         this._parent = parent;
-        this._children = [];    
+        this._children = [];
 
         if (parent != null) {
-            this._parent.registerChild(this);    
+            this._parent.registerChild(this);
         }
     }
 
@@ -426,4 +426,11 @@ export function appendFilterArrays(arr1, arr2, primaryGroup){
     )
 
     return filterArr;
+}
+
+export function assertNTemplates(n, $templateSelection) {
+  console.assert(
+    $templateSelection.length === n,
+    `Should be exactly ${n} template(s) but found ${$templateSelection.length}`
+  );
 }


### PR DESCRIPTION
## Description

Use the indicator template from the component library for new instances instead of just the first indicator found in the DOM.

Since HTML indicators change the indicator DOM structure in was incompatible with quantitiative indicators, quantitative indicators can't be initiated using an HTML indicator as template. Using a real instance as a template also has the risk of not cleaning up some of its data when setting up the new one.

## Related Issue

Fixes https://wazimap.atlassian.net/browse/WNCM-96?atlOrigin=eyJpIjoiMjFkNzQ3OTQxY2QwNDMyZDkyNjY0YjQ5MjM0NDMyNDUiLCJwIjoiaiJ9

## How is it tested automatically?

## How should a reviewer test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
