### PR TITLE
fixing navigating while an indicator is selected

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -121,10 +121,6 @@ export default class Controller extends Component {
         }
     }
 
-    test() {
-        console.log('aaa')
-    }
-
     setChoroplethData(payload) {
         const subindicator = {
             indicatorTitle: payload.indicatorTitle,
@@ -166,8 +162,15 @@ export default class Controller extends Component {
             .subcategories[this.state.subindicator.parents.subcategory]
             .indicators;
 
-        let childData = indicators[this.state.subindicator.parents.indicator].child_data;
-        let data = indicators[this.state.subindicator.parents.indicator].data;
+        let selectedIndicator = indicators[this.state.subindicator.parents.indicator];
+
+        if (selectedIndicator === undefined) {
+            this.triggerEvent('data_mapper_menu.nodata');
+            return;
+        }
+
+        let childData = selectedIndicator.child_data;
+        let data = selectedIndicator.data;
 
         this.state.subindicator.data.data = data;
         this.state.subindicator.data.child_data = childData;

--- a/src/js/elements/menu.js
+++ b/src/js/elements/menu.js
@@ -32,7 +32,7 @@ function subindicatorsInIndicator(indicator) {
 
 export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
     parentContainer = $(".data-mapper-content__list");
-    categoryTemplate = $(".data-category")[0].cloneNode(true);
+    categoryTemplate = $(".styles .data-category")[0].cloneNode(true);
     subCategoryTemplate = $(".data-category__h2", categoryTemplate)[0].cloneNode(true);
     indicatorTemplate = $(".data-category__h2_content", subCategoryTemplate)[0].cloneNode(true);
     indicatorItemTemplate = $(".data-category__h4", subCategoryTemplate)[0].cloneNode(true);


### PR DESCRIPTION
## Description
when an indicator is selected and the user navigates to another geography, if the selected indicator's category does not exist the front end was crashing. this PR fixes the problem by 
- removing the mapchip if the indicator/category does not exist
- cloning the menu elements from the `.styles` section


## Related Issue
https://wazimap.atlassian.net/browse/WNCM-110

## How is it tested automatically?


## How should a reviewer test it locally
* go to sanef profile
* navigate to Free State
* select an indicator of a category that doesn’t exist for ZA - e.g Financial Performance
* navigate back to ZA using the breadcrumbs


## Screenshots


## Changelog

### Added

### Updated
* `controller.js` to trigger `data_mapper_menu.nodata` when the selected indicator does not exist
* `menu.js` to clone the menu elements from the `.styles` section

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
