### PR TITLE
showing loading indicator in data mapper when navigating to another geography

### DIFF
--- a/__tests__/gui/toggling_indicators.feature
+++ b/__tests__/gui/toggling_indicators.feature
@@ -9,3 +9,4 @@ Feature: Facility Modal
       Then I select an indicator
     And I select another indicator
       Then I check if everything is zero
+    And I navigate to EC and check if the loading state is displayed correctly

--- a/__tests__/gui/toggling_indicators/toggling_indicators.js
+++ b/__tests__/gui/toggling_indicators/toggling_indicators.js
@@ -43,3 +43,31 @@ Then('I check if everything is zero', () => {
         expect($div.text()).not.equal('0.0%');
     })
 })
+
+When('I navigate to EC and check if the loading state is displayed correctly', ()=>{
+    //intercepting the request and testing the loading state
+    //for more info : https://blog.dai.codes/cypress-loading-state-tests/
+    let sendResponse;
+    const trigger = new Promise((resolve) => {
+        sendResponse = resolve;
+    });
+
+    cy.intercept('/api/v1/all_details/profile/8/geography/EC/?version=test&format=json', (request) => {
+        return trigger.then(() => {
+            request.reply({
+                statusCode: 201,
+                body: all_details,
+                forceNetworkError: false // default
+            })
+        });
+    });
+
+    cy.visit('/#geo:EC');
+
+    cy.get('.data-mapper-content__loading').should('be.visible').then(() => {
+        cy.get('.data-mapper-content__list').should('not.be.visible');
+        sendResponse();
+        cy.get('.data-mapper-content__loading').should('not.be.visible');
+        cy.get('.data-mapper-content__list').should('be.visible');
+    });
+})

--- a/src/js/elements/menu.js
+++ b/src/js/elements/menu.js
@@ -71,7 +71,7 @@ export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
                                 parents: parents,
                                 choropleth_method: indicatorDetail.choropleth_method,
                                 indicatorId: indicatorDetail.id,
-                                versionData:indicatorDetail.version_data
+                                versionData: indicatorDetail.version_data
                             })
                     });
                 }
@@ -170,6 +170,8 @@ export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
     if (hasNoItems) {
         dataMapperMenu.showNoData()
     }
+
+    dataMapperMenu.isLoading = false;
 }
 
 /**
@@ -177,7 +179,34 @@ export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
  */
 export class DataMapperMenu extends Component {
     constructor(parent) {
-        super(parent)
+        super(parent);
+
+        this._isLoading = false;
+    }
+
+    get isLoading() {
+        return this._isLoading;
+    }
+
+    set isLoading(value) {
+        if (value) {
+            this.showLoadingState();
+        } else {
+            this.hideLoadingState();
+        }
+
+        this._isLoading = value;
+    }
+
+    hideLoadingState() {
+        $(`.${loadingClsName}`).addClass('hidden');
+        $('.data-mapper-content__list').removeClass('hidden');
+    }
+
+    showLoadingState() {
+        $(`.${loadingClsName}`).removeClass('hidden');
+        $('.data-mapper-content__list').addClass('hidden');
+        $(`.${noDataWrapperClsName}`).addClass('hidden');
     }
 
     showNoData() {

--- a/src/js/setup/dataexplorer.js
+++ b/src/js/setup/dataexplorer.js
@@ -13,4 +13,8 @@ export function configureDataExplorerEvents(controller, dataMapperMenu) {
             })
         }
     })
+
+    controller.on('hashChange', () => {
+        dataMapperMenu.isLoading = true;
+    })
 }


### PR DESCRIPTION
## Description
showing / hiding the loading state in the data mapper when navigating between the indicators. 

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-134

## How is it tested automatically?
added a test step to `__tests__/gui/toggling_indicators.feature` to check if `.data-mapper-content__loading` is shown when navigating to another geography

## How should a reviewer test it locally
* expand data mapper
* navigate to another geography
* confirm that a loading chip is shown in the data mapper instead of the profile indicator categories
* confirm that the profile indicator categories of the new geography are shown when the navigation is completed
* especially test the case where there are no data to show in the data mapper e.g. when there are no child geographies

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/139836075-db076937-6a2a-4155-ac72-7edecb0b5858.png)


## Changelog

### Added

### Updated
* `src/js/setup/dataexplorer.js` to show the loading indicator when navigation is started
* `src/js/elements/menu.js` showing / hiding the loading indicator

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
