### PR TITLE
hiding profile indicators in data mapper

### DIFF
--- a/__tests__/setup/dataexplorer.test.js
+++ b/__tests__/setup/dataexplorer.test.js
@@ -65,4 +65,22 @@ describe('Data explorer', () => {
         let descriptionElement = document.querySelector(".data-category__h3");
         expect(descriptionElement).toBeVisible();
     })
+
+    test('Excluded indicators are not shown', () => {
+        let config = new SAConfig();
+
+        const controller = new Controller(this, null, config, 1);
+        const dataMapperMenu = new DataMapperMenu(this);
+
+        configureDataExplorerEvents(controller, dataMapperMenu);
+        const payload = JSON.parse(JSON.stringify(quantQualBasePayload));
+        payload.profile.profileData["Demo category"].subcategories["Demo subcategory"].indicators["Qualitative indicator"].chart_configuration = {
+            "exclude": ["data mapper"]
+        }
+
+        controller.triggerEvent("versions.all.loaded", payload);
+
+        let descriptionElement = document.querySelector(".data-category__h3");
+        expect(descriptionElement).not.toBeVisible();
+    })
 })

--- a/src/js/elements/menu.js
+++ b/src/js/elements/menu.js
@@ -1,5 +1,5 @@
 import {SubIndicator} from '../dataobjects'
-import {checkIfSubCategoryHasChildren, checkIfCategoryHasChildren, Component} from '../utils'
+import {checkIfSubCategoryHasChildren, checkIfCategoryHasChildren, Component, isIndicatorExcluded} from '../utils'
 
 const hideondeployClsName = 'hideondeploy';
 let parentContainer = null;
@@ -10,6 +10,7 @@ let indicatorItemTemplate = null;
 const noDataWrapperClsName = 'data-mapper-content__no-data';
 const loadingClsName = 'data-mapper-content__loading';
 const DATASET_TYPES = {Quantitative: 'quantitative', Qualitative: 'qualitative'};
+const EXCLUDE_TYPES = {DataMapper: 'data mapper'};
 
 function subindicatorsInSubCategory(subcategory) {
 
@@ -38,7 +39,6 @@ export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
     indicatorItemTemplate = $(".data-category__h4", subCategoryTemplate)[0].cloneNode(true);
 
     function addSubIndicators(wrapper, category, subcategory, indicator, groups, indicators, indicatorDetail) {
-
         $(".data-category__h3", wrapper).remove();
         $(".data-category__h4", wrapper).remove();
 
@@ -91,7 +91,8 @@ export function loadMenu(dataMapperMenu, data, subindicatorCallback) {
         $(".data-category__h3", h3Wrapper).remove();
 
         for (const [indicator, detail] of Object.entries(indicators)) {
-            if (detail.dataset_content_type != DATASET_TYPES.Qualitative) {
+            const isExcluded = isIndicatorExcluded(detail, EXCLUDE_TYPES.DataMapper);
+            if (detail.dataset_content_type !== DATASET_TYPES.Qualitative && !isExcluded) {
                 let newIndicator = indicatorClone.cloneNode(true);
                 $('.truncate', newIndicator).text(indicator);
                 $(h3Wrapper).append(newIndicator);

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -336,7 +336,7 @@ export function checkIfCategoryHasChildren(category, detail) {
 export function checkIfSubCategoryHasChildren(subcategory, detail) {
     let hasChildren = false;
     for (const [title, data] of Object.entries(detail.indicators)) {
-        if (!hasChildren && typeof data.child_data !== 'undefined') {
+        if (!hasChildren && data.child_data !== undefined && !isIndicatorExcluded(data, 'data mapper')) {
             for (const [geo, arr] of Object.entries(data.child_data)) {
                 hasChildren = hasChildren || arr.length > 0;
             }
@@ -344,6 +344,20 @@ export function checkIfSubCategoryHasChildren(subcategory, detail) {
     }
 
     return hasChildren;
+}
+
+export function isIndicatorExcluded(indicatorData, excludeType) {
+    let isExcluded = false;
+
+    if (indicatorData.chartConfiguration.exclude === undefined) {
+        isExcluded = false;
+    } else {
+        if (indicatorData.chartConfiguration.exclude.indexOf(excludeType) >= 0) {
+            isExcluded = true;
+        }
+    }
+
+    return isExcluded;
 }
 
 export function filterAndSumGeoCounts(childData, primaryGroup, selectedSubindicator) {
@@ -415,30 +429,30 @@ export function getSheetName(name) {
     return sheetName;
 }
 
-export function appendFilterArrays(arr1, arr2, primaryGroup){
+export function appendFilterArrays(arr1, arr2, primaryGroup) {
     let filterArr = arr1.concat(arr2).filter((f) => {
         return f.group !== primaryGroup
     });
 
     filterArr = filterArr.filter((f, index, self) =>
-        index === self.findIndex((t) => (
-            t.group === f.group
-        ))
+            index === self.findIndex((t) => (
+                t.group === f.group
+            ))
     )
 
     return filterArr;
 }
 
 export function assertNTemplates(n, $templateSelection) {
-  console.assert(
-    $templateSelection.length === n,
-    `Should be exactly ${n} template(s) but found ${$templateSelection.length}`
-  );
+    console.assert(
+        $templateSelection.length === n,
+        `Should be exactly ${n} template(s) but found ${$templateSelection.length}`
+    );
 }
 
-export function trimValue(val){
+export function trimValue(val) {
     let result = val;
-    if (typeof val === 'string' || val instanceof String){
+    if (typeof val === 'string' || val instanceof String) {
         result = val.trim();
     }
 

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -349,7 +349,7 @@ export function checkIfSubCategoryHasChildren(subcategory, detail) {
 export function isIndicatorExcluded(indicatorData, excludeType) {
     let isExcluded = false;
 
-    if (indicatorData.chartConfiguration.exclude === undefined) {
+    if (indicatorData.chartConfiguration === undefined || indicatorData.chartConfiguration.exclude === undefined) {
         isExcluded = false;
     } else {
         if (indicatorData.chartConfiguration.exclude.indexOf(excludeType) >= 0) {


### PR DESCRIPTION
## Description
hiding profile indicators in data mapper based on profile indicator configuration.

sample configuration : 
```
"exclude": ["data mapper"]
```

documentation : https://app.gitbook.com/@openup/s/wazi-ng-technical/profile-indicator-configuration#excluding-profile-indicators

an example of use can be seen here :
https://staging.wazimap-ng.openup.org.za/admin/profile/profileindicator/1123/change/

if all the indicators of a subcategory are hidden, the subcategory will not be shown too.

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-146

## How is it tested automatically?
added a unit test in `__tests__/setup/dataexplorer.test.js`

## How should a reviewer test it locally
* add `"exclude": ["data mapper"]` to the configuration json of any profile indicator
* confirm that in data mapper that indicator is shown
* confirm that once you remove the exclude property from the configuration json, the indicator is shown again

## Screenshots
without the `exclude` property : 
![image](https://user-images.githubusercontent.com/53019884/141269172-eaa52344-974d-4337-a9b0-4ffa50961b0f.png)


with the `exclude` property : 
![image](https://user-images.githubusercontent.com/53019884/141269295-471148d3-d0f9-40f8-a488-9b96cab090b1.png)


## Changelog

### Added

### Updated
* `src/js/utils.js` to add a function that will check if a profile indicator is excluded or not
* `src/js/elements/menu.js` to exclude the profile indicators based on the configuration

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
