### PR TITLE
WNCM-124 Reorder indicator data according to primary group's subindicator list

### DIFF
--- a/__tests__/profile/blocks/indicator.test.js
+++ b/__tests__/profile/blocks/indicator.test.js
@@ -4,19 +4,15 @@ import html from '../../../src/index.html';
 
 const CHART_DATA = {
     data: [
-        {count: "1203627", income: "R 153601 - R 307200"},
-        {count: "1649796", income: "R 76801 - R 153600"},
-        {count: "2469585", income: "R 19201 - R 38400"},
-        {count: "1132167", income: "No income"},
-        {count: "419334", income: "R 1 - R 4800"},
-        {count: "796136", income: "R 4801 - R 9600"},
-        {count: "2208054", income: "R 9601 - R 19200"},
-        {count: "1940963", income: "R 38401 - R 76800"},
-        {count: "494584", income: "R 307201 - R 614400"},
-        {count: "155154", income: "R 614401- R 1228800"},
-        {count: "50433", income: "R 1228801 - R 2457600"},
-        {count: "37034", income: "R2457601 or more"},
-        {count: "623210", income: "Unspecified"}],
+        {count: "1203627", income: "R 153601 - R 307200", gender: "Male"},
+        {count: "1649796", income: "R 76801 - R 153600", gender: "Male"},
+        {count: "2469585", income: "R 19201 - R 38400", gender: "Male"},
+        {count: "1132167", income: "No income", gender: "Male"},
+        {count: "1203627", income: "R 153601 - R 307200", gender: "Female"},
+        {count: "1649796", income: "R 76801 - R 153600", gender: "Female"},
+        {count: "2469585", income: "R 19201 - R 38400", gender: "Female"},
+        {count: "1132167", income: "No income", gender: "Female"},
+    ],
     groups: [],
     chartConfiguration: {
         disableToggle: false,
@@ -33,18 +29,16 @@ const CHART_DATA = {
             name: "income",
             subindicators: [
                 "No income",
-                "R 1 - R 4800",
-                "R 4801 - R 9600",
-                "R 9601 - R 19200",
-                "R 19201 - R 38400",
-                "R 38401 - R 76800",
                 "R 76801 - R 153600",
+                "R 19201 - R 38400",
                 "R 153601 - R 307200",
-                "R 307201 - R 614400",
-                "R 614401- R 1228800",
-                "R 1228801 - R 2457600",
-                "R2457601 or more",
-                "Unspecified"
+            ]
+        },
+        {
+            name: "gender",
+            subindicators: [
+                "Female",
+                "Male"
             ]
         }]
     }
@@ -59,7 +53,16 @@ describe('Indicator', () => {
         const component = new Component();
         const indicator = new Indicator(component, null, CHART_DATA, 'some title', false);
         indicator.orderChartData();
-        let order = CHART_DATA.metadata.groups[0].subindicators;
+        let order = [
+            "No income",
+            "No income",
+            "R 76801 - R 153600",
+            "R 76801 - R 153600",
+            "R 19201 - R 38400",
+            "R 19201 - R 38400",
+            "R 153601 - R 307200",
+            "R 153601 - R 307200",
+        ]
         order.forEach((x, index) => {
             expect(indicator.indicator.data[index].income).toBe(x);
         })

--- a/__tests__/profile/blocks/indicator.test.js
+++ b/__tests__/profile/blocks/indicator.test.js
@@ -41,6 +41,11 @@ const CHART_DATA = {
                 "Male"
             ]
         }]
+    },
+    version_data: {
+        model: {
+            isActive: true
+        }
     }
 }
 

--- a/__tests__/profile/blocks/indicator.test.js
+++ b/__tests__/profile/blocks/indicator.test.js
@@ -1,0 +1,67 @@
+import {Component} from "../../../src/js/utils";
+import {Indicator} from "../../../src/js/profile/blocks/indicator";
+import html from '../../../src/index.html';
+
+const CHART_DATA = {
+    data: [
+        {count: "1203627", income: "R 153601 - R 307200"},
+        {count: "1649796", income: "R 76801 - R 153600"},
+        {count: "2469585", income: "R 19201 - R 38400"},
+        {count: "1132167", income: "No income"},
+        {count: "419334", income: "R 1 - R 4800"},
+        {count: "796136", income: "R 4801 - R 9600"},
+        {count: "2208054", income: "R 9601 - R 19200"},
+        {count: "1940963", income: "R 38401 - R 76800"},
+        {count: "494584", income: "R 307201 - R 614400"},
+        {count: "155154", income: "R 614401- R 1228800"},
+        {count: "50433", income: "R 1228801 - R 2457600"},
+        {count: "37034", income: "R2457601 or more"},
+        {count: "623210", income: "Unspecified"}],
+    groups: [],
+    chartConfiguration: {
+        disableToggle: false,
+        defaultType: "Percentage",
+        types: {
+            Percentage: {formatting: ".0%", minX: "default", maxX: "default"},
+            Value: {formatting: ",.0f", minX: "default", maxX: "default"}
+        },
+        xTicks: null
+    },
+    metadata: {
+        primary_group: "income",
+        groups: [{
+            name: "income",
+            subindicators: [
+                "No income",
+                "R 1 - R 4800",
+                "R 4801 - R 9600",
+                "R 9601 - R 19200",
+                "R 19201 - R 38400",
+                "R 38401 - R 76800",
+                "R 76801 - R 153600",
+                "R 153601 - R 307200",
+                "R 307201 - R 614400",
+                "R 614401- R 1228800",
+                "R 1228801 - R 2457600",
+                "R2457601 or more",
+                "Unspecified"
+            ]
+        }]
+    }
+}
+
+describe('Indicator', () => {
+    beforeEach(() => {
+        document.body.innerHTML = html;
+    })
+
+    test('Handles chart data order correctly', () => {
+        const component = new Component();
+        const indicator = new Indicator(component, null, CHART_DATA, 'some title', false);
+        indicator.orderChartData();
+        let order = CHART_DATA.metadata.groups[0].subindicators;
+        order.forEach((x, index) => {
+            expect(indicator.indicator.data[index].income).toBe(x);
+        })
+    })
+})

--- a/src/js/profile/blocks/indicator.js
+++ b/src/js/profile/blocks/indicator.js
@@ -10,7 +10,9 @@ export class Indicator extends ContentBlock {
     }
 
     get hasData() {
-        return this.indicator.data.some(function(e) { return e.count > 0 });
+        return this.indicator.data.some(function (e) {
+            return e.count > 0
+        });
     }
 
     prepareDomElements() {
@@ -22,7 +24,8 @@ export class Indicator extends ContentBlock {
         const configuration = this.indicator.chartConfiguration;
 
         if (this.hasData) {
-            let c = new Chart(this, configuration, this.indicator, groups, this.container, this.title);
+            let chartData = this.orderChartData();
+            let c = new Chart(this, configuration, chartData, groups, this.container, this.title);
             this.bubbleEvents(c, [
                 'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
                 'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
@@ -30,5 +33,24 @@ export class Indicator extends ContentBlock {
             ]);
 
         }
+    }
+
+    orderChartData() {
+        let primaryGroup = this.indicator.metadata.primary_group;
+        let groupsOrder = this.indicator.metadata.groups.filter((g) => {
+            return g.name === primaryGroup
+        })[0];
+        let orderedGroups = [];
+
+        groupsOrder.subindicators.forEach((g) => {
+            let d = this.indicator.data.filter((x) => {
+                return x[primaryGroup] === g
+            })[0];
+            orderedGroups.push(d);
+        })
+
+        this.indicator.data = orderedGroups;
+
+        return this.indicator;
     }
 }

--- a/src/js/profile/blocks/indicator.js
+++ b/src/js/profile/blocks/indicator.js
@@ -37,19 +37,17 @@ export class Indicator extends ContentBlock {
 
     orderChartData() {
         let primaryGroup = this.indicator.metadata.primary_group;
-        let groupsOrder = this.indicator.metadata.groups.filter((g) => {
+        let groupsOrder = this.indicator.metadata.groups.find((g) => {
             return g.name === primaryGroup
-        })[0];
-        let orderedGroups = [];
+        });
+        let subindicators = groupsOrder.subindicators;
+        let data  = this.indicator.data;
 
-        groupsOrder.subindicators.forEach((g) => {
-            let d = this.indicator.data.filter((x) => {
-                return x[primaryGroup] === g
-            })[0];
-            orderedGroups.push(d);
+        // Sort data by subindicators
+        data.sort(function(obj1, obj2){
+            return subindicators.indexOf(obj1[primaryGroup]) - subindicators.indexOf(obj2[primaryGroup]);
         })
-
-        this.indicator.data = orderedGroups;
+        this.indicator.data = data;
 
         return this.indicator;
     }


### PR DESCRIPTION
## Description

Fix Bar chart reordering
Update for PR: https://github.com/OpenUpSA/wazimap-ng-ui/pull/439

## Related Issue
https://wazimap.atlassian.net/jira/software/c/projects/WNCM/boards/2?modal=detail&selectedIssue=WNCM-124

## How should a reviewer test it locally
How I tested it is:
* Change ordering of subindicators in subindicator group
* Visit UI and expand rich data panel
* Chart will not be ordered according to the new subindicator group
* Switch to branch and check bar chart again

## Screenshots


## Changelog

* Changed the way emre was doing sorting
* Added data with multiple groups in tests

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
