### PR TITLE
truncating point theme labels in point mapper

### DIFF
--- a/src/js/elements/point_tray/category.js
+++ b/src/js/elements/point_tray/category.js
@@ -35,7 +35,6 @@ export class Category extends Component {
 
         $(this.element).on('click', () => this.toggle())
         $(this.element).find(categoryItemLoadingClsName).addClass('hidden');
-        $(this.element).find('.point-mapper__h2_source div').removeAttr('title');
         this.showLoading(false);
         this.showDone(false);
         $(this.element).removeClass(activeClsName);
@@ -47,9 +46,10 @@ export class Category extends Component {
         $(this.element).attr('data-id', this.data.id);
         $(this.element).attr('data-themeIndex', this.themeIndex);
 
-        $('.point-mapper__h2_name .truncate', this.element).text(this.name);
+        $('.point-mapper__h2_name .truncate', this.element)
+            .text(this.name)
+            .attr('title', this.name);
         $('.point-data__label_source .truncate', this.element).text(this.data.metadata.source);
-        $('.point-data__label_source .truncate', this.element).attr('title', this.data.metadata.source);
         $('.point-data__h2_link', this.element).removeClass('point-data__h2_link').addClass('point-data__h2_link--disabled');
     }
 

--- a/src/js/elements/point_tray/category.js
+++ b/src/js/elements/point_tray/category.js
@@ -35,6 +35,7 @@ export class Category extends Component {
 
         $(this.element).on('click', () => this.toggle())
         $(this.element).find(categoryItemLoadingClsName).addClass('hidden');
+        $(this.element).find('.point-mapper__h2_source div').removeAttr('title');
         this.showLoading(false);
         this.showDone(false);
         $(this.element).removeClass(activeClsName);

--- a/src/js/elements/point_tray/theme.js
+++ b/src/js/elements/point_tray/theme.js
@@ -28,7 +28,11 @@ export class Theme extends Component {
         $(this.element).removeClass(hideondeployClsName);
         $(this.element).find('.point-mapper__h1_checkbox input[type=checkbox]').on('click', () => self.toggle());
         $('.point-data__h1_name .truncate', this.element).text(this.name);
-        $('.point-mapper__h1_trigger', this.element).removeClass(activeClsName).addClass('theme-' + this.themeIndex);
+        $('.point-mapper__h1_trigger', this.element)
+            .removeClass(activeClsName)
+            .addClass('theme-' + this.themeIndex)
+            .addClass('is--toggle-all')
+            .attr('title', this.name);
         $('.point-mapper__h1_checkbox', this.element).addClass('is--shown');
 
         $(categoryWrapperClsName, this.element).html('');

--- a/src/js/elements/point_tray/theme.js
+++ b/src/js/elements/point_tray/theme.js
@@ -54,7 +54,7 @@ export class Theme extends Component {
             this.categories.push(category);
 
             $(self.element).find(categoryWrapperClsName).append(category.element);
-            $(categorySourceClsName, category.element).text(category.metadata.source);
+            $(categorySourceClsName, category.element).text(category.metadata.source).attr('title', category.metadata.source);
         })
     }
 


### PR DESCRIPTION
## Description
truncating the point theme labels using the `is--toggle-all` class and adding title attribute to them

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-129

## How is it tested automatically?

## How should a reviewer test it locally
* go to SANEF profile 
* confirm that in the point mapper the long theme labels are truncated
* confirm that when you hover over a truncated label you can see the full name

## Screenshots
before : 
![image](https://user-images.githubusercontent.com/53019884/144047413-b2c46a22-6b91-4589-959f-59620a0c512e.png)

after : 
![image](https://user-images.githubusercontent.com/53019884/144047465-9db28710-73da-4afa-a7d0-5c9d24bc394d.png)


## Changelog

### Added

### Updated
* `theme.js` to add `is--toggle-all` class and title attribute

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
