### PR TITLE
WNCM-238 Added tests for metadata source value in chart download

### DIFF
--- a/__tests__/profile/charts/barchart.test.js
+++ b/__tests__/profile/charts/barchart.test.js
@@ -326,4 +326,50 @@ describe('Test downloadable barchart', () => {
       expect(view.signal('geography')).toBe('South Africa');
       expect(view.signal('attribution').toString()).toBe('Profile config attribution');
     });
+
+    test('Test to check null metadata source', async () => {
+      let annotations = {
+          'title': 'Population',
+          'geography': 'South Africa',
+          'attribution': 'Profile config attribution',
+          'graphValueType': 'Percentage'
+      }
+      metadata["source"] = null;
+      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let view = renderVegaHeadless(vegaDownloadSpec);
+      await view.runAsync()
+      expect(view.signal('source')).toBe('');
+    });
+
+    test('Test to check undefined metadata source', async () => {
+      let annotations = {
+          'title': 'Population',
+          'geography': 'South Africa',
+          'attribution': 'Profile config attribution',
+          'graphValueType': 'Percentage'
+      }
+      metadata["source"] = undefined;
+      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let view = renderVegaHeadless(vegaDownloadSpec);
+      await view.runAsync()
+      expect(view.signal('source')).toBe('');
+    });
+
+    test('Test to check valid metadata source', async () => {
+      let annotations = {
+          'title': 'Population',
+          'geography': 'South Africa',
+          'attribution': 'Profile config attribution',
+          'graphValueType': 'Percentage'
+      }
+      let metadata = {
+        source: "test",
+        primary_group: 'age',
+        groups: [ { name: 'age' } ]
+      }
+      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let view = renderVegaHeadless(vegaDownloadSpec);
+      await view.runAsync()
+      expect(view.signal('source')).toBe('Source : test');
+    });
 });


### PR DESCRIPTION
## Description
Added test cases for hotfix for metadata source value null in chart download.


## Related Issue
https://wazimap.atlassian.net/browse/WNCM-236
https://wazimap.atlassian.net/browse/WNCM-238

## How is it tested automatically?
run jest tests to check if hotfix works for various conditions

## How should a reviewer test it locally


## Screenshots


## Changelog
Added 3 new tests in  `__tests__/profile/charts/barchart.test.js`
tests:
* If metadata source value is null
* If metadata source value is undefiend
* If metadata source has valid value


### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
