### PR TITLE
showing an error message when the themes-count fails

### DIFF
--- a/__tests__/gui/facilities.feature
+++ b/__tests__/gui/facilities.feature
@@ -17,3 +17,15 @@ Feature: Facilities
     When I navigate back to ZA
     And I wait until "South Africa Test" is ready
     Then Facilities should be visible
+
+    # test the failed state
+    When I navigate to a geography where themes-count endpoint fails
+    And I wait until "South Africa Test" is ready
+    Then I check if error message is displayed on the theme count section
+
+    # confirm that after navigating back to ZA everything works correctly
+    When I navigate back to ZA
+    And I click on Show Locations button
+    Then I check if the location count is correct
+    Then I check if the facilities are created correctly
+    Then I navigate to EC and check if the loading state is displayed correctly

--- a/__tests__/gui/facilities/all_details_WC.json
+++ b/__tests__/gui/facilities/all_details_WC.json
@@ -1,0 +1,51 @@
+{
+  "profile": {
+    "logo": {
+      "image": "",
+      "url": "/"
+    },
+    "geography": {
+      "name": "South Africa Test",
+      "code": "WC",
+      "level": "country",
+      "version": "2011 Boundaries",
+      "parents": []
+    },
+    "profile_data": {},
+    "highlights": [],
+    "overview": {
+      "name": "Test profile",
+      "description": ""
+    }
+  },
+  "boundary": {
+    "type": "Feature",
+    "geometry": {
+      "type": "MultiPolygon",
+      "coordinates": [
+        [
+          18.1593,
+          -33.3645
+        ],
+        [
+          18.1513,
+          -33.3542
+        ],
+        [
+          18.1472,
+          -33.3551
+        ]
+      ]
+    },
+   "properties": {
+     "code": "WC",
+     "name": "South Africa Test",
+     "area": 129462.194,
+     "parent": "Africa",
+     "level": "country",
+     "version": "2011 Boundaries"
+   }
+  },
+  "parent_layers": [],
+  "children":{}
+}

--- a/__tests__/gui/facilities/facilities.js
+++ b/__tests__/gui/facilities/facilities.js
@@ -10,6 +10,7 @@ import all_details from "../facilities/all_details.json";
 import all_details_CPT from "../facilities/all_details_CPT.json";
 import themes_count from "./themes_count.json";
 import themes_count_EC from "./themes_count_EC.json";
+import all_details_WC from "./all_details_WC.json";
 import profile from "../facilities/profile.json";
 import profiles from "./profiles.json";
 
@@ -129,3 +130,27 @@ When(/^I wait until "([^"]*)" is ready$/, function (word) {
     cy.wait(1000);  //creating the point summary is async
     cy.get('.location__title h1').should('have.text', word);
 });
+
+When('I navigate to a geography where themes-count endpoint fails', () => {
+    cy.intercept(`/api/v1/${allDetailsEndpoint}/profile/8/geography/WC/?version=test&skip-children=true&format=json`, (request) => {
+        request.reply({
+            statusCode: 201,
+            body: all_details_WC,
+            forceNetworkError: false // default
+        })
+    });
+
+    cy.intercept('/api/v1/profile/8/geography/WC/themes_count/?version=test&format=json', (request) => {
+        request.reply({
+            statusCode: 201,
+            body: null,
+            forceNetworkError: false // default
+        })
+    });
+
+    cy.visit('/#geo:WC');
+})
+
+Then('I check if error message is displayed on the theme count section', () => {
+    cy.get('.location__facilities_error').should('be.visible');
+})

--- a/src/js/profile/facilities/facility_controller.js
+++ b/src/js/profile/facilities/facility_controller.js
@@ -80,6 +80,8 @@ export class FacilityController extends Component {
 
     set isFailed(value) {
         if (value) {
+            $('.rich-data-content .location__facilities .location__facilities_header').addClass('hidden');
+            $('.rich-data-content .location__facilities .location__facilities_trigger').addClass('hidden');
             $('.rich-data-content .location__facilities .location__facilities_error').removeClass('hidden');
         } else {
             $('.rich-data-content .location__facilities .location__facilities_error').addClass('hidden');
@@ -130,6 +132,10 @@ export class FacilityController extends Component {
     }
 
     prepareFailMessage() {
+        if ($('.rich-data-content .location__facilities .location__facilities_error').length > 0) {
+            return;
+        }
+
         let failMsg = document.createElement('div');
         $(failMsg).addClass('location__facilities_error').addClass('hidden');
         $(failMsg).html('Failed to load this data');
@@ -206,6 +212,7 @@ export class FacilityController extends Component {
 
             self.model.triggerEvent(FacilityControllerModel.EVENTS.facilitiesCreated);
             self.isLoading = false;
+            self.isFailed = false;
             $('.location__facilities').removeClass('hidden');
         } else {
             $('.location__facilities').addClass('hidden');

--- a/src/js/profile/facilities/facility_controller.js
+++ b/src/js/profile/facilities/facility_controller.js
@@ -1,7 +1,6 @@
 import {Facility} from "./facility";
 import XLSX from "xlsx";
-import {Component, extractSheetsData, Observable} from "../../utils";
-import {TestData} from "../../test_data";
+import {Component, extractSheetsData} from "../../utils";
 
 export class FacilityControllerModel extends Component {
     static EVENTS = {
@@ -50,6 +49,7 @@ export class FacilityController extends Component {
 
         this._model = new FacilityControllerModel(this, parent);
         this._isLoading = false;
+        this._isFailed = false;
         this._isExpanded = false;
         this.facilityItems = [];
         this.prepareDomElements();
@@ -72,6 +72,20 @@ export class FacilityController extends Component {
         }
 
         this._isLoading = value;
+    }
+
+    get isFailed() {
+        return this._isFailed;
+    }
+
+    set isFailed(value) {
+        if (value) {
+            $('.rich-data-content .location__facilities .location__facilities_error').removeClass('hidden');
+        } else {
+            $('.rich-data-content .location__facilities .location__facilities_error').addClass('hidden');
+        }
+
+        this._isFailed = value;
     }
 
     get isExpanded() {
@@ -100,6 +114,9 @@ export class FacilityController extends Component {
 
         this.expandButton = $('.location__facilities_expand');
         this.collapseButton = $('.location__facilities_contract');
+
+        this.prepareFailMessage();
+
         this.isExpanded = false;
     }
 
@@ -112,12 +129,34 @@ export class FacilityController extends Component {
         })
     }
 
+    prepareFailMessage() {
+        let failMsg = document.createElement('div');
+        $(failMsg).addClass('location__facilities_error').addClass('hidden');
+        $(failMsg).html('Failed to load this data');
+
+        $(failMsg).css('display', 'block');
+        $(failMsg).css('color', '#666');
+        $(failMsg).css('width', '100%');
+        $(failMsg).css('background-color', '#f0f0f0');
+        $(failMsg).css('padding', '4px 6px');
+        $(failMsg).css('font-size', '0.9em');
+        $(failMsg).css('border-radius', '2px');
+        $(failMsg).css('margin-right', '6px');
+        $(failMsg).css('margin-left', '6px');
+
+        $('.rich-data-content .location__facilities').append(failMsg);
+    }
+
     getAndAddFacilities(activeVersion) {
         if (this.model.api !== null) {
             this.model.api.getThemesCount(this.model.profileId, this.model.geography.code, activeVersion.model.name)
                 .then((data) => {
                     this.model.themes = data;
                     this.addFacilities();
+                })
+                .catch(() => {
+                    this.isLoading = false;
+                    this.isFailed = true;
                 })
         }
     }
@@ -193,6 +232,7 @@ export class FacilityController extends Component {
     }
 
     hideLoadingState() {
+        $('.location__facilities_loading').addClass('hidden');
         $('.location__facilities_title--loading').addClass('hidden');
         $('.location__facilities_title').removeClass('hidden');
 

--- a/src/js/profile/facilities/facility_controller.js
+++ b/src/js/profile/facilities/facility_controller.js
@@ -139,7 +139,7 @@ export class FacilityController extends Component {
 
         let failMsg = document.createElement('div');
         $(failMsg).addClass('location__facilities_error').addClass('hidden');
-        $(failMsg).html('Failed to load this data');
+        $(failMsg).html('Failed to load summary of available point data. Please reload or try again later.');
 
         $(failMsg).css('display', 'block');
         $(failMsg).css('color', '#666');

--- a/src/js/profile/facilities/facility_controller.js
+++ b/src/js/profile/facilities/facility_controller.js
@@ -1,6 +1,7 @@
 import {Facility} from "./facility";
 import XLSX from "xlsx";
 import {Component, extractSheetsData} from "../../utils";
+import * as Sentry from "@sentry/browser";
 
 export class FacilityControllerModel extends Component {
     static EVENTS = {
@@ -160,9 +161,11 @@ export class FacilityController extends Component {
                     this.model.themes = data;
                     this.addFacilities();
                 })
-                .catch(() => {
+                .catch((err) => {
+                    console.error({err})
                     this.isLoading = false;
                     this.isFailed = true;
+                    Sentry.captureException(err);
                 })
         }
     }


### PR DESCRIPTION
## Description
showing an error message on the theme counts section instead of the generic alert when the themes-count endpoint fails to respond 

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-257

## How is it tested automatically?
added test steps into `__tests__/gui/facilities/facilities.js`

## How should a reviewer test it locally


## Screenshots
![image](https://user-images.githubusercontent.com/53019884/153591697-c166fa13-8851-4330-b8a2-5420ae18e838.png)


## Changelog

### Added

### Updated
* `src/js/profile/facilities/facility_controller.js` to show / hide the failed message

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
