### PR TITLE
hiding description when mapchip is minimised

### DIFF
--- a/__tests__/elements/subindicator_filter/filter_controller.test.js
+++ b/__tests__/elements/subindicator_filter/filter_controller.test.js
@@ -134,22 +134,24 @@ describe('Visibility of the filter area', () => {
         mc.onSubIndicatorChange(params);
         const isVisible = mc.filterController.shouldFiltersBeVisible();
         let filterArea = document.querySelector('.map-options__filters_content');
+        let message = document.querySelector(`${mapBottomItems} .map-options__filters_content .map-options__no-data`);
 
         expect(isVisible).toBe(true);
         expect(filterArea).not.toHaveClass('hidden');
+        expect(message).toHaveClass('hidden');
     })
 
-    test('Filters are hidden when there are no groups to filter by', () => {
+    test('Warning message is shown when there are no groups to filter by', () => {
         params.groups = [];
         let component = new Component();
         let mc = new MapChip(component, mapchip_colors);
 
         mc.onSubIndicatorChange(params);
         const isVisible = mc.filterController.shouldFiltersBeVisible();
-        let filterArea = document.querySelector(`${mapBottomItems} .map-options__filters_content`);
+        let message = document.querySelector(`${mapBottomItems} .map-options__filters_content .map-options__no-data`);
 
         expect(isVisible).toBe(false);
-        expect(filterArea).toHaveClass('hidden');
+        expect(message).not.toHaveClass('hidden');
     })
 
     test('Filters are visible when all the groups are non-aggregatable', () => {

--- a/__tests__/gui/common_cy_functions/general.js
+++ b/__tests__/gui/common_cy_functions/general.js
@@ -178,7 +178,9 @@ export function collapseChoroplethFilterDialog() {
 }
 
 export function checkIfChoroplethFilterDialogIsCollapsed() {
+    const descriptionArea = '.map-options__context--v2';
     checkIfFilterDialogIsCollapsed('.map-options', '.map-options__filters_content');
+    cy.get(`${mapBottomItems} .map-options ${descriptionArea}`).should('not.be.visible');
 }
 
 export function expandChoroplethFilterDialog() {
@@ -186,7 +188,9 @@ export function expandChoroplethFilterDialog() {
 }
 
 export function checkIfChoroplethFilterDialogIsExpanded() {
+    const descriptionArea = '.map-options__context--v2';
     checkIfFilterDialogIsExpanded('.map-options', '.map-options__filters_content');
+    cy.get(`${mapBottomItems} .map-options ${descriptionArea}`).should('be.visible');
 }
 
 function expandFilterDialog(parentDiv) {

--- a/__tests__/gui/common_cy_functions/general.js
+++ b/__tests__/gui/common_cy_functions/general.js
@@ -179,8 +179,10 @@ export function collapseChoroplethFilterDialog() {
 
 export function checkIfChoroplethFilterDialogIsCollapsed() {
     const descriptionArea = '.map-options__context--v2';
+    const legendArea = '.map-options__legend';
     checkIfFilterDialogIsCollapsed('.map-options', '.map-options__filters_content');
     cy.get(`${mapBottomItems} .map-options ${descriptionArea}`).should('not.be.visible');
+    cy.get(`${mapBottomItems} .map-options ${legendArea}`).should('be.visible');
 }
 
 export function expandChoroplethFilterDialog() {
@@ -189,8 +191,10 @@ export function expandChoroplethFilterDialog() {
 
 export function checkIfChoroplethFilterDialogIsExpanded() {
     const descriptionArea = '.map-options__context--v2';
+    const legendArea = '.map-options__legend';
     checkIfFilterDialogIsExpanded('.map-options', '.map-options__filters_content');
     cy.get(`${mapBottomItems} .map-options ${descriptionArea}`).should('be.visible');
+    cy.get(`${mapBottomItems} .map-options ${legendArea}`).should('be.visible');
 }
 
 function expandFilterDialog(parentDiv) {

--- a/src/js/elements/subindicator_filter/filter_controller.js
+++ b/src/js/elements/subindicator_filter/filter_controller.js
@@ -70,6 +70,7 @@ export class FilterController extends Component {
         this._filterCallback = null;
         this._elements = elements;
         this._isLoading = true;
+        this._noFiltersAvailable = true;
 
         this._mapBottomItems = '.map-bottom-items--v2';
         this._upArrow = `${this._mapBottomItems} .map-options .toggle-icon-v--last`;
@@ -116,6 +117,22 @@ export class FilterController extends Component {
         this._isLoading = value;
     }
 
+    get noFiltersAvailable() {
+        return this._noFiltersAvailable;
+    }
+
+    set noFiltersAvailable(value) {
+        if (value) {
+            this.addFilterButton.hide();
+            $('.map-options__no-data').removeClass('hidden');
+        } else {
+            this.addFilterButton.show();
+            $('.map-options__no-data').addClass('hidden');
+        }
+
+        this._noFiltersAvailable = value;
+    }
+
     prepareDomElements() {
         this._rowContainer = $(this.container).find(this._elements.filterRowClass)[0];
         $(this._rowContainer).hide();
@@ -135,12 +152,7 @@ export class FilterController extends Component {
 
     setFilterVisibility() {
         const isVisible = this.shouldFiltersBeVisible();
-
-        if (isVisible) {
-            $(this.container).removeClass('hidden');
-        } else {
-            $(this.container).addClass('hidden');
-        }
+        this.noFiltersAvailable = !isVisible;
     }
 
     shouldFiltersBeVisible() {
@@ -154,6 +166,10 @@ export class FilterController extends Component {
     }
 
     addInitialFilterRow(dataFilterModel) {
+        if (this.noFiltersAvailable){
+            return;
+        }
+
         let isDefault = true;
         let isExtra = false;
 
@@ -312,11 +328,13 @@ export class FilterController extends Component {
 
     setContentVisibility() {
         $(this._upArrow).on('click', () => {
-            this.showFilterContent()
+            this.showFilterContent();
+            this.showDescription();
         });
 
         $(this._downArrow).on('click', () => {
-            this.hideFilterContent()
+            this.hideFilterContent();
+            this.hideDescription();
         });
 
         this.showFilterContent();
@@ -332,5 +350,13 @@ export class FilterController extends Component {
         $(this._upArrow).removeClass('hidden');
         $(this._downArrow).addClass('hidden');
         $(this._filterContent).addClass('hidden');
+    }
+
+    showDescription() {
+        $('.map-options__context--v2').removeClass('hidden');
+    }
+
+    hideDescription() {
+        $('.map-options__context--v2').addClass('hidden');
     }
 }


### PR DESCRIPTION
## Description
* hiding the filter area and description & only showing the legend when mapchip is minimised
* showing "No filters available for the selected data." message in mapchip when there are no columns to filter by

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-228


## How is it tested automatically?
testing the visibility of the description in `__tests__/gui/common_cy_functions/general.js` when the mapchip is collapsed / expanded

## How should a reviewer test it locally
* Go to SANEF profile
* Select Elections > 2021 Municipal elections > Voter turnout > Voted
* Confirm that "No filters available for the selected data." message is displayed
* Confirm that when you collapse the mapchip, filter area and the description is hidden but the legend is visible
* Confirm that choropleth filtering still works the same way as before when there are columns to filter by

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/154967831-342c6a90-81c9-4dae-9988-620966f0e07a.png)


## Changelog

### Added

### Updated
* `src/js/elements/subindicator_filter/filter_controller.js` to show error message and hide description when collapsed
* `__tests__/gui/common_cy_functions/general.js` to check the visibility of the description and the legend when collapsed and expanded

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
