### PR TITLE
Fix breaking bar chart labels when data is not present

### DIFF
--- a/__tests__/profile/charts/barchart.test.js
+++ b/__tests__/profile/charts/barchart.test.js
@@ -214,7 +214,7 @@ describe('Test downloadable barchart', () => {
             'attribution': 'Profile config attribution',
             'graphValueType': 'Percentage'
         }
-        let vegaDownloadSpec = configureBarchartDownload(data, metadata, config, annotations);
+        let vegaDownloadSpec = configureBarchartDownload(data, data, metadata, config, annotations);
         let view = renderVegaHeadless(vegaDownloadSpec);
         await view.runAsync()
 
@@ -234,7 +234,7 @@ describe('Test downloadable barchart', () => {
             'graphValueType': 'Percentage'
         }
         metadata["source"] = '';
-        let vegaDownloadSpec = configureBarchartDownload(data, metadata, config, annotations);
+        let vegaDownloadSpec = configureBarchartDownload(data, data, metadata, config, annotations);
         let view = renderVegaHeadless(vegaDownloadSpec);
         await view.runAsync()
         expect(view.signal('source').toString()).toBe('');
@@ -317,7 +317,7 @@ describe('Test downloadable barchart', () => {
           'attribution': 'Profile config attribution',
           'graphValueType': 'Percentage'
       }
-      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
 
@@ -335,7 +335,7 @@ describe('Test downloadable barchart', () => {
           'graphValueType': 'Percentage'
       }
       metadata["source"] = null;
-      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
       expect(view.signal('source')).toBe('');
@@ -349,7 +349,7 @@ describe('Test downloadable barchart', () => {
           'graphValueType': 'Percentage'
       }
       metadata["source"] = undefined;
-      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
       expect(view.signal('source')).toBe('');
@@ -367,9 +367,79 @@ describe('Test downloadable barchart', () => {
         primary_group: 'age',
         groups: [ { name: 'age' } ]
       }
-      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
       expect(view.signal('source')).toBe('Source : test');
     });
+});
+
+
+describe('configureBarchart for missing data', () => {
+    document.body.innerHTML = html;
+
+    let data, metadata, config;
+    beforeEach(() => {
+        metadata = {
+            primary_group: "education_level",
+            groups: [{name: "education_level"}, {name: "gender"}]
+        },
+            data = [
+                {age: 15, gender: 'male', count: 1, education_level: "Grade9"},
+                {age: 12, gender: 'female', count: 3, education_level: "Grade10"},
+                {age: 14, gender: 'male', count: 2, education_level: "Grade9"}
+            ]
+        config = {
+            types: {
+                Value: {
+                    formatting: ",.0f",
+                    minX: "default",
+                    maxX: "default"
+                },
+                Percentage: {
+                    formatting: ".0%",
+                    minX: "default",
+                    maxX: "default"
+                }
+            },
+            disableToggle: false,
+            defaultType: "Value",
+            xTicks: null
+        }
+    });
+
+    test('Test missing data after apply filters', async () => {
+      let vegaSpec = configureBarchart(data, metadata, config);
+      let view = renderVegaHeadless(vegaSpec);
+      await view.runAsync()
+
+      let yscaleDomain = view._runtime.scales.yscale._argval.domain;
+      // assert there will be 2 domains - Grade9 & Grade10
+      expect(yscaleDomain.length).toEqual(2);
+      expect(yscaleDomain).toEqual(["Grade9", "Grade10"]);
+
+      // Assert there will be 2 bars for 2 domains
+      let bars = view._runtime.data.bars.values.value;
+      expect(bars.length).toEqual(2);
+      expect(bars[0].datum.education_level).toEqual("Grade9");
+      expect(bars[1].datum.education_level).toEqual("Grade10");
+
+      // Call Filter Signal
+      view.signal('genderFilter', true).run();
+      view.signal('genderFilterValue', "male").run();
+
+      await view.runAsync();
+      yscaleDomain = view._runtime.scales.yscale._argval.domain;
+
+      // assert there will be 2 domains - Grade9 & Grade10
+      expect(yscaleDomain.length).toEqual(2);
+      expect(yscaleDomain).toEqual(["Grade9", "Grade10"]);
+
+      // Assert there will be 1 bar for 2 domains
+      bars = view._runtime.data.bars.values.value;
+      expect(bars.length).toEqual(1);
+      expect(bars[0].datum.education_level).toEqual("Grade9");
+
+    });
+
 });

--- a/__tests__/profile/charts/barchart.test.js
+++ b/__tests__/profile/charts/barchart.test.js
@@ -214,7 +214,7 @@ describe('Test downloadable barchart', () => {
             'attribution': 'Profile config attribution',
             'graphValueType': 'Percentage'
         }
-        let vegaDownloadSpec = configureBarchartDownload(data, metadata, config, annotations);
+        let vegaDownloadSpec = configureBarchartDownload(data, [], metadata, config, annotations);
         let view = renderVegaHeadless(vegaDownloadSpec);
         await view.runAsync()
 
@@ -234,7 +234,7 @@ describe('Test downloadable barchart', () => {
             'graphValueType': 'Percentage'
         }
         metadata["source"] = '';
-        let vegaDownloadSpec = configureBarchartDownload(data, metadata, config, annotations);
+        let vegaDownloadSpec = configureBarchartDownload(data, [], metadata, config, annotations);
         let view = renderVegaHeadless(vegaDownloadSpec);
         await view.runAsync()
         expect(view.signal('source').toString()).toBe('');
@@ -317,7 +317,7 @@ describe('Test downloadable barchart', () => {
           'attribution': 'Profile config attribution',
           'graphValueType': 'Percentage'
       }
-      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
 
@@ -335,7 +335,7 @@ describe('Test downloadable barchart', () => {
           'graphValueType': 'Percentage'
       }
       metadata["source"] = null;
-      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
       expect(view.signal('source')).toBe('');
@@ -349,7 +349,7 @@ describe('Test downloadable barchart', () => {
           'graphValueType': 'Percentage'
       }
       metadata["source"] = undefined;
-      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
       expect(view.signal('source')).toBe('');
@@ -367,7 +367,7 @@ describe('Test downloadable barchart', () => {
         primary_group: 'age',
         groups: [ { name: 'age' } ]
       }
-      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
       expect(view.signal('source')).toBe('Source : test');

--- a/__tests__/profile/charts/barchart.test.js
+++ b/__tests__/profile/charts/barchart.test.js
@@ -214,7 +214,7 @@ describe('Test downloadable barchart', () => {
             'attribution': 'Profile config attribution',
             'graphValueType': 'Percentage'
         }
-        let vegaDownloadSpec = configureBarchartDownload(data, data, metadata, config, annotations);
+        let vegaDownloadSpec = configureBarchartDownload(data, metadata, config, annotations);
         let view = renderVegaHeadless(vegaDownloadSpec);
         await view.runAsync()
 
@@ -234,7 +234,7 @@ describe('Test downloadable barchart', () => {
             'graphValueType': 'Percentage'
         }
         metadata["source"] = '';
-        let vegaDownloadSpec = configureBarchartDownload(data, data, metadata, config, annotations);
+        let vegaDownloadSpec = configureBarchartDownload(data, metadata, config, annotations);
         let view = renderVegaHeadless(vegaDownloadSpec);
         await view.runAsync()
         expect(view.signal('source').toString()).toBe('');
@@ -317,7 +317,7 @@ describe('Test downloadable barchart', () => {
           'attribution': 'Profile config attribution',
           'graphValueType': 'Percentage'
       }
-      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
 
@@ -335,7 +335,7 @@ describe('Test downloadable barchart', () => {
           'graphValueType': 'Percentage'
       }
       metadata["source"] = null;
-      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
       expect(view.signal('source')).toBe('');
@@ -349,7 +349,7 @@ describe('Test downloadable barchart', () => {
           'graphValueType': 'Percentage'
       }
       metadata["source"] = undefined;
-      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
       expect(view.signal('source')).toBe('');
@@ -367,7 +367,7 @@ describe('Test downloadable barchart', () => {
         primary_group: 'age',
         groups: [ { name: 'age' } ]
       }
-      let vegaDownloadSpec = configureBarchartDownload([], [], metadata, config, annotations);
+      let vegaDownloadSpec = configureBarchartDownload([], metadata, config, annotations);
       let view = renderVegaHeadless(vegaDownloadSpec);
       await view.runAsync()
       expect(view.signal('source')).toBe('Source : test');
@@ -382,7 +382,13 @@ describe('configureBarchart for missing data', () => {
     beforeEach(() => {
         metadata = {
             primary_group: "education_level",
-            groups: [{name: "education_level"}, {name: "gender"}]
+            groups: [{
+                name: "education_level",
+                subindicators: ["Grade9", "Grade10"]
+            }, {
+                name: "gender",
+                subindicators: ["male", "female"]
+            }]
         },
         data = [
             {age: 15, gender: 'male', count: 1, education_level: "Grade9"},

--- a/__tests__/profile/charts/barchart.test.js
+++ b/__tests__/profile/charts/barchart.test.js
@@ -384,11 +384,11 @@ describe('configureBarchart for missing data', () => {
             primary_group: "education_level",
             groups: [{name: "education_level"}, {name: "gender"}]
         },
-            data = [
-                {age: 15, gender: 'male', count: 1, education_level: "Grade9"},
-                {age: 12, gender: 'female', count: 3, education_level: "Grade10"},
-                {age: 14, gender: 'male', count: 2, education_level: "Grade9"}
-            ]
+        data = [
+            {age: 15, gender: 'male', count: 1, education_level: "Grade9"},
+            {age: 12, gender: 'female', count: 3, education_level: "Grade10"},
+            {age: 14, gender: 'male', count: 2, education_level: "Grade9"}
+        ]
         config = {
             types: {
                 Value: {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -12,7 +12,7 @@ import embed from "vega-embed";
 import * as vega from "vega";
 
 import {configureBarchart, configureBarchartDownload} from './charts/barChart';
-import {slugify} from './charts/utils';
+import {slugify, sortDataForSubindicatorGroup} from './charts/utils';
 import DropdownMenu from "../elements/dropdown_menu";
 import {FilterController} from "../elements/subindicator_filter/filter_controller";
 import {DataFilterModel} from "../models/data_filter_model";
@@ -76,7 +76,6 @@ export class Chart extends Component {
     addChart = (data) => {
         $(".bar-chart", this.container).remove();
         $("svg", this.container).remove();
-
         let vegaSpec = configureBarchart(data.data, data.metadata, this.config);
 
         const calculatePosition = (event, tooltipBox, offsetX, offsetY) => {
@@ -196,10 +195,12 @@ export class Chart extends Component {
 
         let tbody = document.createElement('tbody');
 
-        const dataArr = this.vegaView.data('data_formatted');
+        let dataArr = this.vegaView.data('data_formatted');
         const primaryGroup = this.vegaView.signal('mainGroup');
+        const subindicators = this.vegaView.signal('yAxisDomain');
         const formatting = this.vegaView.signal('numberFormat');
 
+        dataArr = sortDataForSubindicatorGroup(dataArr, subindicators, primaryGroup)
         dataArr.forEach((d) => {
             let absoluteVal = d.count;
             let percentageVal = d.percentage;
@@ -269,8 +270,7 @@ export class Chart extends Component {
             "attribution": this.profileAttribution,
             "graphValueType": this.graphValueType
         }
-
-        let specDownload = configureBarchartDownload(this.vegaView.data('table'), this.vegaView.data('filteredTable'), this.data.metadata, this.config, annotations);
+        let specDownload = configureBarchartDownload(this.vegaView.data('filteredTable'), this.data.metadata, this.config, annotations);
 
         this.vegaDownloadView = new vega.View(vega.parse(specDownload));
 

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -270,7 +270,12 @@ export class Chart extends Component {
             "attribution": this.profileAttribution,
             "graphValueType": this.graphValueType
         }
-        let specDownload = configureBarchartDownload(this.vegaView.data('filteredTable'), this.data.metadata, this.config, annotations);
+
+        let specDownload = configureBarchartDownload(
+          this.vegaView.data('filteredTable'),
+          this.vegaView.signal('yAxisDomain'),
+          this.data.metadata, this.config, annotations
+        );
 
         this.vegaDownloadView = new vega.View(vega.parse(specDownload));
 

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -270,7 +270,7 @@ export class Chart extends Component {
             "graphValueType": this.graphValueType
         }
 
-        let specDownload = configureBarchartDownload(this.vegaView.data('table'), this.data.metadata, this.config, annotations);
+        let specDownload = configureBarchartDownload(this.vegaView.data('table'), this.vegaView.data('filteredTable'), this.data.metadata, this.config, annotations);
 
         this.vegaDownloadView = new vega.View(vega.parse(specDownload));
 

--- a/src/js/profile/charts/barChart.js
+++ b/src/js/profile/charts/barChart.js
@@ -18,7 +18,7 @@ export const configureBarchart = (data, metadata, config) => {
         }
     } = config;
     const {primary_group: primaryGroup} = metadata;
-    const subindicators = getSubindicatorsOfGroup(metadata.groups, primaryGroup)
+    const subindicators = getSubindicatorsOfGroup(data, metadata.groups, primaryGroup)
 
     if (xTicks) {
         xAxis.tickCount = xTicks;
@@ -227,7 +227,7 @@ export const configureBarchart = (data, metadata, config) => {
     };
 };
 
-export const configureBarchartDownload = (filteredData, metadata, config, annotations) => {
+export const configureBarchartDownload = (filteredData, subindicators, metadata, config, annotations) => {
     const {
         xTicks,
         defaultType,
@@ -238,7 +238,6 @@ export const configureBarchartDownload = (filteredData, metadata, config, annota
     } = config;
 
     const {primary_group: primaryGroup} = metadata;
-    const subindicators = getSubindicatorsOfGroup(metadata.groups, primaryGroup)
 
     if (xTicks) {
         xAxis.tickCount = xTicks;

--- a/src/js/profile/charts/barChart.js
+++ b/src/js/profile/charts/barChart.js
@@ -1,5 +1,5 @@
 import {xAxis, xScale} from "./properties";
-import {createFiltersForGroups} from "./utils";
+import {createFiltersForGroups, getSubindicatorsOfGroup} from "./utils";
 
 const PERCENTAGE_TYPE = "percentage";
 const VALUE_TYPE = "value";
@@ -17,8 +17,8 @@ export const configureBarchart = (data, metadata, config) => {
             Percentage: {formatting: percentageFormatting, minX: percentageMinX, maxX: percentageMaxX}
         }
     } = config;
-
     const {primary_group: primaryGroup} = metadata;
+    const subindicators = getSubindicatorsOfGroup(metadata.groups, primaryGroup)
 
     if (xTicks) {
         xAxis.tickCount = xTicks;
@@ -33,13 +33,9 @@ export const configureBarchart = (data, metadata, config) => {
         background: "white",
         padding: {"left": 5, "top": 5, "right": 30, "bottom": 5},
         data: [
-            {
-                name: "table",
-                values: data,
-            },
-            {
+          {
                 name: "filteredTable",
-                source: "table",
+                values: data,
                 transform: [
                     ...filters
                 ]
@@ -107,6 +103,10 @@ export const configureBarchart = (data, metadata, config) => {
                 value: primaryGroup,
             },
             {
+              name: "yAxisDomain",
+              value: subindicators,
+            },
+            {
                 name: "numberFormat",
                 value: {percentage: percentageFormatting, value: valueFormatting},
             },
@@ -152,7 +152,7 @@ export const configureBarchart = (data, metadata, config) => {
             {
                 name: "yscale",
                 type: "band",
-                domain: {data: "table", field: {signal: "mainGroup"}},
+                domain: {signal: "yAxisDomain"},
                 range: {step: {signal: "y_step"}},
                 padding: 0.1,
             },
@@ -227,7 +227,7 @@ export const configureBarchart = (data, metadata, config) => {
     };
 };
 
-export const configureBarchartDownload = (data, filteredData, metadata, config, annotations) => {
+export const configureBarchartDownload = (filteredData, metadata, config, annotations) => {
     const {
         xTicks,
         defaultType,
@@ -238,6 +238,11 @@ export const configureBarchartDownload = (data, filteredData, metadata, config, 
     } = config;
 
     const {primary_group: primaryGroup} = metadata;
+    const subindicators = getSubindicatorsOfGroup(metadata.groups, primaryGroup)
+
+    if (xTicks) {
+        xAxis.tickCount = xTicks;
+    }
 
     if (xTicks) {
         xAxis.tickCount = xTicks;
@@ -253,15 +258,8 @@ export const configureBarchartDownload = (data, filteredData, metadata, config, 
         padding: {"left": 5, "top": 5, "right": 30, "bottom": 5},
         data: [
             {
-                name: "table",
-                values: data,
-            },
-            {
               name: "filteredTable",
               values: filteredData,
-              transform: [
-                  ...filters
-              ]
             },
             {
                 name: "data_formatted",
@@ -389,6 +387,10 @@ export const configureBarchartDownload = (data, filteredData, metadata, config, 
                 name: "chart_bottom",
                 update: "height + 40"
             },
+            {
+              name: "yAxisDomain",
+              value: subindicators,
+            },
             ...filterSignals
         ],
         title: {
@@ -401,7 +403,7 @@ export const configureBarchartDownload = (data, filteredData, metadata, config, 
             {
                 name: "yscale",
                 type: "band",
-                domain: {data: "table", field: {signal: "mainGroup"}},
+                domain: {signal: "yAxisDomain"},
                 range: {step: {signal: "y_step"}},
                 padding: 0.1,
             },

--- a/src/js/profile/charts/barChart.js
+++ b/src/js/profile/charts/barChart.js
@@ -227,7 +227,7 @@ export const configureBarchart = (data, metadata, config) => {
     };
 };
 
-export const configureBarchartDownload = (data, filteredData,metadata, config, annotations) => {
+export const configureBarchartDownload = (data, filteredData, metadata, config, annotations) => {
     const {
         xTicks,
         defaultType,

--- a/src/js/profile/charts/barChart.js
+++ b/src/js/profile/charts/barChart.js
@@ -36,13 +36,17 @@ export const configureBarchart = (data, metadata, config) => {
             {
                 name: "table",
                 values: data,
+            },
+            {
+                name: "filteredTable",
+                source: "table",
                 transform: [
                     ...filters
                 ]
             },
             {
                 name: "data_formatted",
-                source: "table",
+                source: "filteredTable",
                 transform: [
                     {
                         type: "aggregate",
@@ -148,7 +152,7 @@ export const configureBarchart = (data, metadata, config) => {
             {
                 name: "yscale",
                 type: "band",
-                domain: {data: "data_formatted", field: {signal: "mainGroup"}},
+                domain: {data: "table", field: {signal: "mainGroup"}},
                 range: {step: {signal: "y_step"}},
                 padding: 0.1,
             },
@@ -223,7 +227,7 @@ export const configureBarchart = (data, metadata, config) => {
     };
 };
 
-export const configureBarchartDownload = (data, metadata, config, annotations) => {
+export const configureBarchartDownload = (data, filteredData,metadata, config, annotations) => {
     const {
         xTicks,
         defaultType,
@@ -251,13 +255,17 @@ export const configureBarchartDownload = (data, metadata, config, annotations) =
             {
                 name: "table",
                 values: data,
-                transform: [
-                    ...filters
-                ]
+            },
+            {
+              name: "filteredTable",
+              values: filteredData,
+              transform: [
+                  ...filters
+              ]
             },
             {
                 name: "data_formatted",
-                source: "table",
+                source: "filteredTable",
                 transform: [
                     {
                         type: "aggregate",
@@ -393,7 +401,7 @@ export const configureBarchartDownload = (data, metadata, config, annotations) =
             {
                 name: "yscale",
                 type: "band",
-                domain: {data: "data_formatted", field: {signal: "mainGroup"}},
+                domain: {data: "table", field: {signal: "mainGroup"}},
                 range: {step: {signal: "y_step"}},
                 padding: 0.1,
             },

--- a/src/js/profile/charts/utils.js
+++ b/src/js/profile/charts/utils.js
@@ -4,7 +4,7 @@ export const slugify = (string) => {
 }
 /**
  * createFiltersForGroups
- * this method creates the filter for the data transformations as well as the signals that drive the filter. we can set signals from outside to set the filter. we use two signals, one to indicate if the filter is active (we can have multiple filters) the second is the value we filter for. 
+ * this method creates the filter for the data transformations as well as the signals that drive the filter. we can set signals from outside to set the filter. we use two signals, one to indicate if the filter is active (we can have multiple filters) the second is the value we filter for.
  *
 **/
 export const createFiltersForGroups = (groups) => {
@@ -25,4 +25,25 @@ export const createFiltersForGroups = (groups) => {
     signals: Array.from(signals.values()),
     filters: Array.from(filters.values()),
   }
+}
+
+export function getSubindicatorsOfGroup(groups, groupName) {
+    let subindicators = [];
+    let filteredGroup = groups.find(function(group){
+        return group["name"] === groupName;
+    });
+    if (filteredGroup){
+      subindicators = filteredGroup.subindicators;
+    }
+    return subindicators;
+}
+
+export function sortDataForSubindicatorGroup(dataArr, subindicators, group) {
+    if (dataArr && subindicators){
+      dataArr.sort(function (obj1, obj2) {
+        return subindicators.indexOf(obj1[group]) - subindicators.indexOf(obj2[group]);
+      });
+    }
+    return dataArr;
+
 }

--- a/src/js/profile/charts/utils.js
+++ b/src/js/profile/charts/utils.js
@@ -27,13 +27,18 @@ export const createFiltersForGroups = (groups) => {
   }
 }
 
-export function getSubindicatorsOfGroup(groups, groupName) {
+export function getSubindicatorsOfGroup(data, groups, groupName) {
     let subindicators = [];
+    let requiredSubindicators = data.map(function(value) {
+      return value[groupName];
+    });
     let filteredGroup = groups.find(function(group){
         return group["name"] === groupName;
     });
-    if (filteredGroup){
-      subindicators = filteredGroup.subindicators;
+    if (filteredGroup && filteredGroup.subindicators){
+      subindicators = filteredGroup.subindicators.filter(function(value){
+        return requiredSubindicators.includes(value);
+      });
     }
     return subindicators;
 }


### PR DESCRIPTION
## Description
Issue : 
Chart bar labels were misaligned if some labels if missing due to filtering

Solution: 
Keep all labels even if they do not have any data.

Before : 
<img width="1002" alt="Screenshot 2022-02-25 at 8 02 46 AM" src="https://user-images.githubusercontent.com/6871866/155642693-6da9443e-b3ff-4866-bf05-f88093486a21.png">

After:
<img width="902" alt="Screenshot 2022-02-25 at 8 03 15 AM" src="https://user-images.githubusercontent.com/6871866/155642734-2eb9721e-0c29-44fd-8394-b40d6a6ddb49.png">

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-187

## How is it tested automatically?
There is an automated test included that explicitly checks the numbers of bars & the number of domains in vega view before and after applying filters.

## How should a reviewer test it locally
* visit Stellenbosch on the Youth Explorer profile `/#geo:WC024`
* Open the rich Data view
* Scroll to “Language most spoken at home”
* Add filter Race: White
* Chart should not be misaligned now

## Screenshots

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
