### PR TITLE
loading state bug in mapchip when there are no available filters

### DIFF
--- a/__tests__/gui/data_mapper.feature
+++ b/__tests__/gui/data_mapper.feature
@@ -7,7 +7,7 @@ Feature: Data Mapper
     And I expand Data Mapper
     Then Data Mapper should be displayed
 
-    And I click on Demographics in Data Mapper
+    And I click on "Demographics" in Data Mapper
     And I select an indicator
     And I select another indicator
     Then I check if choropleth legend is displayed
@@ -46,3 +46,11 @@ Feature: Data Mapper
     And I navigate to WC and back to ZA quickly
     And I expand Data Mapper
     Then I check if there are 2 categories
+
+    # confirm that no filters available message is displayed correctly
+    When I expand Data Mapper
+    And I click on "Elections" in Data Mapper
+    And I click on "2016 Municipal elections" in Data Mapper
+    And I click on "Number of hung and majority councils" in Data Mapper
+    And I click on "Hung" in Data Mapper
+    Then I check if the message is displayed correctly

--- a/__tests__/gui/data_mapper/data_mapper.js
+++ b/__tests__/gui/data_mapper/data_mapper.js
@@ -37,9 +37,9 @@ Then('Data Mapper should be displayed', () => {
     cy.get('.data-mapper-content__list').should('be.visible');
 })
 
-When('I click on {word} in Data Mapper', () => {
-    cy.get('.data-category__h1_title').contains('Demographics').click();
-})
+When(/^I click on "([^"]*)" in Data Mapper$/, function (word) {
+    cy.get('.data-mapper').findByText(word).click();
+});
 
 Then('I select an indicator', () => {
     cy.get('.data-category__h1_content--v2').contains('Population (2016 Community Survey)').click();
@@ -210,4 +210,10 @@ When('I navigate to WC and back to ZA quickly', () => {
     cy.visit('/#geo:WC');
     cy.wait(500);   //without this controller ignores the first request  - to be able to navigate between 2 geographies we need a small delay
     cy.visit('/#geo:ZA');
+})
+
+Then('I check if the message is displayed correctly', () => {
+    cy.get(`${mapBottomItems} .map-options  .map-options__loading`).should('not.be.visible');
+    cy.get(`${mapBottomItems} .map-options  .map-options__no-data`).should('be.visible');
+    cy.get(`${mapBottomItems} .map-options  .map-options__no-data`).should('contain.text', 'No filters available for the selected data.');
 })

--- a/src/js/elements/subindicator_filter/filter_controller.js
+++ b/src/js/elements/subindicator_filter/filter_controller.js
@@ -107,11 +107,12 @@ export class FilterController extends Component {
 
     set isLoading(value) {
         if (value) {
-            $('.map-options__loading').removeClass('hidden');
-            $('.mapping-options__add-filter').addClass('hidden');
-            $('.map-options__filter-row').addClass('hidden')
+            $(this.container).find('.map-options__loading').removeClass('hidden');
+            $(this.container).find('.mapping-options__add-filter').addClass('hidden');
+            $(this.container).find('.map-options__filter-row').addClass('hidden')
+            $(this.container).find('.map-options__no-data').addClass('hidden');
         } else {
-            $('.map-options__loading').addClass('hidden');
+            $(this.container).find('.map-options__loading').addClass('hidden');
         }
 
         this._isLoading = value;
@@ -125,10 +126,10 @@ export class FilterController extends Component {
         if (value) {
             this.addFilterButton.hide();
             this.isLoading = false;
-            $('.map-options__no-data').removeClass('hidden');
+            $(this.container).find('.map-options__no-data').removeClass('hidden');
         } else {
             this.addFilterButton.show();
-            $('.map-options__no-data').addClass('hidden');
+            $(this.container).find('.map-options__no-data').addClass('hidden');
         }
 
         this._noFiltersAvailable = value;

--- a/src/js/elements/subindicator_filter/filter_controller.js
+++ b/src/js/elements/subindicator_filter/filter_controller.js
@@ -124,6 +124,7 @@ export class FilterController extends Component {
     set noFiltersAvailable(value) {
         if (value) {
             this.addFilterButton.hide();
+            this.isLoading = false;
             $('.map-options__no-data').removeClass('hidden');
         } else {
             this.addFilterButton.show();
@@ -166,7 +167,7 @@ export class FilterController extends Component {
     }
 
     addInitialFilterRow(dataFilterModel) {
-        if (this.noFiltersAvailable){
+        if (this.noFiltersAvailable) {
             return;
         }
 


### PR DESCRIPTION
## Description
fixing the bug that prevented hiding the loading state when showing `No filters available for the selected data` message

https://openupsa.slack.com/archives/C024AJAJ3T8/p1646139478708379

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-284

## How is it tested automatically?
added test steps into `__tests__/gui/data_mapper.feature`

## How should a reviewer test it locally
* go to `hsrc-demo` profile or any other profile/geo with no charts in rich data panel
* select an indicator with no filters available from the data mapper
* confirm that the message is displayed correctly without the loading state

## Screenshots
before the fix : 
![image](https://user-images.githubusercontent.com/53019884/156178334-34c29022-79d0-4cbc-9d4c-7b690bb164ce.png)

after the fix :
![image](https://user-images.githubusercontent.com/53019884/156178347-5d496312-9081-4ce0-8b05-61b7e2b1439e.png)



## Changelog

### Added

### Updated
* `src/js/elements/subindicator_filter/filter_controller.js` to remove the loading state when showing the message

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
