### PR TITLE
Hide chart bar labels if there is no data after adding filters

### DIFF
--- a/src/js/profile/charts/barChart.js
+++ b/src/js/profile/charts/barChart.js
@@ -181,6 +181,7 @@ export const configureBarchart = (data, metadata, config) => {
                     },
                     update: {
                         fill: {value: "rgb(57, 173, 132)"},
+                        y: {scale: "yscale", field: {signal: "mainGroup"}},
                         x: {scale: "xscale", field: {signal: "datatype[Units]"}},
                         x2: {scale: "xscale", value: 0},
                         tooltip: {


### PR DESCRIPTION
## Description
Issue :
Chart bar labels were misaligned if some labels if missing due to filtering

Solution:
Re render bars in updates so they are not misaligned anymore.

Before:
<img width="1002" alt="155642693-6da9443e-b3ff-4866-bf05-f88093486a21" src="https://user-images.githubusercontent.com/6871866/157582644-74ec8eed-82fc-4c78-851c-d2901b1d71e9.png">

After:
<img width="1030" alt="Screenshot 2022-03-10 at 8 57 07 AM" src="https://user-images.githubusercontent.com/6871866/157582671-b1ce812e-9e07-455b-a717-c9ff9d676dcd.png">


## Related Issue
https://wazimap.atlassian.net/browse/WNCM-187

## How is it tested automatically?
There is an automated test included that explicitly checks the numbers of bars & the number of domains in vega view before and after applying filters.

## How should a reviewer test it locally
- visit Stellenbosch on the Youth Explorer profile /#geo:WC024
- Open the rich Data view
- Scroll to “Language most spoken at home”
- Add filter Race: White
- Chart should not be misaligned now

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
