### PR TITLE
changing the chart type config

### DIFF
--- a/__tests__/profile/chart.test.js
+++ b/__tests__/profile/chart.test.js
@@ -50,7 +50,7 @@ describe('displaying a chart', () => {
         }
         const node = document.querySelector('.profile-indicator');
 
-        config.chartType = 'bar';
+        newdata.chart_type = 'bar';
         let spy = jest.spyOn(configureBarchart, 'configureBarchart');
 
         let chart = new Chart(parent, config, newdata, [], node, "TEST", "this is chart attribution");

--- a/__tests__/profile/chart.test.js
+++ b/__tests__/profile/chart.test.js
@@ -30,7 +30,7 @@ describe('displaying a chart', () => {
         }
         const node = document.querySelector('.profile-indicator');
 
-        config.chartType = 'line';
+        newdata.chart_type = 'line';
         let spy = jest.spyOn(configureLinechart, 'configureLinechart');
 
         let chart = new Chart(parent, config, newdata, [], node, "TEST", "this is chart attribution");

--- a/__tests__/profile/charts/lineChart.test.js
+++ b/__tests__/profile/charts/lineChart.test.js
@@ -73,7 +73,7 @@ describe('creating specs', () => {
             chartConfiguration: config
         }
 
-        config.chartType = 'line';
+        newdata.chart_type = 'line';
         config.disableToggle = false;
         config.defaultType = 'Percentage';
 

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -81,7 +81,7 @@ export class Chart extends Component {
     }
 
     get chartType() {
-        const type = this._config.chartType;
+        const type = this.data.chart_type;
         if (type === chartTypes.LineChart) {
             return chartTypes.LineChart;
         } else {


### PR DESCRIPTION
## Description
modified the way the FE gets the chart type config from the BE

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-409

## How is it tested automatically?


## How should a reviewer test it locally
* go to deploy preview
* set hostname as `deploy-preview-606--wazimap-production.netlify.app`
* set api url as `https://wazimap-pr-410.herokuapp.com`
* login to the admin panel using this url `https://wazimap-pr-410.herokuapp.com/admin/`
* change the chart type from the admin panel
* in the webpage confirm that the chart type is set correctly and the chart is displayed correctly

## Screenshots


## Changelog

### Added

### Updated
* `src/js/profile/chart.js` to change the way FE uses the config

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
