### PR TITLE
disabling chart type toggle

### DIFF
--- a/__tests__/profile/chart.test.js
+++ b/__tests__/profile/chart.test.js
@@ -75,4 +75,34 @@ describe('displaying a chart', () => {
         let chart = new Chart(parent, config, newdata, [], node, "TEST", "this is chart attribution");
         expect(spy).toBeCalled();
     })
+
+    test('chart value type toggle is hidden correctly', async () => {
+        let parent = new Component();
+        let newdata = {
+            data: data,
+            metadata: metadata,
+            chartConfiguration: config
+        }
+
+        config.chartType = 'bar';
+        config.disableToggle = true;
+        config.defaultType = 'Percentage';
+
+        const node = document.querySelector('.profile-indicator');
+
+        let chart = new Chart(parent, config, newdata, [], node, "TEST", "this is chart attribution");
+
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        const percentageBtn = $(node).find(".hover-menu__content_list a[data-id='Percentage'] div").closest('.hover-menu__content_list');
+        const valueBtn = $(node).find(".hover-menu__content_list a[data-id='Value'] div").closest('.hover-menu__content_list');
+
+        const percentageBtnField = $(percentageBtn)[0];
+        const valueBtnField = $(valueBtn)[0];
+
+        expect(percentageBtnField).toHaveStyle('display: none')
+        expect(valueBtnField).toHaveStyle('display: none')
+
+        expect(chart.vegaView.signal('Units')).toBe('percentage');
+    })
 })

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -94,6 +94,10 @@ export class Chart extends Component {
     }
 
     set isToggleDisabled(value) {
+        if  (value){
+            this.disableChartTypeToggle();
+        }
+
         this._isToggleDisabled = value;
     }
 
@@ -349,8 +353,6 @@ export class Chart extends Component {
     disableChartTypeToggle = () => {
         $(this.containerParent).find('.hover-menu__content_item--no-link:first').hide();
         $(this.containerParent).find('.hover-menu__content_list').hide();
-
-        this.isToggleDisabled = true;
     }
 
     setChartMenu = (barChart) => {
@@ -374,8 +376,8 @@ export class Chart extends Component {
 
         self.selectedGraphValueTypeChanged(self.containerParent, this.config.defaultType);
 
-        if (this.chartType === chartTypes.LineChart || this.isToggleDisabled) {
-            this.disableChartTypeToggle();
+        if (this.chartType === chartTypes.LineChart || this.config.disableToggle) {
+            this.isToggleDisabled = true;
         }
 
         $(this.containerParent).find('.hover-menu__content_list--last a').each(function () {


### PR DESCRIPTION
## Description
disabling the chart value type toggle config was not working.

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-460

## How is it tested automatically?
* added a unit test to `__tests__/profile/chart.test.js`

## How should a reviewer test it locally
* add `"disableToggle" = true` to the profile indicator config of any profile indicator
* in the web page confirm that  the chart value type toggle is hidden

## Screenshots
before the fix : 
![image](https://user-images.githubusercontent.com/53019884/179457836-5b4c284b-303e-4108-9a01-3e817e6001ae.png)

after the fix :
![image](https://user-images.githubusercontent.com/53019884/179457933-16281933-7a13-49c5-b2fb-41c92da13b70.png)


## Changelog

### Added

### Updated
* `src/js/profile/chart.js` to fix hiding the toggle 

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
