### PR TITLE
choropleth legend range by indicator

### DIFF
--- a/__tests__/map/choropleth.test.js
+++ b/__tests__/map/choropleth.test.js
@@ -1,0 +1,162 @@
+import {Choropleth} from "../../src/js/map/choropleth/choropleth";
+import {Component} from "../../src/js/utils";
+import SubindicatorCalculator from "../../src/js/map/choropleth/subindicator_calculator";
+
+describe('choropleth', () => {
+    let component;
+    let layerStyler;
+    let layerCache;
+    let options;
+    let calculator;
+    let childData;
+    let primaryGroup;
+    let selectedSubindicator;
+    let allSubindicators;
+
+    beforeEach(() => {
+        component = new Component();
+        layerStyler = {
+            "styles": {
+                "hoverOnly": {
+                    "over": {
+                        "fillColor": "#3BAD84",
+                        "fillOpacity": 0.5
+                    },
+                    "out": {
+                        "fillColor": "#ffffff",
+                        "stroke": false
+                    }
+                },
+                "selected": {
+                    "over": {
+                        "color": "#666666",
+                        "fillColor": "#3BAD84",
+                        "fillOpacity": 0.6
+                    },
+                    "out": {
+                        "color": "#666666",
+                        "fillColor": "#cccccc",
+                        "opacity": 0.5,
+                        "fillOpacity": 0.5,
+                        "weight": 1
+                    }
+                }
+            }
+        };
+        layerCache = {};
+        options = {
+            "colors": [
+                "#fef0d9",
+                "#fdcc8a",
+                "#fc8d59",
+                "#e34a33",
+                "#b30000"
+            ],
+            "opacity": 0.7,
+            "opacity_over": 0.8
+        };
+        calculator = new SubindicatorCalculator();
+        childData = {
+            "Geography1": [
+                {"count": 15, "age": "15-19"},
+                {"count": 20, "age": "20-24"},
+                {"count": 30, "age": "25-29"},
+            ],
+            "Geography2": [
+                {"count": 20, "age": "15-19"},
+                {"count": 10, "age": "20-24"},
+                {"count": 30, "age": "25-29"},
+            ]
+        }
+        primaryGroup = "age";
+        selectedSubindicator = "15-19";
+        allSubindicators = ["15-19", "20-24", "25-29"];
+    })
+
+    test('calculates the values correctly when choropleth range is by_subindicator', () => {
+        const choropleth = new Choropleth(component, layerCache, layerStyler, options);
+        choropleth.choroplethRangeType = 'by_subindicator';
+
+        const {
+            values,
+            calculation
+        } = choropleth.getChoroplethValues(calculator, childData, primaryGroup, selectedSubindicator, allSubindicators);
+
+        expect(values).toStrictEqual([0.23076923076923078, 0.3333333333333333]);
+        expect(calculation).toStrictEqual([
+                {code: 'Geography1', val: 0.23076923076923078, total: 15},
+                {code: 'Geography2', val: 0.3333333333333333, total: 20}
+            ]
+        );
+
+        const intervals = choropleth.getIntervals(values);  //legend values
+        expect(intervals).toStrictEqual([
+                0.23076923076923078,
+                0.2564102564102564,
+                0.28205128205128205,
+                0.3076923076923077,
+                0.3333333333333333
+            ]
+        );
+    })
+
+    test('calculates the values correctly when choropleth range is by_indicator', () => {
+        const choropleth = new Choropleth(component, layerCache, layerStyler, options);
+        choropleth.choroplethRangeType = 'by_indicator';
+
+        const {
+            values,
+            calculation
+        } = choropleth.getChoroplethValues(calculator, childData, primaryGroup, selectedSubindicator, allSubindicators);
+
+        expect(values).toStrictEqual([
+            0.23076923076923078,
+            0.3333333333333333,
+            0.3076923076923077,
+            0.16666666666666666,
+            0.46153846153846156,
+            0.5
+        ]);
+        expect(calculation).toStrictEqual([
+                {code: 'Geography1', val: 0.23076923076923078, total: 15},
+                {code: 'Geography2', val: 0.3333333333333333, total: 20}
+            ]
+        );
+
+        const intervals = choropleth.getIntervals(values);  //legend values
+        expect(intervals).toStrictEqual([
+                0.16666666666666666,
+                0.25,
+                0.3333333333333333,
+                0.4166666666666667,
+                0.5
+            ]
+        );
+    })
+
+    test('calculates the values correctly when choropleth range is not set', () => {
+        const choropleth = new Choropleth(component, layerCache, layerStyler, options);
+
+        const {
+            values,
+            calculation
+        } = choropleth.getChoroplethValues(calculator, childData, primaryGroup, selectedSubindicator, allSubindicators);
+
+        expect(values).toStrictEqual([0.23076923076923078, 0.3333333333333333]);
+        expect(calculation).toStrictEqual([
+                {code: 'Geography1', val: 0.23076923076923078, total: 15},
+                {code: 'Geography2', val: 0.3333333333333333, total: 20}
+            ]
+        );
+
+        const intervals = choropleth.getIntervals(values);  //legend values
+        expect(intervals).toStrictEqual([
+                0.23076923076923078,
+                0.2564102564102564,
+                0.28205128205128205,
+                0.3076923076923077,
+                0.3333333333333333
+            ]
+        );
+    })
+})

--- a/src/js/map/choropleth/choropleth.js
+++ b/src/js/map/choropleth/choropleth.js
@@ -6,6 +6,11 @@ import SubindicatorCalculator from './subindicator_calculator';
 import SiblingCalculator from './sibling_calculator';
 import AbsoluteValueCalculator from './absolute_value_calculator';
 
+const choroplethRangeTypes = {
+    BY_SUBINDICATOR: "by_subindicator",
+    BY_INDICATOR: 'by_indicator'
+}
+
 export class Choropleth extends Component {
     constructor(parent, layers, layerStyler, options, buffer = 0.1) {
         super(parent);
@@ -16,6 +21,18 @@ export class Choropleth extends Component {
         this.options = options;
         this.buffer = buffer;
         this.currentLayers = [];
+        this._choroplethRangeType = choroplethRangeTypes.BY_SUBINDICATOR;
+    }
+
+    get choroplethRangeType() {
+        return this._choroplethRangeType;
+    }
+
+    set choroplethRangeType(value) {
+        if (value === undefined){
+            return;
+        }
+        this._choroplethRangeType = value;
     }
 
     getCalculator(method) {
@@ -25,12 +42,10 @@ export class Choropleth extends Component {
             absolute_value: new AbsoluteValueCalculator(),
         }[method];
 
-
-        if (calculator == undefined)
+        if (calculator === undefined)
             calculator = SubindicatorCalculator
 
         return calculator;
-
     }
 
     getIntervals(values) {
@@ -62,21 +77,34 @@ export class Choropleth extends Component {
         this.triggerEvent('map.choropleth.reset', null);
     }
 
-    getBounds(values) {
-        const lowest = (1 - this.buffer) * d3min(values) < 0 ? 0 : (1 - this.buffer) * d3min(values);
-        const highest = (1 + this.buffer) * d3max(values) > 1 ? 1 : (1 + this.buffer) * d3max(values);
+    getChoroplethValues(calculator, childData, primaryGroup, selectedSubindicator, allSubindicators) {
+        let values = [];
+        let calculation;
+        calculation = calculator.calculate(childData, primaryGroup, selectedSubindicator);
+        if (this.choroplethRangeType === choroplethRangeTypes.BY_SUBINDICATOR) {
+            values = calculation.map(el => el.val);
+        } else if (this.choroplethRangeType === choroplethRangeTypes.BY_INDICATOR) {
+            allSubindicators.forEach((si) => {
+                let tempCalculation = calculator.calculate(childData, primaryGroup, si);
+                let tempValues = tempCalculation.map(el => el.val);
+                values.push(...tempValues);
+            })
+        }
 
+        return {values, calculation};
+    }
+
+    getBounds(values) {
         return {
             lower: d3min(values),
             upper: d3max(values)
         }
     }
 
-    showChoropleth(calculations, setLayerToSelected) {
+    showChoropleth(calculations, values) {
         this.reset(true);
         const self = this;
         const childGeographyValues = [...calculations];
-        const values = childGeographyValues.map(el => el.val);
         const bounds = this.getBounds(values);
         const numIntervals = this.legendColors.length;
 
@@ -84,11 +112,9 @@ export class Choropleth extends Component {
             .domain([bounds.lower, bounds.upper])
             .range([this.legendColors[0], this.legendColors[numIntervals - 1]]);
 
-        // this.reset(setLayerToSelected);
-
         childGeographyValues.forEach(el => {
             const layer = self.layers[el.code];
-            if (layer != undefined) {
+            if (layer !== undefined) {
                 self.currentLayers.push(el.code);
                 const color = scale(el.val);
                 self.layerStyler.setLayerStyle(layer, {

--- a/src/js/map/maps.js
+++ b/src/js/map/maps.js
@@ -41,8 +41,6 @@ export class MapControl extends Component {
 
         this.registerEvents();
 
-        console.log({config})
-
         this.choropleth = new Choropleth(this, this.layerCache, this.layerStyler, config.map.choropleth);
     };
 

--- a/src/js/map/maps.js
+++ b/src/js/map/maps.js
@@ -41,6 +41,8 @@ export class MapControl extends Component {
 
         this.registerEvents();
 
+        console.log({config})
+
         this.choropleth = new Choropleth(this, this.layerCache, this.layerStyler, config.map.choropleth);
     };
 
@@ -106,7 +108,7 @@ export class MapControl extends Component {
 
         let response;
         let savedObj = this.choroplethData.filter((x) => {
-            return x.geography === geo && x.indicatorId == indicatorId
+            return x.geography === geo && x.indicatorId === indicatorId
         })[0];
 
         if (savedObj !== null && typeof savedObj !== 'undefined') {
@@ -137,20 +139,30 @@ export class MapControl extends Component {
             filter: filter
         }
 
+        let allSubindicators = args.data.metadata.groups.filter(x => {
+            return x.name === data.metadata.primary_group
+        })[0].subindicators;
+
         this.triggerEvent("map.choropleth.loaded", args);
 
-        this.displayChoropleth(data.data, data.metadata.primary_group, method, selectedSubindicator);
+        this.displayChoropleth(data, data.metadata.primary_group, method, selectedSubindicator, allSubindicators);
     };
 
-    displayChoropleth(childData, primaryGroup, method, selectedSubindicator) {
+    displayChoropleth(data, primaryGroup, method, selectedSubindicator, allSubindicators) {
+        const childData = data.data;
+
+        this.choropleth.choroplethRangeType = data.choropleth_range;
+
         const calculator = this.choropleth.getCalculator(method);
 
-        const calculation = calculator.calculate(childData, primaryGroup, selectedSubindicator);
+        const {
+            values,
+            calculation
+        } = this.choropleth.getChoroplethValues(calculator, childData, primaryGroup, selectedSubindicator, allSubindicators);
 
-        const values = calculation.map(el => el.val);
-
-        this.choropleth.showChoropleth(calculation, false);
+        this.choropleth.showChoropleth(calculation, values);
         const intervals = this.choropleth.getIntervals(values);
+
         const formattedIntervals = intervals.map(el => calculator.format(el))
 
         this.triggerEvent("map.choropleth.display", {


### PR DESCRIPTION
## Description
configuring the legend range to be consistent across all subindicators of an indicator

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-440

## How is it tested automatically?
* added automated test coverage into `__tests__/map/choropleth.test.js`

## How should a reviewer test it locally
* go to deploy preview
* set hostname as deploy-preview-608--wazimap-production.netlify.app
* set api url as https://wazimap-pr-412.herokuapp.com
* login to the admin panel using this url https://wazimap-pr-412.herokuapp.com/admin/
* change the choropleth range type from the admin panel
* in the webpage confirm that the choropleth legend values are calculated correctly 

## Screenshots
![image](https://user-images.githubusercontent.com/53019884/180149614-6e0d85e9-1808-4019-bd14-d608e887ce08.png)


## Changelog

### Added

### Updated
* `src/js/map/choropleth/choropleth.js` to change the choropleth calculation depending on the choropleth range type config

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
