### PR TITLE
hiding empty fields in point details popup

### DIFF
--- a/__tests__/gui/facility_modal.feature
+++ b/__tests__/gui/facility_modal.feature
@@ -12,6 +12,7 @@ Feature: Facility Modal
     Then I click on a marker
     And I click on the More info button
     Then Facility modal and Google maps button should be visible
+    Then I confirm that empty values are not displayed in the facility modal
 
     And I switch to print view
     Then I check if the print view is as expected

--- a/__tests__/gui/facility_modal/Wazimap.js
+++ b/__tests__/gui/facility_modal/Wazimap.js
@@ -61,10 +61,17 @@ Then('I check if the print view is as expected', () => {
     cy.get('.rich-data').should('not.be.visible');
 })
 
-Then('I expand Point Mapper', ()=>{
+Then('I expand Point Mapper', () => {
     expandPointMapper();
 })
 
-When('I exit print view', () =>{
+When('I exit print view', () => {
     cy.task('resetCRI')
+})
+
+Then('I confirm that empty values are not displayed in the facility modal', () => {
+    cy.get('.facility-info .facility-info__items .facility-info__item_label').each($label => {
+        cy.wrap($label).should('not.have.text', 'empty value');
+        cy.wrap($label).should('not.have.text', 'null value');
+    })
 })

--- a/__tests__/gui/facility_modal/points.json
+++ b/__tests__/gui/facility_modal/points.json
@@ -1,42 +1,50 @@
 {
-  "type":"FeatureCollection",
-  "features":[
+  "type": "FeatureCollection",
+  "features": [
     {
-      "id":441633,
-      "type":"Feature",
-      "geometry":{
-        "type":"Point",
-        "coordinates":[
+      "id": 441633,
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
           25.093833387362697,
           -28.995409163308832
         ]
       },
-      "properties":{
-        "data":[
+      "properties": {
+        "data": [
           {
-            "key":"campus",
-            "value":"Nongoma"
+            "key": "campus",
+            "value": "Nongoma"
           },
           {
-            "key":"phone number",
-            "value":"0358310358"
+            "key": "phone number",
+            "value": "0358310358"
           },
           {
-            "key":"email address",
-            "value":"campushead@nongoma.co.za"
+            "key": "email address",
+            "value": "campushead@nongoma.co.za"
           },
           {
-            "key":"institution type",
-            "value":"TVET"
+            "key": "institution type",
+            "value": "TVET"
           },
           {
-            "key":"physical address",
-            "value":"Nongoma Main Road Nongoma"
+            "key": "physical address",
+            "value": "Nongoma Main Road Nongoma"
+          },
+          {
+            "key": "empty value",
+            "value": ""
+          },
+          {
+            "key": "null value",
+            "value": null
           }
         ],
-        "name":"Mthashana FET College (A)",
-        "url":null,
-        "image":null
+        "name": "Mthashana FET College (A)",
+        "url": null,
+        "image": null
       }
     }
   ]

--- a/src/js/map/point_data/point_data.js
+++ b/src/js/map/point_data/point_data.js
@@ -40,22 +40,22 @@ const CIRCLE_MARKER_POPUP_OFFSET = [20, 0];
 const allowedTags = ['a', 'b', 'em', 'span', 'i', 'div', 'p', 'ul', 'li', 'ol', 'table', 'tr', 'td', 'th'];
 const allowedAttributes = ["class", "target", "style", "href"];
 const xssOptions = {
-  stripIgnoreTag: true,
-  onTag: function (tag, html, options) {
-    if (allowedTags.indexOf(tag) === -1){
-      return '';
+    stripIgnoreTag: true,
+    onTag: function (tag, html, options) {
+        if (allowedTags.indexOf(tag) === -1) {
+            return '';
+        }
+    },
+    onTagAttr: function (tag, name, value, isWhiteAttr) {
+        if (allowedAttributes.indexOf(name) >= 0) {
+            return name + '="' + xss.escapeAttrValue(value) + '"';
+        }
+    },
+    onIgnoreTagAttr: function (tag, name, value, isWhiteAttr) {
+        if (name.substr(0, 5) === "data-") {
+            return name + '="' + xss.escapeAttrValue(value) + '"';
+        }
     }
-  },
-  onTagAttr : function(tag, name, value, isWhiteAttr) {
-    if (allowedAttributes.indexOf(name) >= 0){
-      return name + '="' + xss.escapeAttrValue(value) + '"';
-    }
-  },
-  onIgnoreTagAttr: function (tag, name, value, isWhiteAttr) {
-    if (name.substr(0, 5) === "data-") {
-      return name + '="' + xss.escapeAttrValue(value) + '"';
-    }
-  }
 };
 
 const xssFilter = new xss.FilterXSS(xssOptions);
@@ -514,17 +514,20 @@ export class PointData extends Component {
         $('.' + itemsClsName, item).empty();
         const htmlFields = point.category.data.configuration?.field_type || {};
         point.data.forEach((a, i) => {
-            if (Object.prototype.toString.call(a.value) !== '[object Object]' && (visibleAttributes === null || visibleAttributes.indexOf(a.key) >= 0)) {
+            if (a.value !== null
+                && (visibleAttributes === null || visibleAttributes.indexOf(a.key) >= 0)
+                && Object.prototype.toString.call(a.value) !== '[object Object]'
+                && a.value.toString().trim() !== '') {
                 let itemRow = rowItem.cloneNode(true);
                 $(itemRow).removeClass('last');
                 $('.' + labelClsName, itemRow).text(a.key);
                 const isKeyHtmlType = htmlFields.hasOwnProperty(a.key) ? htmlFields[a.key] === "html" : false;
 
-                if (isKeyHtmlType){
-                  let htmlText = xssFilter.process(a.value);
-                  $('.' + valueClsName, itemRow).html(htmlText);
+                if (isKeyHtmlType) {
+                    let htmlText = xssFilter.process(a.value);
+                    $('.' + valueClsName, itemRow).html(htmlText);
                 } else {
-                  $('.' + valueClsName, itemRow).text(a.value);
+                    $('.' + valueClsName, itemRow).text(a.value);
                 }
                 if (i === point.data.length - 1) {
                     $(itemRow).addClass('last')


### PR DESCRIPTION
## Description
hiding empty fields in point details popup

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-29

## How is it tested automatically?
added test steps into `__tests__/gui/facility_modal.feature`

## How should a reviewer test it locally
* find a point which has some empty fields e.g. `ACVV Sederhof` in Sifar profile
* compare with the prod to confirm that the empty fields in the point details popup are not shown

## Screenshots
before : 
![image](https://user-images.githubusercontent.com/53019884/181906376-df9d5b9c-b24a-4f34-add2-7f7332d025c3.png)

after :
![image](https://user-images.githubusercontent.com/53019884/181906432-1652c2c2-e634-474d-bef2-1d6445b441e0.png)


## Changelog

### Added

### Updated
* `src/js/map/point_data/point_data.js` to remove the empty fields

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
