### PR TITLE
hiding category and subcategory headings when no indicators available

### DIFF
--- a/__tests__/gui/multi_boundary_versions/all_details_2016.json
+++ b/__tests__/gui/multi_boundary_versions/all_details_2016.json
@@ -74,6 +74,57 @@
           },
           "Municipal leadership":{
             "description":"",
+            "indicators":{
+              "2016 Voter turnout":{
+                "id":836,
+                "description":"The 2016 Municipal Election \"Voter turnout\" indicator shows the larger of the Ward and Proportional Representation ballots in each voting district. Elections in local municipalities that fall in district municipalities actually have a third ballot (DC40), because the district council is elected partly by the councils of the costituent local municipalities, and partly by this third ballot. The Ward and PR ballots are used to ensure a proper comparison between ward, municipality and provincial regions.",
+                "choropleth_method":"subindicator",
+                "last_updated_at":"2021-07-01T09:13:47.019771Z",
+                "metadata":{
+                  "source":"IEC",
+                  "description":"The 2016 Municipal Election \"Voter turnout\" indicator shows the larger of the Ward and Proportional Representation ballots in each voting district. Elections in local municipalities that fall in district municipalities actually have a third ballot (DC40), because the district council is elected partly by the councils of the constituent local municipalities, and partly by this third ballot. The Ward and PR ballots are used to ensure a proper comparison between ward, municipality and provincial regions.",
+                  "url":"http://www.elections.org.za/",
+                  "licence":{
+                    "name":"other",
+                    "url":null
+                  },
+                  "primary_group":"categories",
+                  "groups":[
+                    {
+                      "subindicators":[
+                        "Didn't vote",
+                        "Voted"
+                      ],
+                      "dataset":1034,
+                      "name":"categories",
+                      "can_aggregate":true,
+                      "can_filter":true
+                    }
+                  ]
+                },
+                "content_type":"indicator",
+                "dataset_content_type":"quantitative",
+                "version":"2016 with wards",
+                "chart_configuration":{
+                  "types":{
+                    "Value":{
+                      "formatting":","
+                    }
+                  },
+                  "disableToggle":false
+                },
+                "data":[
+                  {
+                    "count":"1948844",
+                    "categories":"Voted"
+                  },
+                  {
+                    "count":"1122106",
+                    "categories":"Didn't vote"
+                  }
+                ]
+              }
+            },
             "key_metrics": [
               {
                 "label": "test-key-metrics",

--- a/__tests__/gui/rich_data.feature
+++ b/__tests__/gui/rich_data.feature
@@ -15,10 +15,16 @@ Feature: Rich data menu
     Then I check if "Test Category 1" is active
 
     And I scroll to bottom of the page
-    Then I check if "Test Category 3" is active
+    Then I check if "Test Category 4" is active
 
     And I close the Rich Data
     Then I expand Rich Data
     Then Rich Data should be displayed
     Then None of the menu items should be active
     Then I check if the indicator with only zero counts is hidden
+
+    # confirm the visibility of the categories & subcategories
+    Then I confirm that the category "Category with no subcategories" is invisible
+    Then I confirm that the category "Category with no indicators" is invisible
+    Then I confirm that the subcategory "Subcategory with no indicators" is invisible
+    Then I confirm that the subcategory "Subcategory with indicators" is visible

--- a/__tests__/gui/rich_data/all_details.json
+++ b/__tests__/gui/rich_data/all_details.json
@@ -1,6389 +1,6558 @@
 {
-   "profile":{
-      "logo":{
-         "image":"",
-         "url":"/"
-      },
-      "geography":{
-         "name":"South Africa Test",
-         "code":"ZA",
-         "level":"country",
-         "version":"2011 Boundaries",
-         "parents":[
-
-         ]
-      },
-      "profile_data":{
-         "Test Category 1":{
-            "description":"",
-            "subcategories":{
-               "Population":{
-                  "description":"",
-                  "indicators":{
-                     "Youth status":{
-                        "id":98,
-                        "description":"An indicator showing whether an individual is in the age group 15 - 35",
-                        "choropleth_method":"subindicator",
-                        "last_updated_at":"2021-03-04T08:22:16.959409Z",
-                        "metadata":{
-                           "source":"StatsSA Census 2011",
-                           "description":"",
-                           "url":null,
-                           "licence":{
-                              "name":"creative commons",
-                              "url":null
-                           },
-                           "primary_group":"youth status",
-                           "groups":[
-                              {
-                                 "subindicators":[
-                                    "Non-youth",
-                                    "Youth"
-                                 ],
-                                 "dataset":105,
-                                 "name":"youth status",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              }
-                           ]
-                        },
-                        "content_type":"indicator",
-                        "dataset_content_type":"quantitative",
-                        "chart_configuration":{
-                           "types":{
-                              "Value":{
-                                 "formatting":",.0f"
-                              },
-                              "Percentage":{
-                                 "maxX":1,
-                                 "minX":0
-                              }
-                           },
-                           "xTicks":5
-                        },
-                        "data":[
-                           {
-                              "count":19644170.051473208,
-                              "youth status":"Youth"
-                           },
-                           {
-                              "count":31285821.674497947,
-                              "youth status":"Non-youth"
-                           }
-                        ],
-                        "child_data":{
-                           "NC":[
-                              {
-                                 "count":398812.85508897615,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":744984.5530132334,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "MP":[
-                              {
-                                 "count":1549983.6694277155,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":2412477.4226002577,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "NW":[
-                              {
-                                 "count":1270662.729200918,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":2174183.0653655147,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "WC":[
-                              {
-                                 "count":2204214.795469933,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":3577146.107482197,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "EC":[
-                              {
-                                 "count":2226670.1442380003,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":4226439.346470516,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "FS":[
-                              {
-                                 "count":1016237.4047017085,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":1711923.4336486615,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "GT":[
-                              {
-                                 "count":5110466.437825331,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":7005250.811108921,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "KZN":[
-                              {
-                                 "count":3873329.889222033,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":6097948.300427332,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "LIM":[
-                              {
-                                 "count":1993792.126551515,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":3335468.632570535,
-                                 "youth status":"Non-youth"
-                              }
-                           ]
-                        }
-                     }
+  "profile": {
+    "logo": {
+      "image": "",
+      "url": "/"
+    },
+    "geography": {
+      "name": "South Africa Test",
+      "code": "ZA",
+      "level": "country",
+      "version": "2011 Boundaries",
+      "parents": []
+    },
+    "profile_data": {
+      "Test Category 1": {
+        "description": "",
+        "subcategories": {
+          "Population": {
+            "description": "",
+            "indicators": {
+              "Youth status": {
+                "id": 98,
+                "description": "An indicator showing whether an individual is in the age group 15 - 35",
+                "choropleth_method": "subindicator",
+                "last_updated_at": "2021-03-04T08:22:16.959409Z",
+                "metadata": {
+                  "source": "StatsSA Census 2011",
+                  "description": "",
+                  "url": null,
+                  "licence": {
+                    "name": "creative commons",
+                    "url": null
+                  },
+                  "primary_group": "youth status",
+                  "groups": [
+                    {
+                      "subindicators": [
+                        "Non-youth",
+                        "Youth"
+                      ],
+                      "dataset": 105,
+                      "name": "youth status",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    }
+                  ]
+                },
+                "content_type": "indicator",
+                "dataset_content_type": "quantitative",
+                "chart_configuration": {
+                  "types": {
+                    "Value": {
+                      "formatting": ",.0f"
+                    },
+                    "Percentage": {
+                      "maxX": 1,
+                      "minX": 0
+                    }
+                  },
+                  "xTicks": 5
+                },
+                "data": [
+                  {
+                    "count": 19644170.051473208,
+                    "youth status": "Youth"
+                  },
+                  {
+                    "count": 31285821.674497947,
+                    "youth status": "Non-youth"
                   }
-               },
-               "South African Citizenship":{
-                  "description":"",
-                  "indicators":{
-                     "Citizenship":{
-                        "id":91,
-                        "description":"",
-                        "choropleth_method":"subindicator",
-                        "last_updated_at":"2021-06-14T14:30:07.808247Z",
-                        "metadata":{
-                           "source":"StatsSA Census 2011",
-                           "description":"",
-                           "url":null,
-                           "licence":{
-                              "name":"creative commons",
-                              "url":null
-                           },
-                           "primary_group":"citizenship",
-                           "groups":[
-                              {
-                                 "subindicators":[
-                                    "30-35",
-                                    "20-24",
-                                    "15-24 (Intl)",
-                                    "15-35 (ZA)",
-                                    "15-19",
-                                    "25-29"
-                                 ],
-                                 "dataset":96,
-                                 "name":"age group",
-                                 "can_aggregate":false,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Unspecified",
-                                    "No",
-                                    "Yes"
-                                 ],
-                                 "dataset":96,
-                                 "name":"citizenship",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Female",
-                                    "Male"
-                                 ],
-                                 "dataset":96,
-                                 "name":"gender",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Black African",
-                                    "Indian or Asian",
-                                    "Other",
-                                    "Coloured",
-                                    "White"
-                                 ],
-                                 "dataset":96,
-                                 "name":"race",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              }
-                           ]
-                        },
-                        "content_type":"indicator",
-                        "dataset_content_type":"quantitative",
-                        "chart_configuration":{
-                           "types":{
-                              "Value":{
-                                 "formatting":",.0f"
-                              },
-                              "Percentage":{
-                                 "maxX":1,
-                                 "minX":0
-                              }
-                           },
-                           "filter":{
-                              "defaults":[
-                                 {
-                                    "name":"age group",
-                                    "value":"15-35 (ZA)"
-                                 }
-                              ]
-                           },
-                           "xTicks":6
-                        },
-                        "data":[
-                           {
-                              "race":"Black African",
-                              "count":"1986297",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"37359",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"10626",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"207872",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"465",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1101",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"47993",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"1476",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"294",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"129616",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1268",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"949",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4519",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"2974",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"132",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"2010361",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"31435",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"11084",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"209486",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"372",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1084",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"47651",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"779",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"311",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"125861",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1387",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"962",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4361",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"1512",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"87",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1901376",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"131487",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9401",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"199085",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"803",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"725",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"52340",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"7466",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"361",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"141186",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"2176",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"936",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"5791",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"14244",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"359",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"2012015",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"99581",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9777",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"208215",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"716",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"878",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"50961",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"1842",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"246",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"141615",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"2444",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"915",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4896",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"5208",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"200",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1731366",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"186744",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"10152",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"182106",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1051",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"731",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"54317",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"11999",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"469",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"153818",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"2658",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1028",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"6454",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"20342",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"500",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1869178",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"123546",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9849",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"197014",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"683",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"777",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"53672",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"3285",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"357",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"158197",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"3186",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1014",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4877",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"6897",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"268",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1607378",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"167190",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9668",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"178786",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1110",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"719",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"60087",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"10998",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"494",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"176015",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"3598",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1098",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"6402",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"16726",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"429",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1731408",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"91390",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"8633",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"195573",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"629",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"748",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"60271",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"2971",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"370",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"182179",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"4293",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1201",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4635",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"5135",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"210",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":3887673,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":7226417,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":168846,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":522780,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":20027,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":39847,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":406957,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":767849,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1268,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":3429,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1826,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":3276,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":100333,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":214737,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":8942,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":31939,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":655,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":1618,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":270802,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":600635,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":3444,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":9700,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":1885,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":4011,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":10310,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":23166,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":17218,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":54286,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":491,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":1420,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":4022376,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":7622962,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":131016,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":345952,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":20861,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":39343,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":417701,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":810288,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1088,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":2400,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1962,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":3487,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":98612,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":212555,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":2621,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":8877,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":557,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":1284,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":267476,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":607852,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":3831,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":11310,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":1877,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":4092,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":9257,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":18769,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":6720,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":18752,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":287,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":765,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           }
-                        ]
-                     }
-                  }
-               }
+                ],
+                "child_data": {
+                  "NC": [
+                    {
+                      "count": 398812.85508897615,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 744984.5530132334,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "MP": [
+                    {
+                      "count": 1549983.6694277155,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 2412477.4226002577,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "NW": [
+                    {
+                      "count": 1270662.729200918,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 2174183.0653655147,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "WC": [
+                    {
+                      "count": 2204214.795469933,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 3577146.107482197,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "EC": [
+                    {
+                      "count": 2226670.1442380003,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 4226439.346470516,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "FS": [
+                    {
+                      "count": 1016237.4047017085,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 1711923.4336486615,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "GT": [
+                    {
+                      "count": 5110466.437825331,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 7005250.811108921,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "KZN": [
+                    {
+                      "count": 3873329.889222033,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 6097948.300427332,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "LIM": [
+                    {
+                      "count": 1993792.126551515,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 3335468.632570535,
+                      "youth status": "Non-youth"
+                    }
+                  ]
+                }
+              }
             }
-         },
-         "Test Category 2":{
-            "description":"",
-            "subcategories":{
-               "Population":{
-                  "description":"",
-                  "indicators":{
-                     "Youth status":{
-                        "id":98,
-                        "description":"An indicator showing whether an individual is in the age group 15 - 35",
-                        "choropleth_method":"subindicator",
-                        "last_updated_at":"2021-03-04T08:22:16.959409Z",
-                        "metadata":{
-                           "source":"StatsSA Census 2011",
-                           "description":"",
-                           "url":null,
-                           "licence":{
-                              "name":"creative commons",
-                              "url":null
-                           },
-                           "primary_group":"youth status",
-                           "groups":[
-                              {
-                                 "subindicators":[
-                                    "Non-youth",
-                                    "Youth"
-                                 ],
-                                 "dataset":105,
-                                 "name":"youth status",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              }
-                           ]
-                        },
-                        "content_type":"indicator",
-                        "dataset_content_type":"quantitative",
-                        "chart_configuration":{
-                           "types":{
-                              "Value":{
-                                 "formatting":",.0f"
-                              },
-                              "Percentage":{
-                                 "maxX":1,
-                                 "minX":0
-                              }
-                           },
-                           "xTicks":5
-                        },
-                        "data":[
-                           {
-                              "count":19644170.051473208,
-                              "youth status":"Youth"
-                           },
-                           {
-                              "count":31285821.674497947,
-                              "youth status":"Non-youth"
-                           }
-                        ],
-                        "child_data":{
-                           "NC":[
-                              {
-                                 "count":398812.85508897615,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":744984.5530132334,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "MP":[
-                              {
-                                 "count":1549983.6694277155,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":2412477.4226002577,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "NW":[
-                              {
-                                 "count":1270662.729200918,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":2174183.0653655147,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "WC":[
-                              {
-                                 "count":2204214.795469933,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":3577146.107482197,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "EC":[
-                              {
-                                 "count":2226670.1442380003,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":4226439.346470516,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "FS":[
-                              {
-                                 "count":1016237.4047017085,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":1711923.4336486615,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "GT":[
-                              {
-                                 "count":5110466.437825331,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":7005250.811108921,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "KZN":[
-                              {
-                                 "count":3873329.889222033,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":6097948.300427332,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "LIM":[
-                              {
-                                 "count":1993792.126551515,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":3335468.632570535,
-                                 "youth status":"Non-youth"
-                              }
-                           ]
-                        }
-                     }
+          },
+          "South African Citizenship": {
+            "description": "",
+            "indicators": {
+              "Citizenship": {
+                "id": 91,
+                "description": "",
+                "choropleth_method": "subindicator",
+                "last_updated_at": "2021-06-14T14:30:07.808247Z",
+                "metadata": {
+                  "source": "StatsSA Census 2011",
+                  "description": "",
+                  "url": null,
+                  "licence": {
+                    "name": "creative commons",
+                    "url": null
+                  },
+                  "primary_group": "citizenship",
+                  "groups": [
+                    {
+                      "subindicators": [
+                        "30-35",
+                        "20-24",
+                        "15-24 (Intl)",
+                        "15-35 (ZA)",
+                        "15-19",
+                        "25-29"
+                      ],
+                      "dataset": 96,
+                      "name": "age group",
+                      "can_aggregate": false,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Unspecified",
+                        "No",
+                        "Yes"
+                      ],
+                      "dataset": 96,
+                      "name": "citizenship",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Female",
+                        "Male"
+                      ],
+                      "dataset": 96,
+                      "name": "gender",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Black African",
+                        "Indian or Asian",
+                        "Other",
+                        "Coloured",
+                        "White"
+                      ],
+                      "dataset": 96,
+                      "name": "race",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    }
+                  ]
+                },
+                "content_type": "indicator",
+                "dataset_content_type": "quantitative",
+                "chart_configuration": {
+                  "types": {
+                    "Value": {
+                      "formatting": ",.0f"
+                    },
+                    "Percentage": {
+                      "maxX": 1,
+                      "minX": 0
+                    }
+                  },
+                  "filter": {
+                    "defaults": [
+                      {
+                        "name": "age group",
+                        "value": "15-35 (ZA)"
+                      }
+                    ]
+                  },
+                  "xTicks": 6
+                },
+                "data": [
+                  {
+                    "race": "Black African",
+                    "count": "1986297",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "37359",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "10626",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "207872",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "465",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1101",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "47993",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "1476",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "294",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "129616",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1268",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "949",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4519",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "2974",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "132",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "2010361",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "31435",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "11084",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "209486",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "372",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1084",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "47651",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "779",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "311",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "125861",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1387",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "962",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4361",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "1512",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "87",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1901376",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "131487",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9401",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "199085",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "803",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "725",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "52340",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "7466",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "361",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "141186",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "2176",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "936",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "5791",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "14244",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "359",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "2012015",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "99581",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9777",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "208215",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "716",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "878",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "50961",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "1842",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "246",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "141615",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "2444",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "915",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4896",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "5208",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "200",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1731366",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "186744",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "10152",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "182106",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1051",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "731",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "54317",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "11999",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "469",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "153818",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "2658",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1028",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "6454",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "20342",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "500",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1869178",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "123546",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9849",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "197014",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "683",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "777",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "53672",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "3285",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "357",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "158197",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "3186",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1014",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4877",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "6897",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "268",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1607378",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "167190",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9668",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "178786",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1110",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "719",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "60087",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "10998",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "494",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "176015",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "3598",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1098",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "6402",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "16726",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "429",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1731408",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "91390",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "8633",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "195573",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "629",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "748",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "60271",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "2971",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "370",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "182179",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "4293",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1201",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4635",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "5135",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "210",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 3887673,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 7226417,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 168846,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 522780,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 20027,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 39847,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 406957,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 767849,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1268,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 3429,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1826,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 3276,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 100333,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 214737,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 8942,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 31939,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 655,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 1618,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 270802,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 600635,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 3444,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 9700,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 1885,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 4011,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 10310,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 23166,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 17218,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 54286,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 491,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 1420,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 4022376,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 7622962,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 131016,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 345952,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 20861,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 39343,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 417701,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 810288,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1088,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 2400,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1962,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 3487,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 98612,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 212555,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 2621,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 8877,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 557,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 1284,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 267476,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 607852,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 3831,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 11310,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 1877,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 4092,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 9257,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 18769,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 6720,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 18752,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 287,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 765,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
                   }
-               },
-               "South African Citizenship":{
-                  "description":"",
-                  "indicators":{
-                     "Citizenship":{
-                        "id":91,
-                        "description":"",
-                        "choropleth_method":"subindicator",
-                        "last_updated_at":"2021-06-14T14:30:07.808247Z",
-                        "metadata":{
-                           "source":"StatsSA Census 2011",
-                           "description":"",
-                           "url":null,
-                           "licence":{
-                              "name":"creative commons",
-                              "url":null
-                           },
-                           "primary_group":"citizenship",
-                           "groups":[
-                              {
-                                 "subindicators":[
-                                    "30-35",
-                                    "20-24",
-                                    "15-24 (Intl)",
-                                    "15-35 (ZA)",
-                                    "15-19",
-                                    "25-29"
-                                 ],
-                                 "dataset":96,
-                                 "name":"age group",
-                                 "can_aggregate":false,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Unspecified",
-                                    "No",
-                                    "Yes"
-                                 ],
-                                 "dataset":96,
-                                 "name":"citizenship",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Female",
-                                    "Male"
-                                 ],
-                                 "dataset":96,
-                                 "name":"gender",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Black African",
-                                    "Indian or Asian",
-                                    "Other",
-                                    "Coloured",
-                                    "White"
-                                 ],
-                                 "dataset":96,
-                                 "name":"race",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              }
-                           ]
-                        },
-                        "content_type":"indicator",
-                        "dataset_content_type":"quantitative",
-                        "chart_configuration":{
-                           "types":{
-                              "Value":{
-                                 "formatting":",.0f"
-                              },
-                              "Percentage":{
-                                 "maxX":1,
-                                 "minX":0
-                              }
-                           },
-                           "filter":{
-                              "defaults":[
-                                 {
-                                    "name":"age group",
-                                    "value":"15-35 (ZA)"
-                                 }
-                              ]
-                           },
-                           "xTicks":6
-                        },
-                        "data":[
-                           {
-                              "race":"Black African",
-                              "count":"1986297",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"37359",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"10626",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"207872",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"465",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1101",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"47993",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"1476",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"294",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"129616",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1268",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"949",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4519",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"2974",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"132",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"2010361",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"31435",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"11084",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"209486",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"372",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1084",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"47651",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"779",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"311",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"125861",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1387",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"962",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4361",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"1512",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"87",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1901376",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"131487",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9401",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"199085",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"803",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"725",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"52340",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"7466",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"361",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"141186",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"2176",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"936",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"5791",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"14244",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"359",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"2012015",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"99581",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9777",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"208215",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"716",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"878",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"50961",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"1842",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"246",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"141615",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"2444",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"915",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4896",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"5208",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"200",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1731366",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"186744",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"10152",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"182106",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1051",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"731",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"54317",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"11999",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"469",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"153818",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"2658",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1028",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"6454",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"20342",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"500",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1869178",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"123546",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9849",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"197014",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"683",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"777",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"53672",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"3285",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"357",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"158197",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"3186",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1014",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4877",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"6897",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"268",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1607378",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"167190",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9668",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"178786",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1110",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"719",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"60087",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"10998",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"494",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"176015",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"3598",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1098",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"6402",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"16726",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"429",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1731408",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"91390",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"8633",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"195573",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"629",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"748",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"60271",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"2971",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"370",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"182179",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"4293",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1201",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4635",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"5135",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"210",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":3887673,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":7226417,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":168846,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":522780,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":20027,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":39847,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":406957,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":767849,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1268,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":3429,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1826,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":3276,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":100333,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":214737,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":8942,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":31939,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":655,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":1618,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":270802,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":600635,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":3444,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":9700,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":1885,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":4011,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":10310,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":23166,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":17218,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":54286,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":491,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":1420,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":4022376,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":7622962,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":131016,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":345952,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":20861,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":39343,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":417701,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":810288,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1088,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":2400,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1962,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":3487,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":98612,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":212555,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":2621,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":8877,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":557,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":1284,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":267476,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":607852,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":3831,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":11310,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":1877,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":4092,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":9257,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":18769,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":6720,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":18752,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":287,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":765,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           }
-                        ]
-                     }
-                  }
-               }
+                ]
+              }
             }
-         },
-         "Test Category 3":{
-            "description":"",
-            "subcategories":{
-               "Population":{
-                  "description":"",
-                  "indicators":{
-                     "Youth status":{
-                        "id":98,
-                        "description":"An indicator showing whether an individual is in the age group 15 - 35",
-                        "choropleth_method":"subindicator",
-                        "last_updated_at":"2021-03-04T08:22:16.959409Z",
-                        "metadata":{
-                           "source":"StatsSA Census 2011",
-                           "description":"",
-                           "url":null,
-                           "licence":{
-                              "name":"creative commons",
-                              "url":null
-                           },
-                           "primary_group":"youth status",
-                           "groups":[
-                              {
-                                 "subindicators":[
-                                    "Non-youth",
-                                    "Youth"
-                                 ],
-                                 "dataset":105,
-                                 "name":"youth status",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              }
-                           ]
-                        },
-                        "content_type":"indicator",
-                        "dataset_content_type":"quantitative",
-                        "chart_configuration":{
-                           "types":{
-                              "Value":{
-                                 "formatting":",.0f"
-                              },
-                              "Percentage":{
-                                 "maxX":1,
-                                 "minX":0
-                              }
-                           },
-                           "xTicks":5
-                        },
-                        "data":[
-                           {
-                              "count":19644170.051473208,
-                              "youth status":"Youth"
-                           },
-                           {
-                              "count":31285821.674497947,
-                              "youth status":"Non-youth"
-                           }
-                        ],
-                        "child_data":{
-                           "NC":[
-                              {
-                                 "count":398812.85508897615,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":744984.5530132334,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "MP":[
-                              {
-                                 "count":1549983.6694277155,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":2412477.4226002577,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "NW":[
-                              {
-                                 "count":1270662.729200918,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":2174183.0653655147,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "WC":[
-                              {
-                                 "count":2204214.795469933,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":3577146.107482197,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "EC":[
-                              {
-                                 "count":2226670.1442380003,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":4226439.346470516,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "FS":[
-                              {
-                                 "count":1016237.4047017085,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":1711923.4336486615,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "GT":[
-                              {
-                                 "count":5110466.437825331,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":7005250.811108921,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "KZN":[
-                              {
-                                 "count":3873329.889222033,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":6097948.300427332,
-                                 "youth status":"Non-youth"
-                              }
-                           ],
-                           "LIM":[
-                              {
-                                 "count":1993792.126551515,
-                                 "youth status":"Youth"
-                              },
-                              {
-                                 "count":3335468.632570535,
-                                 "youth status":"Non-youth"
-                              }
-                           ]
-                        }
-                     }
-                  }
-               },
-               "South African Citizenship":{
-                  "description":"",
-                  "indicators":{
-                     "Citizenship":{
-                        "id":91,
-                        "description":"",
-                        "choropleth_method":"subindicator",
-                        "last_updated_at":"2021-06-14T14:30:07.808247Z",
-                        "metadata":{
-                           "source":"StatsSA Census 2011",
-                           "description":"",
-                           "url":null,
-                           "licence":{
-                              "name":"creative commons",
-                              "url":null
-                           },
-                           "primary_group":"citizenship",
-                           "groups":[
-                              {
-                                 "subindicators":[
-                                    "30-35",
-                                    "20-24",
-                                    "15-24 (Intl)",
-                                    "15-35 (ZA)",
-                                    "15-19",
-                                    "25-29"
-                                 ],
-                                 "dataset":96,
-                                 "name":"age group",
-                                 "can_aggregate":false,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Unspecified",
-                                    "No",
-                                    "Yes"
-                                 ],
-                                 "dataset":96,
-                                 "name":"citizenship",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Female",
-                                    "Male"
-                                 ],
-                                 "dataset":96,
-                                 "name":"gender",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Black African",
-                                    "Indian or Asian",
-                                    "Other",
-                                    "Coloured",
-                                    "White"
-                                 ],
-                                 "dataset":96,
-                                 "name":"race",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              }
-                           ]
-                        },
-                        "content_type":"indicator",
-                        "dataset_content_type":"quantitative",
-                        "chart_configuration":{
-                           "types":{
-                              "Value":{
-                                 "formatting":",.0f"
-                              },
-                              "Percentage":{
-                                 "maxX":1,
-                                 "minX":0
-                              }
-                           },
-                           "filter":{
-                              "defaults":[
-                                 {
-                                    "name":"age group",
-                                    "value":"15-35 (ZA)"
-                                 }
-                              ]
-                           },
-                           "xTicks":6
-                        },
-                        "data":[
-                           {
-                              "race":"Black African",
-                              "count":"1986297",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"37359",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"10626",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"207872",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"465",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1101",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"47993",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"1476",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"294",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"129616",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1268",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"949",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4519",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"2974",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"132",
-                              "gender":"Male",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"2010361",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"31435",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"11084",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"209486",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"372",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1084",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"47651",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"779",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"311",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"125861",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1387",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"962",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4361",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"1512",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"87",
-                              "gender":"Female",
-                              "age group":"15-19",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1901376",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"131487",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9401",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"199085",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"803",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"725",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"52340",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"7466",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"361",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"141186",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"2176",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"936",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"5791",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"14244",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"359",
-                              "gender":"Male",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"2012015",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"99581",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9777",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"208215",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"716",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"878",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"50961",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"1842",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"246",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"141615",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"2444",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"915",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4896",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"5208",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"200",
-                              "gender":"Female",
-                              "age group":"20-24",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1731366",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"186744",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"10152",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"182106",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1051",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"731",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"54317",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"11999",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"469",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"153818",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"2658",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1028",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"6454",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"20342",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"500",
-                              "gender":"Male",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1869178",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"123546",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9849",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"197014",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"683",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"777",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"53672",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"3285",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"357",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"158197",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"3186",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1014",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4877",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"6897",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"268",
-                              "gender":"Female",
-                              "age group":"25-29",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1607378",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"167190",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"9668",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"178786",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"1110",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"719",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"60087",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"10998",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"494",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"176015",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"3598",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1098",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"6402",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"16726",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"429",
-                              "gender":"Male",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"1731408",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"91390",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"8633",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"195573",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"629",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":"748",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"60271",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"2971",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":"370",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":"182179",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":"4293",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":"1201",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"4635",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"5135",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":"210",
-                              "gender":"Female",
-                              "age group":"30-35",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":3887673,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":7226417,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":168846,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":522780,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":20027,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":39847,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":406957,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":767849,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1268,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":3429,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1826,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":3276,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":100333,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":214737,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":8942,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":31939,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":655,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":1618,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":270802,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":600635,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":3444,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":9700,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":1885,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":4011,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":10310,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":23166,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":17218,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":54286,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":491,
-                              "gender":"Male",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":1420,
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":4022376,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":7622962,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":131016,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":345952,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":20861,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":39343,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":417701,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":810288,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1088,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":2400,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":1962,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Coloured",
-                              "count":3487,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":98612,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":212555,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":2621,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":8877,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":557,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Indian or Asian",
-                              "count":1284,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":267476,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":607852,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"White",
-                              "count":3831,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":11310,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"White",
-                              "count":1877,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"White",
-                              "count":4092,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":9257,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":18769,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Other",
-                              "count":6720,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":18752,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           },
-                           {
-                              "race":"Other",
-                              "count":287,
-                              "gender":"Female",
-                              "age group":"15-24 (Intl)",
-                              "citizenship":"Unspecified"
-                           },
-                           {
-                              "race":"Other",
-                              "count":765,
-                              "gender":"Female",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Unspecified"
-                           }
-                        ]
-                     },
-					 "Indicator with only zero counts":{
-                        "id":91,
-                        "description":"",
-                        "choropleth_method":"subindicator",
-                        "last_updated_at":"2021-06-14T14:30:07.808247Z",
-                        "metadata":{
-                           "source":"StatsSA Census 2011",
-                           "description":"",
-                           "url":null,
-                           "licence":{
-                              "name":"creative commons",
-                              "url":null
-                           },
-                           "primary_group":"citizenship",
-                           "groups":[
-                              {
-                                 "subindicators":[
-                                    "30-35",
-                                    "20-24",
-                                    "15-24 (Intl)",
-                                    "15-35 (ZA)",
-                                    "15-19",
-                                    "25-29"
-                                 ],
-                                 "dataset":96,
-                                 "name":"age group",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Unspecified",
-                                    "No",
-                                    "Yes"
-                                 ],
-                                 "dataset":96,
-                                 "name":"citizenship",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Female",
-                                    "Male"
-                                 ],
-                                 "dataset":96,
-                                 "name":"gender",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              },
-                              {
-                                 "subindicators":[
-                                    "Black African",
-                                    "Indian or Asian",
-                                    "Other",
-                                    "Coloured",
-                                    "White"
-                                 ],
-                                 "dataset":96,
-                                 "name":"race",
-                                 "can_aggregate":true,
-                                 "can_filter":true
-                              }
-                           ]
-                        },
-                        "content_type":"indicator",
-                        "dataset_content_type":"quantitative",
-                        "chart_configuration":{
-                           "types":{
-                              "Value":{
-                                 "formatting":",.0f"
-                              },
-                              "Percentage":{
-                                 "maxX":1,
-                                 "minX":0
-                              }
-                           },
-                           "xTicks":6
-                        },
-                        "data":[
-                           {
-                              "race":"Black African",
-                              "count":"0",
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"Yes"
-                           },
-                           {
-                              "race":"Black African",
-                              "count":"0",
-                              "gender":"Male",
-                              "age group":"15-35 (ZA)",
-                              "citizenship":"No"
-                           }
-                        ]
-                     }
-                  }
-               }
-            }
-         }
+          }
+        }
       },
-      "highlights":[
-         {
-            "label":"Youth",
-            "value":0.3857092723903957,
-            "method":"subindicators"
-         },
-         {
-            "label":"Attended school",
-            "value":0.3704203614249921,
-            "method":"subindicators"
-         },
-         {
-            "label":"Youth Multidimensional Poverty Index (MPI)",
-            "value":0.19563694298267365,
-            "method":"absolute_value"
-         }
-      ],
-      "overview":{
-         "name":"Youth Explorer",
-         "description":""
+      "Test Category 2": {
+        "description": "",
+        "subcategories": {
+          "Population": {
+            "description": "",
+            "indicators": {
+              "Youth status": {
+                "id": 98,
+                "description": "An indicator showing whether an individual is in the age group 15 - 35",
+                "choropleth_method": "subindicator",
+                "last_updated_at": "2021-03-04T08:22:16.959409Z",
+                "metadata": {
+                  "source": "StatsSA Census 2011",
+                  "description": "",
+                  "url": null,
+                  "licence": {
+                    "name": "creative commons",
+                    "url": null
+                  },
+                  "primary_group": "youth status",
+                  "groups": [
+                    {
+                      "subindicators": [
+                        "Non-youth",
+                        "Youth"
+                      ],
+                      "dataset": 105,
+                      "name": "youth status",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    }
+                  ]
+                },
+                "content_type": "indicator",
+                "dataset_content_type": "quantitative",
+                "chart_configuration": {
+                  "types": {
+                    "Value": {
+                      "formatting": ",.0f"
+                    },
+                    "Percentage": {
+                      "maxX": 1,
+                      "minX": 0
+                    }
+                  },
+                  "xTicks": 5
+                },
+                "data": [
+                  {
+                    "count": 19644170.051473208,
+                    "youth status": "Youth"
+                  },
+                  {
+                    "count": 31285821.674497947,
+                    "youth status": "Non-youth"
+                  }
+                ],
+                "child_data": {
+                  "NC": [
+                    {
+                      "count": 398812.85508897615,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 744984.5530132334,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "MP": [
+                    {
+                      "count": 1549983.6694277155,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 2412477.4226002577,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "NW": [
+                    {
+                      "count": 1270662.729200918,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 2174183.0653655147,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "WC": [
+                    {
+                      "count": 2204214.795469933,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 3577146.107482197,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "EC": [
+                    {
+                      "count": 2226670.1442380003,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 4226439.346470516,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "FS": [
+                    {
+                      "count": 1016237.4047017085,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 1711923.4336486615,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "GT": [
+                    {
+                      "count": 5110466.437825331,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 7005250.811108921,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "KZN": [
+                    {
+                      "count": 3873329.889222033,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 6097948.300427332,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "LIM": [
+                    {
+                      "count": 1993792.126551515,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 3335468.632570535,
+                      "youth status": "Non-youth"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "South African Citizenship": {
+            "description": "",
+            "indicators": {
+              "Citizenship": {
+                "id": 91,
+                "description": "",
+                "choropleth_method": "subindicator",
+                "last_updated_at": "2021-06-14T14:30:07.808247Z",
+                "metadata": {
+                  "source": "StatsSA Census 2011",
+                  "description": "",
+                  "url": null,
+                  "licence": {
+                    "name": "creative commons",
+                    "url": null
+                  },
+                  "primary_group": "citizenship",
+                  "groups": [
+                    {
+                      "subindicators": [
+                        "30-35",
+                        "20-24",
+                        "15-24 (Intl)",
+                        "15-35 (ZA)",
+                        "15-19",
+                        "25-29"
+                      ],
+                      "dataset": 96,
+                      "name": "age group",
+                      "can_aggregate": false,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Unspecified",
+                        "No",
+                        "Yes"
+                      ],
+                      "dataset": 96,
+                      "name": "citizenship",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Female",
+                        "Male"
+                      ],
+                      "dataset": 96,
+                      "name": "gender",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Black African",
+                        "Indian or Asian",
+                        "Other",
+                        "Coloured",
+                        "White"
+                      ],
+                      "dataset": 96,
+                      "name": "race",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    }
+                  ]
+                },
+                "content_type": "indicator",
+                "dataset_content_type": "quantitative",
+                "chart_configuration": {
+                  "types": {
+                    "Value": {
+                      "formatting": ",.0f"
+                    },
+                    "Percentage": {
+                      "maxX": 1,
+                      "minX": 0
+                    }
+                  },
+                  "filter": {
+                    "defaults": [
+                      {
+                        "name": "age group",
+                        "value": "15-35 (ZA)"
+                      }
+                    ]
+                  },
+                  "xTicks": 6
+                },
+                "data": [
+                  {
+                    "race": "Black African",
+                    "count": "1986297",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "37359",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "10626",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "207872",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "465",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1101",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "47993",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "1476",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "294",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "129616",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1268",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "949",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4519",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "2974",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "132",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "2010361",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "31435",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "11084",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "209486",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "372",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1084",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "47651",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "779",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "311",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "125861",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1387",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "962",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4361",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "1512",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "87",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1901376",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "131487",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9401",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "199085",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "803",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "725",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "52340",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "7466",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "361",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "141186",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "2176",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "936",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "5791",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "14244",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "359",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "2012015",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "99581",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9777",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "208215",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "716",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "878",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "50961",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "1842",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "246",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "141615",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "2444",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "915",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4896",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "5208",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "200",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1731366",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "186744",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "10152",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "182106",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1051",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "731",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "54317",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "11999",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "469",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "153818",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "2658",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1028",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "6454",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "20342",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "500",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1869178",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "123546",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9849",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "197014",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "683",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "777",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "53672",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "3285",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "357",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "158197",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "3186",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1014",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4877",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "6897",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "268",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1607378",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "167190",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9668",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "178786",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1110",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "719",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "60087",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "10998",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "494",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "176015",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "3598",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1098",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "6402",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "16726",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "429",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1731408",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "91390",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "8633",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "195573",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "629",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "748",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "60271",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "2971",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "370",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "182179",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "4293",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1201",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4635",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "5135",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "210",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 3887673,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 7226417,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 168846,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 522780,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 20027,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 39847,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 406957,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 767849,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1268,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 3429,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1826,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 3276,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 100333,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 214737,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 8942,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 31939,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 655,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 1618,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 270802,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 600635,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 3444,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 9700,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 1885,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 4011,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 10310,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 23166,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 17218,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 54286,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 491,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 1420,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 4022376,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 7622962,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 131016,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 345952,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 20861,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 39343,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 417701,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 810288,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1088,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 2400,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1962,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 3487,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 98612,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 212555,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 2621,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 8877,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 557,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 1284,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 267476,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 607852,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 3831,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 11310,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 1877,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 4092,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 9257,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 18769,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 6720,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 18752,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 287,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 765,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  }
+                ]
+              }
+            }
+          }
+        }
+      },
+      "Test Category 3": {
+        "description": "",
+        "subcategories": {
+          "Subcategory with indicators": {
+            "description": "",
+            "indicators": {
+              "Youth status": {
+                "id": 98,
+                "description": "An indicator showing whether an individual is in the age group 15 - 35",
+                "choropleth_method": "subindicator",
+                "last_updated_at": "2021-03-04T08:22:16.959409Z",
+                "metadata": {
+                  "source": "StatsSA Census 2011",
+                  "description": "",
+                  "url": null,
+                  "licence": {
+                    "name": "creative commons",
+                    "url": null
+                  },
+                  "primary_group": "youth status",
+                  "groups": [
+                    {
+                      "subindicators": [
+                        "Non-youth",
+                        "Youth"
+                      ],
+                      "dataset": 105,
+                      "name": "youth status",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    }
+                  ]
+                },
+                "content_type": "indicator",
+                "dataset_content_type": "quantitative",
+                "chart_configuration": {
+                  "types": {
+                    "Value": {
+                      "formatting": ",.0f"
+                    },
+                    "Percentage": {
+                      "maxX": 1,
+                      "minX": 0
+                    }
+                  },
+                  "xTicks": 5
+                },
+                "data": [
+                  {
+                    "count": 19644170.051473208,
+                    "youth status": "Youth"
+                  },
+                  {
+                    "count": 31285821.674497947,
+                    "youth status": "Non-youth"
+                  }
+                ],
+                "child_data": {
+                  "NC": [
+                    {
+                      "count": 398812.85508897615,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 744984.5530132334,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "MP": [
+                    {
+                      "count": 1549983.6694277155,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 2412477.4226002577,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "NW": [
+                    {
+                      "count": 1270662.729200918,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 2174183.0653655147,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "WC": [
+                    {
+                      "count": 2204214.795469933,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 3577146.107482197,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "EC": [
+                    {
+                      "count": 2226670.1442380003,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 4226439.346470516,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "FS": [
+                    {
+                      "count": 1016237.4047017085,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 1711923.4336486615,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "GT": [
+                    {
+                      "count": 5110466.437825331,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 7005250.811108921,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "KZN": [
+                    {
+                      "count": 3873329.889222033,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 6097948.300427332,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "LIM": [
+                    {
+                      "count": 1993792.126551515,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 3335468.632570535,
+                      "youth status": "Non-youth"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "Subcategory with no indicators": {
+            "description": "",
+            "indicators": {}
+          }
+        }
+      },
+      "Category with no subcategories": {
+        "description": "",
+        "subcategories": {}
+      },
+      "Category with no indicators": {
+        "description": "",
+        "subcategories": {
+          "Subcategory with indicators": {
+            "description": "",
+            "indicators": {}
+          },
+          "Subcategory with no indicators": {
+            "description": "",
+            "indicators": {}
+          }
+        }
+      },
+      "Test Category 4": {
+        "description": "",
+        "subcategories": {
+          "Population": {
+            "description": "",
+            "indicators": {
+              "Youth status": {
+                "id": 98,
+                "description": "An indicator showing whether an individual is in the age group 15 - 35",
+                "choropleth_method": "subindicator",
+                "last_updated_at": "2021-03-04T08:22:16.959409Z",
+                "metadata": {
+                  "source": "StatsSA Census 2011",
+                  "description": "",
+                  "url": null,
+                  "licence": {
+                    "name": "creative commons",
+                    "url": null
+                  },
+                  "primary_group": "youth status",
+                  "groups": [
+                    {
+                      "subindicators": [
+                        "Non-youth",
+                        "Youth"
+                      ],
+                      "dataset": 105,
+                      "name": "youth status",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    }
+                  ]
+                },
+                "content_type": "indicator",
+                "dataset_content_type": "quantitative",
+                "chart_configuration": {
+                  "types": {
+                    "Value": {
+                      "formatting": ",.0f"
+                    },
+                    "Percentage": {
+                      "maxX": 1,
+                      "minX": 0
+                    }
+                  },
+                  "xTicks": 5
+                },
+                "data": [
+                  {
+                    "count": 19644170.051473208,
+                    "youth status": "Youth"
+                  },
+                  {
+                    "count": 31285821.674497947,
+                    "youth status": "Non-youth"
+                  }
+                ],
+                "child_data": {
+                  "NC": [
+                    {
+                      "count": 398812.85508897615,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 744984.5530132334,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "MP": [
+                    {
+                      "count": 1549983.6694277155,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 2412477.4226002577,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "NW": [
+                    {
+                      "count": 1270662.729200918,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 2174183.0653655147,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "WC": [
+                    {
+                      "count": 2204214.795469933,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 3577146.107482197,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "EC": [
+                    {
+                      "count": 2226670.1442380003,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 4226439.346470516,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "FS": [
+                    {
+                      "count": 1016237.4047017085,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 1711923.4336486615,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "GT": [
+                    {
+                      "count": 5110466.437825331,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 7005250.811108921,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "KZN": [
+                    {
+                      "count": 3873329.889222033,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 6097948.300427332,
+                      "youth status": "Non-youth"
+                    }
+                  ],
+                  "LIM": [
+                    {
+                      "count": 1993792.126551515,
+                      "youth status": "Youth"
+                    },
+                    {
+                      "count": 3335468.632570535,
+                      "youth status": "Non-youth"
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "South African Citizenship": {
+            "description": "",
+            "indicators": {
+              "Citizenship": {
+                "id": 91,
+                "description": "",
+                "choropleth_method": "subindicator",
+                "last_updated_at": "2021-06-14T14:30:07.808247Z",
+                "metadata": {
+                  "source": "StatsSA Census 2011",
+                  "description": "",
+                  "url": null,
+                  "licence": {
+                    "name": "creative commons",
+                    "url": null
+                  },
+                  "primary_group": "citizenship",
+                  "groups": [
+                    {
+                      "subindicators": [
+                        "30-35",
+                        "20-24",
+                        "15-24 (Intl)",
+                        "15-35 (ZA)",
+                        "15-19",
+                        "25-29"
+                      ],
+                      "dataset": 96,
+                      "name": "age group",
+                      "can_aggregate": false,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Unspecified",
+                        "No",
+                        "Yes"
+                      ],
+                      "dataset": 96,
+                      "name": "citizenship",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Female",
+                        "Male"
+                      ],
+                      "dataset": 96,
+                      "name": "gender",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Black African",
+                        "Indian or Asian",
+                        "Other",
+                        "Coloured",
+                        "White"
+                      ],
+                      "dataset": 96,
+                      "name": "race",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    }
+                  ]
+                },
+                "content_type": "indicator",
+                "dataset_content_type": "quantitative",
+                "chart_configuration": {
+                  "types": {
+                    "Value": {
+                      "formatting": ",.0f"
+                    },
+                    "Percentage": {
+                      "maxX": 1,
+                      "minX": 0
+                    }
+                  },
+                  "filter": {
+                    "defaults": [
+                      {
+                        "name": "age group",
+                        "value": "15-35 (ZA)"
+                      }
+                    ]
+                  },
+                  "xTicks": 6
+                },
+                "data": [
+                  {
+                    "race": "Black African",
+                    "count": "1986297",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "37359",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "10626",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "207872",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "465",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1101",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "47993",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "1476",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "294",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "129616",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1268",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "949",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4519",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "2974",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "132",
+                    "gender": "Male",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "2010361",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "31435",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "11084",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "209486",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "372",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1084",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "47651",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "779",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "311",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "125861",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1387",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "962",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4361",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "1512",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "87",
+                    "gender": "Female",
+                    "age group": "15-19",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1901376",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "131487",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9401",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "199085",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "803",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "725",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "52340",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "7466",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "361",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "141186",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "2176",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "936",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "5791",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "14244",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "359",
+                    "gender": "Male",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "2012015",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "99581",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9777",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "208215",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "716",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "878",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "50961",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "1842",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "246",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "141615",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "2444",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "915",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4896",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "5208",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "200",
+                    "gender": "Female",
+                    "age group": "20-24",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1731366",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "186744",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "10152",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "182106",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1051",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "731",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "54317",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "11999",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "469",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "153818",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "2658",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1028",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "6454",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "20342",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "500",
+                    "gender": "Male",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1869178",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "123546",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9849",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "197014",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "683",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "777",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "53672",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "3285",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "357",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "158197",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "3186",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1014",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4877",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "6897",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "268",
+                    "gender": "Female",
+                    "age group": "25-29",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1607378",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "167190",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "9668",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "178786",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "1110",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "719",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "60087",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "10998",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "494",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "176015",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "3598",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1098",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "6402",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "16726",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "429",
+                    "gender": "Male",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "1731408",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "91390",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "8633",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "195573",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "629",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": "748",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "60271",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "2971",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": "370",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": "182179",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": "4293",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": "1201",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "4635",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "5135",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": "210",
+                    "gender": "Female",
+                    "age group": "30-35",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 3887673,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 7226417,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 168846,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 522780,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 20027,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 39847,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 406957,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 767849,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1268,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 3429,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1826,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 3276,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 100333,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 214737,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 8942,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 31939,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 655,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 1618,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 270802,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 600635,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 3444,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 9700,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 1885,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 4011,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 10310,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 23166,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 17218,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 54286,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 491,
+                    "gender": "Male",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 1420,
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 4022376,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 7622962,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 131016,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 345952,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 20861,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": 39343,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 417701,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 810288,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1088,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 2400,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 1962,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Coloured",
+                    "count": 3487,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 98612,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 212555,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 2621,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 8877,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 557,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Indian or Asian",
+                    "count": 1284,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 267476,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 607852,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "White",
+                    "count": 3831,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 11310,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "White",
+                    "count": 1877,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "White",
+                    "count": 4092,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 9257,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 18769,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 6720,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 18752,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 287,
+                    "gender": "Female",
+                    "age group": "15-24 (Intl)",
+                    "citizenship": "Unspecified"
+                  },
+                  {
+                    "race": "Other",
+                    "count": 765,
+                    "gender": "Female",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Unspecified"
+                  }
+                ]
+              },
+              "Indicator with only zero counts": {
+                "id": 91,
+                "description": "",
+                "choropleth_method": "subindicator",
+                "last_updated_at": "2021-06-14T14:30:07.808247Z",
+                "metadata": {
+                  "source": "StatsSA Census 2011",
+                  "description": "",
+                  "url": null,
+                  "licence": {
+                    "name": "creative commons",
+                    "url": null
+                  },
+                  "primary_group": "citizenship",
+                  "groups": [
+                    {
+                      "subindicators": [
+                        "30-35",
+                        "20-24",
+                        "15-24 (Intl)",
+                        "15-35 (ZA)",
+                        "15-19",
+                        "25-29"
+                      ],
+                      "dataset": 96,
+                      "name": "age group",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Unspecified",
+                        "No",
+                        "Yes"
+                      ],
+                      "dataset": 96,
+                      "name": "citizenship",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Female",
+                        "Male"
+                      ],
+                      "dataset": 96,
+                      "name": "gender",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    },
+                    {
+                      "subindicators": [
+                        "Black African",
+                        "Indian or Asian",
+                        "Other",
+                        "Coloured",
+                        "White"
+                      ],
+                      "dataset": 96,
+                      "name": "race",
+                      "can_aggregate": true,
+                      "can_filter": true
+                    }
+                  ]
+                },
+                "content_type": "indicator",
+                "dataset_content_type": "quantitative",
+                "chart_configuration": {
+                  "types": {
+                    "Value": {
+                      "formatting": ",.0f"
+                    },
+                    "Percentage": {
+                      "maxX": 1,
+                      "minX": 0
+                    }
+                  },
+                  "xTicks": 6
+                },
+                "data": [
+                  {
+                    "race": "Black African",
+                    "count": "0",
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "Yes"
+                  },
+                  {
+                    "race": "Black African",
+                    "count": "0",
+                    "gender": "Male",
+                    "age group": "15-35 (ZA)",
+                    "citizenship": "No"
+                  }
+                ]
+              }
+            }
+          }
+        }
       }
-   },
-   "boundary":{
-      "type":"Feature",
-      "geometry":{
-         "type":"MultiPolygon",
-         "coordinates":[
+    },
+    "highlights": [
+      {
+        "label": "Youth",
+        "value": 0.3857092723903957,
+        "method": "subindicators"
+      },
+      {
+        "label": "Attended school",
+        "value": 0.3704203614249921,
+        "method": "subindicators"
+      },
+      {
+        "label": "Youth Multidimensional Poverty Index (MPI)",
+        "value": 0.19563694298267365,
+        "method": "absolute_value"
+      }
+    ],
+    "overview": {
+      "name": "Youth Explorer",
+      "description": ""
+    }
+  },
+  "boundary": {
+    "type": "Feature",
+    "geometry": {
+      "type": "MultiPolygon",
+      "coordinates": [
+        [
+          [
             [
-               [
-                  [
-                     25.849,
-                     -33.7225
-                  ],
-                  [
-                     25.7912,
-                     -33.7426
-                  ],
-                  [
-                     25.704,
-                     -33.7905
-                  ],
-                  [
-                     25.6415,
-                     -33.8517
-                  ],
-                  [
-                     25.6134,
-                     -33.9189
-                  ],
-                  [
-                     25.6125,
-                     -33.9483
-                  ],
-                  [
-                     25.6714,
-                     -33.9831
-                  ],
-                  [
-                     25.6971,
-                     -34.0321
-                  ],
-                  [
-                     25.6529,
-                     -34.028
-                  ],
-                  [
-                     25.6342,
-                     -34.0465
-                  ],
-                  [
-                     25.5893,
-                     -34.0506
-                  ],
-                  [
-                     25.4522,
-                     -34.0309
-                  ],
-                  [
-                     25.3949,
-                     -34.0314
-                  ],
-                  [
-                     25.3055,
-                     -33.993
-                  ],
-                  [
-                     25.2215,
-                     -33.9708
-                  ],
-                  [
-                     25.1537,
-                     -33.9628
-                  ],
-                  [
-                     25.0779,
-                     -33.9647
-                  ],
-                  [
-                     24.9751,
-                     -33.9851
-                  ],
-                  [
-                     24.9368,
-                     -34.0055
-                  ],
-                  [
-                     24.9215,
-                     -34.0788
-                  ],
-                  [
-                     24.8429,
-                     -34.1416
-                  ],
-                  [
-                     24.8273,
-                     -34.2112
-                  ],
-                  [
-                     24.7301,
-                     -34.1863
-                  ],
-                  [
-                     24.659,
-                     -34.1749
-                  ],
-                  [
-                     24.5991,
-                     -34.1879
-                  ],
-                  [
-                     24.4754,
-                     -34.1619
-                  ],
-                  [
-                     24.3819,
-                     -34.1031
-                  ],
-                  [
-                     24.3239,
-                     -34.1034
-                  ],
-                  [
-                     24.1936,
-                     -34.066
-                  ],
-                  [
-                     24.1133,
-                     -34.0592
-                  ],
-                  [
-                     23.9033,
-                     -34.0291
-                  ],
-                  [
-                     23.8465,
-                     -34.0271
-                  ],
-                  [
-                     23.6529,
-                     -33.9896
-                  ],
-                  [
-                     23.6346,
-                     -33.9521
-                  ],
-                  [
-                     23.6552,
-                     -33.8874
-                  ],
-                  [
-                     23.7033,
-                     -33.8641
-                  ],
-                  [
-                     23.5619,
-                     -33.8289
-                  ],
-                  [
-                     23.554,
-                     -33.7964
-                  ],
-                  [
-                     23.5179,
-                     -33.7856
-                  ],
-                  [
-                     23.468,
-                     -33.8075
-                  ],
-                  [
-                     23.395,
-                     -33.7926
-                  ],
-                  [
-                     23.4301,
-                     -33.7618
-                  ],
-                  [
-                     23.4399,
-                     -33.7174
-                  ],
-                  [
-                     23.4754,
-                     -33.7177
-                  ],
-                  [
-                     23.5413,
-                     -33.6995
-                  ],
-                  [
-                     23.5555,
-                     -33.673
-                  ],
-                  [
-                     23.6704,
-                     -33.6726
-                  ],
-                  [
-                     23.675,
-                     -33.6259
-                  ],
-                  [
-                     23.5962,
-                     -33.5725
-                  ],
-                  [
-                     23.604,
-                     -33.4964
-                  ],
-                  [
-                     23.5142,
-                     -33.4627
-                  ],
-                  [
-                     23.4956,
-                     -33.4434
-                  ],
-                  [
-                     23.3549,
-                     -33.4412
-                  ],
-                  [
-                     23.2971,
-                     -33.3886
-                  ],
-                  [
-                     23.1348,
-                     -33.3876
-                  ],
-                  [
-                     22.9348,
-                     -33.4291
-                  ],
-                  [
-                     22.8303,
-                     -33.4191
-                  ],
-                  [
-                     22.7744,
-                     -33.4197
-                  ],
-                  [
-                     22.7357,
-                     -33.3948
-                  ],
-                  [
-                     22.7393,
-                     -33.324
-                  ],
-                  [
-                     22.7734,
-                     -33.3263
-                  ],
-                  [
-                     22.8402,
-                     -33.2202
-                  ],
-                  [
-                     22.8772,
-                     -33.1869
-                  ],
-                  [
-                     22.8923,
-                     -33.1416
-                  ],
-                  [
-                     22.9553,
-                     -33.0731
-                  ],
-                  [
-                     22.9578,
-                     -33.0451
-                  ],
-                  [
-                     22.9352,
-                     -33.013
-                  ],
-                  [
-                     22.9693,
-                     -32.9934
-                  ],
-                  [
-                     22.9488,
-                     -32.95
-                  ],
-                  [
-                     23.0037,
-                     -32.8983
-                  ],
-                  [
-                     23.0074,
-                     -32.8728
-                  ],
-                  [
-                     23.098,
-                     -32.8737
-                  ],
-                  [
-                     23.1164,
-                     -32.858
-                  ],
-                  [
-                     23.0894,
-                     -32.7992
-                  ],
-                  [
-                     23.1493,
-                     -32.7667
-                  ],
-                  [
-                     23.2011,
-                     -32.7854
-                  ],
-                  [
-                     23.2504,
-                     -32.7886
-                  ],
-                  [
-                     23.3052,
-                     -32.8095
-                  ],
-                  [
-                     23.3786,
-                     -32.825
-                  ],
-                  [
-                     23.3977,
-                     -32.7635
-                  ],
-                  [
-                     23.3516,
-                     -32.7638
-                  ],
-                  [
-                     23.3535,
-                     -32.7294
-                  ],
-                  [
-                     23.3329,
-                     -32.7036
-                  ],
-                  [
-                     23.2696,
-                     -32.6715
-                  ],
-                  [
-                     23.3013,
-                     -32.6518
-                  ],
-                  [
-                     23.3073,
-                     -32.6116
-                  ],
-                  [
-                     23.2882,
-                     -32.5512
-                  ],
-                  [
-                     23.2445,
-                     -32.5132
-                  ],
-                  [
-                     23.2475,
-                     -32.4653
-                  ],
-                  [
-                     23.2216,
-                     -32.425
-                  ],
-                  [
-                     23.3073,
-                     -32.3959
-                  ],
-                  [
-                     23.3331,
-                     -32.3511
-                  ],
-                  [
-                     23.4099,
-                     -32.3892
-                  ],
-                  [
-                     23.449,
-                     -32.3233
-                  ],
-                  [
-                     23.5918,
-                     -32.3408
-                  ],
-                  [
-                     23.6651,
-                     -32.3442
-                  ],
-                  [
-                     23.6489,
-                     -32.298
-                  ],
-                  [
-                     23.6705,
-                     -32.2377
-                  ],
-                  [
-                     23.7471,
-                     -32.2007
-                  ],
-                  [
-                     23.7662,
-                     -32.1787
-                  ],
-                  [
-                     23.7979,
-                     -32.1941
-                  ],
-                  [
-                     23.8511,
-                     -32.2425
-                  ],
-                  [
-                     23.8923,
-                     -32.2549
-                  ],
-                  [
-                     23.9611,
-                     -32.2065
-                  ],
-                  [
-                     24.0305,
-                     -32.1935
-                  ],
-                  [
-                     24.038,
-                     -32.1581
-                  ],
-                  [
-                     24.1001,
-                     -32.164
-                  ],
-                  [
-                     24.1355,
-                     -32.1231
-                  ],
-                  [
-                     24.1097,
-                     -32.0843
-                  ],
-                  [
-                     24.1409,
-                     -32.0117
-                  ],
-                  [
-                     24.183,
-                     -31.9959
-                  ],
-                  [
-                     24.2224,
-                     -31.9556
-                  ],
-                  [
-                     24.1642,
-                     -31.9024
-                  ],
-                  [
-                     24.1054,
-                     -31.9069
-                  ],
-                  [
-                     24.1238,
-                     -31.8472
-                  ],
-                  [
-                     24.1533,
-                     -31.8549
-                  ],
-                  [
-                     24.1525,
-                     -31.7886
-                  ],
-                  [
-                     24.1616,
-                     -31.7401
-                  ],
-                  [
-                     24.2258,
-                     -31.7475
-                  ],
-                  [
-                     24.2683,
-                     -31.7667
-                  ],
-                  [
-                     24.314,
-                     -31.7513
-                  ],
-                  [
-                     24.346,
-                     -31.7145
-                  ],
-                  [
-                     24.5063,
-                     -31.7068
-                  ],
-                  [
-                     24.523,
-                     -31.6037
-                  ],
-                  [
-                     24.5039,
-                     -31.5684
-                  ],
-                  [
-                     24.533,
-                     -31.5098
-                  ],
-                  [
-                     24.5589,
-                     -31.4818
-                  ],
-                  [
-                     24.5672,
-                     -31.4186
-                  ],
-                  [
-                     24.5961,
-                     -31.3992
-                  ],
-                  [
-                     24.665,
-                     -31.3837
-                  ],
-                  [
-                     24.7048,
-                     -31.4006
-                  ],
-                  [
-                     24.7887,
-                     -31.3895
-                  ],
-                  [
-                     24.853,
-                     -31.3282
-                  ],
-                  [
-                     24.942,
-                     -31.3151
-                  ],
-                  [
-                     24.9605,
-                     -31.2855
-                  ],
-                  [
-                     25.0056,
-                     -31.2631
-                  ],
-                  [
-                     25.0585,
-                     -31.2694
-                  ],
-                  [
-                     25.1307,
-                     -31.2394
-                  ],
-                  [
-                     25.1705,
-                     -31.2392
-                  ],
-                  [
-                     25.225,
-                     -31.1952
-                  ],
-                  [
-                     25.3544,
-                     -31.236
-                  ],
-                  [
-                     25.3862,
-                     -31.2178
-                  ],
-                  [
-                     25.3846,
-                     -31.151
-                  ],
-                  [
-                     25.4464,
-                     -31.1002
-                  ],
-                  [
-                     25.4638,
-                     -31.0547
-                  ],
-                  [
-                     25.4868,
-                     -31.0369
-                  ],
-                  [
-                     25.475,
-                     -30.9839
-                  ],
-                  [
-                     25.5109,
-                     -30.9557
-                  ],
-                  [
-                     25.5176,
-                     -30.9034
-                  ],
-                  [
-                     25.4713,
-                     -30.8698
-                  ],
-                  [
-                     25.5216,
-                     -30.8332
-                  ],
-                  [
-                     25.5249,
-                     -30.7964
-                  ],
-                  [
-                     25.4802,
-                     -30.7789
-                  ],
-                  [
-                     25.4565,
-                     -30.637
-                  ],
-                  [
-                     25.4671,
-                     -30.6242
-                  ],
-                  [
-                     25.5563,
-                     -30.6166
-                  ],
-                  [
-                     25.6031,
-                     -30.5944
-                  ],
-                  [
-                     25.6309,
-                     -30.6593
-                  ],
-                  [
-                     25.6716,
-                     -30.6409
-                  ],
-                  [
-                     25.7001,
-                     -30.6795
-                  ],
-                  [
-                     25.7789,
-                     -30.6759
-                  ],
-                  [
-                     25.7998,
-                     -30.6348
-                  ],
-                  [
-                     25.8512,
-                     -30.6293
-                  ],
-                  [
-                     25.8925,
-                     -30.5982
-                  ],
-                  [
-                     25.8748,
-                     -30.5728
-                  ],
-                  [
-                     25.9027,
-                     -30.5428
-                  ],
-                  [
-                     25.9268,
-                     -30.5703
-                  ],
-                  [
-                     25.9731,
-                     -30.5394
-                  ],
-                  [
-                     26.098,
-                     -30.5165
-                  ],
-                  [
-                     26.1626,
-                     -30.4835
-                  ],
-                  [
-                     26.1941,
-                     -30.5038
-                  ],
-                  [
-                     26.1938,
-                     -30.528
-                  ],
-                  [
-                     26.2596,
-                     -30.5407
-                  ],
-                  [
-                     26.2942,
-                     -30.591
-                  ],
-                  [
-                     26.3489,
-                     -30.595
-                  ],
-                  [
-                     26.4252,
-                     -30.5652
-                  ],
-                  [
-                     26.4902,
-                     -30.596
-                  ],
-                  [
-                     26.4812,
-                     -30.6276
-                  ],
-                  [
-                     26.5752,
-                     -30.6668
-                  ],
-                  [
-                     26.6261,
-                     -30.6614
-                  ],
-                  [
-                     26.6295,
-                     -30.6939
-                  ],
-                  [
-                     26.7066,
-                     -30.6857
-                  ],
-                  [
-                     26.7257,
-                     -30.6664
-                  ],
-                  [
-                     26.8141,
-                     -30.6427
-                  ],
-                  [
-                     26.8477,
-                     -30.6839
-                  ],
-                  [
-                     26.943,
-                     -30.6621
-                  ],
-                  [
-                     26.9299,
-                     -30.6272
-                  ],
-                  [
-                     26.9479,
-                     -30.6076
-                  ],
-                  [
-                     27.0427,
-                     -30.5864
-                  ],
-                  [
-                     27.0036,
-                     -30.5383
-                  ],
-                  [
-                     27.0853,
-                     -30.5281
-                  ],
-                  [
-                     27.1053,
-                     -30.5583
-                  ],
-                  [
-                     27.138,
-                     -30.5322
-                  ],
-                  [
-                     27.1885,
-                     -30.5238
-                  ],
-                  [
-                     27.2295,
-                     -30.4992
-                  ],
-                  [
-                     27.2845,
-                     -30.5034
-                  ],
-                  [
-                     27.3284,
-                     -30.4819
-                  ],
-                  [
-                     27.2935,
-                     -30.4568
-                  ],
-                  [
-                     27.3446,
-                     -30.3973
-                  ],
-                  [
-                     27.3769,
-                     -30.4088
-                  ],
-                  [
-                     27.403,
-                     -30.393
-                  ],
-                  [
-                     27.3774,
-                     -30.3271
-                  ],
-                  [
-                     27.4646,
-                     -30.314
-                  ],
-                  [
-                     27.475,
-                     -30.3565
-                  ],
-                  [
-                     27.5069,
-                     -30.3876
-                  ],
-                  [
-                     27.534,
-                     -30.3844
-                  ],
-                  [
-                     27.6044,
-                     -30.4495
-                  ],
-                  [
-                     27.6236,
-                     -30.5062
-                  ],
-                  [
-                     27.6934,
-                     -30.5448
-                  ],
-                  [
-                     27.7419,
-                     -30.6039
-                  ],
-                  [
-                     27.7817,
-                     -30.6173
-                  ],
-                  [
-                     27.8811,
-                     -30.6137
-                  ],
-                  [
-                     27.9184,
-                     -30.6026
-                  ],
-                  [
-                     27.9405,
-                     -30.6441
-                  ],
-                  [
-                     28.0037,
-                     -30.659
-                  ],
-                  [
-                     28.0846,
-                     -30.654
-                  ],
-                  [
-                     28.1232,
-                     -30.6634
-                  ],
-                  [
-                     28.1141,
-                     -30.599
-                  ],
-                  [
-                     28.1507,
-                     -30.5843
-                  ],
-                  [
-                     28.1774,
-                     -30.5224
-                  ],
-                  [
-                     28.1789,
-                     -30.4895
-                  ],
-                  [
-                     28.1556,
-                     -30.4718
-                  ],
-                  [
-                     28.1796,
-                     -30.4389
-                  ],
-                  [
-                     28.2577,
-                     -30.4164
-                  ],
-                  [
-                     28.2688,
-                     -30.3737
-                  ],
-                  [
-                     28.2528,
-                     -30.3233
-                  ],
-                  [
-                     28.2154,
-                     -30.3068
-                  ],
-                  [
-                     28.2364,
-                     -30.2599
-                  ],
-                  [
-                     28.3057,
-                     -30.2551
-                  ],
-                  [
-                     28.3403,
-                     -30.2346
-                  ],
-                  [
-                     28.3651,
-                     -30.1686
-                  ],
-                  [
-                     28.3998,
-                     -30.1437
-                  ],
-                  [
-                     28.4515,
-                     -30.1578
-                  ],
-                  [
-                     28.4998,
-                     -30.151
-                  ],
-                  [
-                     28.5367,
-                     -30.1249
-                  ],
-                  [
-                     28.5682,
-                     -30.1229
-                  ],
-                  [
-                     28.6676,
-                     -30.1407
-                  ],
-                  [
-                     28.6899,
-                     -30.1243
-                  ],
-                  [
-                     28.8588,
-                     -30.0882
-                  ],
-                  [
-                     28.8789,
-                     -30.0698
-                  ],
-                  [
-                     28.9853,
-                     -30.0314
-                  ],
-                  [
-                     29.0147,
-                     -30.0018
-                  ],
-                  [
-                     29.0449,
-                     -30.013
-                  ],
-                  [
-                     29.0901,
-                     -30.0567
-                  ],
-                  [
-                     29.1172,
-                     -30.1002
-                  ],
-                  [
-                     29.1213,
-                     -30.1429
-                  ],
-                  [
-                     29.1037,
-                     -30.1805
-                  ],
-                  [
-                     29.1322,
-                     -30.2164
-                  ],
-                  [
-                     29.1372,
-                     -30.2623
-                  ],
-                  [
-                     29.1881,
-                     -30.2887
-                  ],
-                  [
-                     29.3019,
-                     -30.3201
-                  ],
-                  [
-                     29.2919,
-                     -30.3456
-                  ],
-                  [
-                     29.305,
-                     -30.3799
-                  ],
-                  [
-                     29.2382,
-                     -30.4049
-                  ],
-                  [
-                     29.1968,
-                     -30.4344
-                  ],
-                  [
-                     29.1984,
-                     -30.4623
-                  ],
-                  [
-                     29.1577,
-                     -30.5538
-                  ],
-                  [
-                     29.1153,
-                     -30.5796
-                  ],
-                  [
-                     29.1681,
-                     -30.6131
-                  ],
-                  [
-                     29.2613,
-                     -30.6212
-                  ],
-                  [
-                     29.3225,
-                     -30.6445
-                  ],
-                  [
-                     29.3456,
-                     -30.6717
-                  ],
-                  [
-                     29.3728,
-                     -30.649
-                  ],
-                  [
-                     29.443,
-                     -30.639
-                  ],
-                  [
-                     29.5124,
-                     -30.6182
-                  ],
-                  [
-                     29.5294,
-                     -30.6428
-                  ],
-                  [
-                     29.5722,
-                     -30.6551
-                  ],
-                  [
-                     29.5995,
-                     -30.6895
-                  ],
-                  [
-                     29.6515,
-                     -30.6858
-                  ],
-                  [
-                     29.6754,
-                     -30.6699
-                  ],
-                  [
-                     29.7079,
-                     -30.7048
-                  ],
-                  [
-                     29.7706,
-                     -30.7186
-                  ],
-                  [
-                     29.7782,
-                     -30.6972
-                  ],
-                  [
-                     29.8526,
-                     -30.7616
-                  ],
-                  [
-                     29.9469,
-                     -30.7699
-                  ],
-                  [
-                     29.9326,
-                     -30.8079
-                  ],
-                  [
-                     29.968,
-                     -30.8095
-                  ],
-                  [
-                     29.9748,
-                     -30.8381
-                  ],
-                  [
-                     30.0622,
-                     -30.8481
-                  ],
-                  [
-                     30.0927,
-                     -30.8622
-                  ],
-                  [
-                     30.1464,
-                     -30.9311
-                  ],
-                  [
-                     30.1345,
-                     -30.9638
-                  ],
-                  [
-                     30.1428,
-                     -31.0228
-                  ],
-                  [
-                     30.1939,
-                     -31.0813
-                  ],
-                  [
-                     30.153,
-                     -31.1416
-                  ],
-                  [
-                     30.1231,
-                     -31.1629
-                  ],
-                  [
-                     30.0476,
-                     -31.2476
-                  ],
-                  [
-                     30.0079,
-                     -31.298
-                  ],
-                  [
-                     29.9214,
-                     -31.3709
-                  ],
-                  [
-                     29.9073,
-                     -31.3908
-                  ],
-                  [
-                     29.8345,
-                     -31.4433
-                  ],
-                  [
-                     29.7592,
-                     -31.4524
-                  ],
-                  [
-                     29.6951,
-                     -31.5265
-                  ],
-                  [
-                     29.6338,
-                     -31.5668
-                  ],
-                  [
-                     29.6239,
-                     -31.586
-                  ],
-                  [
-                     29.5491,
-                     -31.628
-                  ],
-                  [
-                     29.5019,
-                     -31.6647
-                  ],
-                  [
-                     29.4223,
-                     -31.6917
-                  ],
-                  [
-                     29.4028,
-                     -31.7342
-                  ],
-                  [
-                     29.3567,
-                     -31.7585
-                  ],
-                  [
-                     29.3463,
-                     -31.8049
-                  ],
-                  [
-                     29.3204,
-                     -31.8105
-                  ],
-                  [
-                     29.2605,
-                     -31.8698
-                  ],
-                  [
-                     29.2145,
-                     -31.9311
-                  ],
-                  [
-                     29.184,
-                     -31.9506
-                  ],
-                  [
-                     29.0934,
-                     -32.0593
-                  ],
-                  [
-                     28.9464,
-                     -32.2048
-                  ],
-                  [
-                     28.8824,
-                     -32.2798
-                  ],
-                  [
-                     28.8317,
-                     -32.3055
-                  ],
-                  [
-                     28.7784,
-                     -32.3494
-                  ],
-                  [
-                     28.657,
-                     -32.4718
-                  ],
-                  [
-                     28.6159,
-                     -32.4926
-                  ],
-                  [
-                     28.5117,
-                     -32.6032
-                  ],
-                  [
-                     28.4315,
-                     -32.6332
-                  ],
-                  [
-                     28.3745,
-                     -32.6904
-                  ],
-                  [
-                     28.3079,
-                     -32.7255
-                  ],
-                  [
-                     28.269,
-                     -32.7589
-                  ],
-                  [
-                     28.1786,
-                     -32.7863
-                  ],
-                  [
-                     28.1176,
-                     -32.8301
-                  ],
-                  [
-                     28.1077,
-                     -32.8735
-                  ],
-                  [
-                     28.0755,
-                     -32.9078
-                  ],
-                  [
-                     28.0345,
-                     -32.9428
-                  ],
-                  [
-                     27.9691,
-                     -32.9737
-                  ],
-                  [
-                     27.9226,
-                     -33.0116
-                  ],
-                  [
-                     27.9197,
-                     -33.0296
-                  ],
-                  [
-                     27.7821,
-                     -33.1026
-                  ],
-                  [
-                     27.728,
-                     -33.1214
-                  ],
-                  [
-                     27.7008,
-                     -33.1525
-                  ],
-                  [
-                     27.6086,
-                     -33.2182
-                  ],
-                  [
-                     27.5295,
-                     -33.2555
-                  ],
-                  [
-                     27.4225,
-                     -33.3337
-                  ],
-                  [
-                     27.3537,
-                     -33.3649
-                  ],
-                  [
-                     27.2106,
-                     -33.4625
-                  ],
-                  [
-                     27.165,
-                     -33.4735
-                  ],
-                  [
-                     27.1356,
-                     -33.4963
-                  ],
-                  [
-                     27.111,
-                     -33.5253
-                  ],
-                  [
-                     27.0679,
-                     -33.5329
-                  ],
-                  [
-                     27.0432,
-                     -33.5535
-                  ],
-                  [
-                     26.9363,
-                     -33.582
-                  ],
-                  [
-                     26.8667,
-                     -33.6263
-                  ],
-                  [
-                     26.7517,
-                     -33.65
-                  ],
-                  [
-                     26.6259,
-                     -33.7191
-                  ],
-                  [
-                     26.5586,
-                     -33.7482
-                  ],
-                  [
-                     26.4684,
-                     -33.7734
-                  ],
-                  [
-                     26.3802,
-                     -33.7594
-                  ],
-                  [
-                     26.3219,
-                     -33.7678
-                  ],
-                  [
-                     26.1883,
-                     -33.7262
-                  ],
-                  [
-                     26.0788,
-                     -33.7068
-                  ],
-                  [
-                     26.0159,
-                     -33.7053
-                  ],
-                  [
-                     25.849,
-                     -33.7225
-                  ]
-               ],
-               [
-                  [
-                     28.6411,
-                     -30.7729
-                  ],
-                  [
-                     28.6412,
-                     -30.7731
-                  ],
-                  [
-                     28.641,
-                     -30.7726
-                  ],
-                  [
-                     28.6411,
-                     -30.7729
-                  ]
-               ]
+              25.849,
+              -33.7225
+            ],
+            [
+              25.7912,
+              -33.7426
+            ],
+            [
+              25.704,
+              -33.7905
+            ],
+            [
+              25.6415,
+              -33.8517
+            ],
+            [
+              25.6134,
+              -33.9189
+            ],
+            [
+              25.6125,
+              -33.9483
+            ],
+            [
+              25.6714,
+              -33.9831
+            ],
+            [
+              25.6971,
+              -34.0321
+            ],
+            [
+              25.6529,
+              -34.028
+            ],
+            [
+              25.6342,
+              -34.0465
+            ],
+            [
+              25.5893,
+              -34.0506
+            ],
+            [
+              25.4522,
+              -34.0309
+            ],
+            [
+              25.3949,
+              -34.0314
+            ],
+            [
+              25.3055,
+              -33.993
+            ],
+            [
+              25.2215,
+              -33.9708
+            ],
+            [
+              25.1537,
+              -33.9628
+            ],
+            [
+              25.0779,
+              -33.9647
+            ],
+            [
+              24.9751,
+              -33.9851
+            ],
+            [
+              24.9368,
+              -34.0055
+            ],
+            [
+              24.9215,
+              -34.0788
+            ],
+            [
+              24.8429,
+              -34.1416
+            ],
+            [
+              24.8273,
+              -34.2112
+            ],
+            [
+              24.7301,
+              -34.1863
+            ],
+            [
+              24.659,
+              -34.1749
+            ],
+            [
+              24.5991,
+              -34.1879
+            ],
+            [
+              24.4754,
+              -34.1619
+            ],
+            [
+              24.3819,
+              -34.1031
+            ],
+            [
+              24.3239,
+              -34.1034
+            ],
+            [
+              24.1936,
+              -34.066
+            ],
+            [
+              24.1133,
+              -34.0592
+            ],
+            [
+              23.9033,
+              -34.0291
+            ],
+            [
+              23.8465,
+              -34.0271
+            ],
+            [
+              23.6529,
+              -33.9896
+            ],
+            [
+              23.6346,
+              -33.9521
+            ],
+            [
+              23.6552,
+              -33.8874
+            ],
+            [
+              23.7033,
+              -33.8641
+            ],
+            [
+              23.5619,
+              -33.8289
+            ],
+            [
+              23.554,
+              -33.7964
+            ],
+            [
+              23.5179,
+              -33.7856
+            ],
+            [
+              23.468,
+              -33.8075
+            ],
+            [
+              23.395,
+              -33.7926
+            ],
+            [
+              23.4301,
+              -33.7618
+            ],
+            [
+              23.4399,
+              -33.7174
+            ],
+            [
+              23.4754,
+              -33.7177
+            ],
+            [
+              23.5413,
+              -33.6995
+            ],
+            [
+              23.5555,
+              -33.673
+            ],
+            [
+              23.6704,
+              -33.6726
+            ],
+            [
+              23.675,
+              -33.6259
+            ],
+            [
+              23.5962,
+              -33.5725
+            ],
+            [
+              23.604,
+              -33.4964
+            ],
+            [
+              23.5142,
+              -33.4627
+            ],
+            [
+              23.4956,
+              -33.4434
+            ],
+            [
+              23.3549,
+              -33.4412
+            ],
+            [
+              23.2971,
+              -33.3886
+            ],
+            [
+              23.1348,
+              -33.3876
+            ],
+            [
+              22.9348,
+              -33.4291
+            ],
+            [
+              22.8303,
+              -33.4191
+            ],
+            [
+              22.7744,
+              -33.4197
+            ],
+            [
+              22.7357,
+              -33.3948
+            ],
+            [
+              22.7393,
+              -33.324
+            ],
+            [
+              22.7734,
+              -33.3263
+            ],
+            [
+              22.8402,
+              -33.2202
+            ],
+            [
+              22.8772,
+              -33.1869
+            ],
+            [
+              22.8923,
+              -33.1416
+            ],
+            [
+              22.9553,
+              -33.0731
+            ],
+            [
+              22.9578,
+              -33.0451
+            ],
+            [
+              22.9352,
+              -33.013
+            ],
+            [
+              22.9693,
+              -32.9934
+            ],
+            [
+              22.9488,
+              -32.95
+            ],
+            [
+              23.0037,
+              -32.8983
+            ],
+            [
+              23.0074,
+              -32.8728
+            ],
+            [
+              23.098,
+              -32.8737
+            ],
+            [
+              23.1164,
+              -32.858
+            ],
+            [
+              23.0894,
+              -32.7992
+            ],
+            [
+              23.1493,
+              -32.7667
+            ],
+            [
+              23.2011,
+              -32.7854
+            ],
+            [
+              23.2504,
+              -32.7886
+            ],
+            [
+              23.3052,
+              -32.8095
+            ],
+            [
+              23.3786,
+              -32.825
+            ],
+            [
+              23.3977,
+              -32.7635
+            ],
+            [
+              23.3516,
+              -32.7638
+            ],
+            [
+              23.3535,
+              -32.7294
+            ],
+            [
+              23.3329,
+              -32.7036
+            ],
+            [
+              23.2696,
+              -32.6715
+            ],
+            [
+              23.3013,
+              -32.6518
+            ],
+            [
+              23.3073,
+              -32.6116
+            ],
+            [
+              23.2882,
+              -32.5512
+            ],
+            [
+              23.2445,
+              -32.5132
+            ],
+            [
+              23.2475,
+              -32.4653
+            ],
+            [
+              23.2216,
+              -32.425
+            ],
+            [
+              23.3073,
+              -32.3959
+            ],
+            [
+              23.3331,
+              -32.3511
+            ],
+            [
+              23.4099,
+              -32.3892
+            ],
+            [
+              23.449,
+              -32.3233
+            ],
+            [
+              23.5918,
+              -32.3408
+            ],
+            [
+              23.6651,
+              -32.3442
+            ],
+            [
+              23.6489,
+              -32.298
+            ],
+            [
+              23.6705,
+              -32.2377
+            ],
+            [
+              23.7471,
+              -32.2007
+            ],
+            [
+              23.7662,
+              -32.1787
+            ],
+            [
+              23.7979,
+              -32.1941
+            ],
+            [
+              23.8511,
+              -32.2425
+            ],
+            [
+              23.8923,
+              -32.2549
+            ],
+            [
+              23.9611,
+              -32.2065
+            ],
+            [
+              24.0305,
+              -32.1935
+            ],
+            [
+              24.038,
+              -32.1581
+            ],
+            [
+              24.1001,
+              -32.164
+            ],
+            [
+              24.1355,
+              -32.1231
+            ],
+            [
+              24.1097,
+              -32.0843
+            ],
+            [
+              24.1409,
+              -32.0117
+            ],
+            [
+              24.183,
+              -31.9959
+            ],
+            [
+              24.2224,
+              -31.9556
+            ],
+            [
+              24.1642,
+              -31.9024
+            ],
+            [
+              24.1054,
+              -31.9069
+            ],
+            [
+              24.1238,
+              -31.8472
+            ],
+            [
+              24.1533,
+              -31.8549
+            ],
+            [
+              24.1525,
+              -31.7886
+            ],
+            [
+              24.1616,
+              -31.7401
+            ],
+            [
+              24.2258,
+              -31.7475
+            ],
+            [
+              24.2683,
+              -31.7667
+            ],
+            [
+              24.314,
+              -31.7513
+            ],
+            [
+              24.346,
+              -31.7145
+            ],
+            [
+              24.5063,
+              -31.7068
+            ],
+            [
+              24.523,
+              -31.6037
+            ],
+            [
+              24.5039,
+              -31.5684
+            ],
+            [
+              24.533,
+              -31.5098
+            ],
+            [
+              24.5589,
+              -31.4818
+            ],
+            [
+              24.5672,
+              -31.4186
+            ],
+            [
+              24.5961,
+              -31.3992
+            ],
+            [
+              24.665,
+              -31.3837
+            ],
+            [
+              24.7048,
+              -31.4006
+            ],
+            [
+              24.7887,
+              -31.3895
+            ],
+            [
+              24.853,
+              -31.3282
+            ],
+            [
+              24.942,
+              -31.3151
+            ],
+            [
+              24.9605,
+              -31.2855
+            ],
+            [
+              25.0056,
+              -31.2631
+            ],
+            [
+              25.0585,
+              -31.2694
+            ],
+            [
+              25.1307,
+              -31.2394
+            ],
+            [
+              25.1705,
+              -31.2392
+            ],
+            [
+              25.225,
+              -31.1952
+            ],
+            [
+              25.3544,
+              -31.236
+            ],
+            [
+              25.3862,
+              -31.2178
+            ],
+            [
+              25.3846,
+              -31.151
+            ],
+            [
+              25.4464,
+              -31.1002
+            ],
+            [
+              25.4638,
+              -31.0547
+            ],
+            [
+              25.4868,
+              -31.0369
+            ],
+            [
+              25.475,
+              -30.9839
+            ],
+            [
+              25.5109,
+              -30.9557
+            ],
+            [
+              25.5176,
+              -30.9034
+            ],
+            [
+              25.4713,
+              -30.8698
+            ],
+            [
+              25.5216,
+              -30.8332
+            ],
+            [
+              25.5249,
+              -30.7964
+            ],
+            [
+              25.4802,
+              -30.7789
+            ],
+            [
+              25.4565,
+              -30.637
+            ],
+            [
+              25.4671,
+              -30.6242
+            ],
+            [
+              25.5563,
+              -30.6166
+            ],
+            [
+              25.6031,
+              -30.5944
+            ],
+            [
+              25.6309,
+              -30.6593
+            ],
+            [
+              25.6716,
+              -30.6409
+            ],
+            [
+              25.7001,
+              -30.6795
+            ],
+            [
+              25.7789,
+              -30.6759
+            ],
+            [
+              25.7998,
+              -30.6348
+            ],
+            [
+              25.8512,
+              -30.6293
+            ],
+            [
+              25.8925,
+              -30.5982
+            ],
+            [
+              25.8748,
+              -30.5728
+            ],
+            [
+              25.9027,
+              -30.5428
+            ],
+            [
+              25.9268,
+              -30.5703
+            ],
+            [
+              25.9731,
+              -30.5394
+            ],
+            [
+              26.098,
+              -30.5165
+            ],
+            [
+              26.1626,
+              -30.4835
+            ],
+            [
+              26.1941,
+              -30.5038
+            ],
+            [
+              26.1938,
+              -30.528
+            ],
+            [
+              26.2596,
+              -30.5407
+            ],
+            [
+              26.2942,
+              -30.591
+            ],
+            [
+              26.3489,
+              -30.595
+            ],
+            [
+              26.4252,
+              -30.5652
+            ],
+            [
+              26.4902,
+              -30.596
+            ],
+            [
+              26.4812,
+              -30.6276
+            ],
+            [
+              26.5752,
+              -30.6668
+            ],
+            [
+              26.6261,
+              -30.6614
+            ],
+            [
+              26.6295,
+              -30.6939
+            ],
+            [
+              26.7066,
+              -30.6857
+            ],
+            [
+              26.7257,
+              -30.6664
+            ],
+            [
+              26.8141,
+              -30.6427
+            ],
+            [
+              26.8477,
+              -30.6839
+            ],
+            [
+              26.943,
+              -30.6621
+            ],
+            [
+              26.9299,
+              -30.6272
+            ],
+            [
+              26.9479,
+              -30.6076
+            ],
+            [
+              27.0427,
+              -30.5864
+            ],
+            [
+              27.0036,
+              -30.5383
+            ],
+            [
+              27.0853,
+              -30.5281
+            ],
+            [
+              27.1053,
+              -30.5583
+            ],
+            [
+              27.138,
+              -30.5322
+            ],
+            [
+              27.1885,
+              -30.5238
+            ],
+            [
+              27.2295,
+              -30.4992
+            ],
+            [
+              27.2845,
+              -30.5034
+            ],
+            [
+              27.3284,
+              -30.4819
+            ],
+            [
+              27.2935,
+              -30.4568
+            ],
+            [
+              27.3446,
+              -30.3973
+            ],
+            [
+              27.3769,
+              -30.4088
+            ],
+            [
+              27.403,
+              -30.393
+            ],
+            [
+              27.3774,
+              -30.3271
+            ],
+            [
+              27.4646,
+              -30.314
+            ],
+            [
+              27.475,
+              -30.3565
+            ],
+            [
+              27.5069,
+              -30.3876
+            ],
+            [
+              27.534,
+              -30.3844
+            ],
+            [
+              27.6044,
+              -30.4495
+            ],
+            [
+              27.6236,
+              -30.5062
+            ],
+            [
+              27.6934,
+              -30.5448
+            ],
+            [
+              27.7419,
+              -30.6039
+            ],
+            [
+              27.7817,
+              -30.6173
+            ],
+            [
+              27.8811,
+              -30.6137
+            ],
+            [
+              27.9184,
+              -30.6026
+            ],
+            [
+              27.9405,
+              -30.6441
+            ],
+            [
+              28.0037,
+              -30.659
+            ],
+            [
+              28.0846,
+              -30.654
+            ],
+            [
+              28.1232,
+              -30.6634
+            ],
+            [
+              28.1141,
+              -30.599
+            ],
+            [
+              28.1507,
+              -30.5843
+            ],
+            [
+              28.1774,
+              -30.5224
+            ],
+            [
+              28.1789,
+              -30.4895
+            ],
+            [
+              28.1556,
+              -30.4718
+            ],
+            [
+              28.1796,
+              -30.4389
+            ],
+            [
+              28.2577,
+              -30.4164
+            ],
+            [
+              28.2688,
+              -30.3737
+            ],
+            [
+              28.2528,
+              -30.3233
+            ],
+            [
+              28.2154,
+              -30.3068
+            ],
+            [
+              28.2364,
+              -30.2599
+            ],
+            [
+              28.3057,
+              -30.2551
+            ],
+            [
+              28.3403,
+              -30.2346
+            ],
+            [
+              28.3651,
+              -30.1686
+            ],
+            [
+              28.3998,
+              -30.1437
+            ],
+            [
+              28.4515,
+              -30.1578
+            ],
+            [
+              28.4998,
+              -30.151
+            ],
+            [
+              28.5367,
+              -30.1249
+            ],
+            [
+              28.5682,
+              -30.1229
+            ],
+            [
+              28.6676,
+              -30.1407
+            ],
+            [
+              28.6899,
+              -30.1243
+            ],
+            [
+              28.8588,
+              -30.0882
+            ],
+            [
+              28.8789,
+              -30.0698
+            ],
+            [
+              28.9853,
+              -30.0314
+            ],
+            [
+              29.0147,
+              -30.0018
+            ],
+            [
+              29.0449,
+              -30.013
+            ],
+            [
+              29.0901,
+              -30.0567
+            ],
+            [
+              29.1172,
+              -30.1002
+            ],
+            [
+              29.1213,
+              -30.1429
+            ],
+            [
+              29.1037,
+              -30.1805
+            ],
+            [
+              29.1322,
+              -30.2164
+            ],
+            [
+              29.1372,
+              -30.2623
+            ],
+            [
+              29.1881,
+              -30.2887
+            ],
+            [
+              29.3019,
+              -30.3201
+            ],
+            [
+              29.2919,
+              -30.3456
+            ],
+            [
+              29.305,
+              -30.3799
+            ],
+            [
+              29.2382,
+              -30.4049
+            ],
+            [
+              29.1968,
+              -30.4344
+            ],
+            [
+              29.1984,
+              -30.4623
+            ],
+            [
+              29.1577,
+              -30.5538
+            ],
+            [
+              29.1153,
+              -30.5796
+            ],
+            [
+              29.1681,
+              -30.6131
+            ],
+            [
+              29.2613,
+              -30.6212
+            ],
+            [
+              29.3225,
+              -30.6445
+            ],
+            [
+              29.3456,
+              -30.6717
+            ],
+            [
+              29.3728,
+              -30.649
+            ],
+            [
+              29.443,
+              -30.639
+            ],
+            [
+              29.5124,
+              -30.6182
+            ],
+            [
+              29.5294,
+              -30.6428
+            ],
+            [
+              29.5722,
+              -30.6551
+            ],
+            [
+              29.5995,
+              -30.6895
+            ],
+            [
+              29.6515,
+              -30.6858
+            ],
+            [
+              29.6754,
+              -30.6699
+            ],
+            [
+              29.7079,
+              -30.7048
+            ],
+            [
+              29.7706,
+              -30.7186
+            ],
+            [
+              29.7782,
+              -30.6972
+            ],
+            [
+              29.8526,
+              -30.7616
+            ],
+            [
+              29.9469,
+              -30.7699
+            ],
+            [
+              29.9326,
+              -30.8079
+            ],
+            [
+              29.968,
+              -30.8095
+            ],
+            [
+              29.9748,
+              -30.8381
+            ],
+            [
+              30.0622,
+              -30.8481
+            ],
+            [
+              30.0927,
+              -30.8622
+            ],
+            [
+              30.1464,
+              -30.9311
+            ],
+            [
+              30.1345,
+              -30.9638
+            ],
+            [
+              30.1428,
+              -31.0228
+            ],
+            [
+              30.1939,
+              -31.0813
+            ],
+            [
+              30.153,
+              -31.1416
+            ],
+            [
+              30.1231,
+              -31.1629
+            ],
+            [
+              30.0476,
+              -31.2476
+            ],
+            [
+              30.0079,
+              -31.298
+            ],
+            [
+              29.9214,
+              -31.3709
+            ],
+            [
+              29.9073,
+              -31.3908
+            ],
+            [
+              29.8345,
+              -31.4433
+            ],
+            [
+              29.7592,
+              -31.4524
+            ],
+            [
+              29.6951,
+              -31.5265
+            ],
+            [
+              29.6338,
+              -31.5668
+            ],
+            [
+              29.6239,
+              -31.586
+            ],
+            [
+              29.5491,
+              -31.628
+            ],
+            [
+              29.5019,
+              -31.6647
+            ],
+            [
+              29.4223,
+              -31.6917
+            ],
+            [
+              29.4028,
+              -31.7342
+            ],
+            [
+              29.3567,
+              -31.7585
+            ],
+            [
+              29.3463,
+              -31.8049
+            ],
+            [
+              29.3204,
+              -31.8105
+            ],
+            [
+              29.2605,
+              -31.8698
+            ],
+            [
+              29.2145,
+              -31.9311
+            ],
+            [
+              29.184,
+              -31.9506
+            ],
+            [
+              29.0934,
+              -32.0593
+            ],
+            [
+              28.9464,
+              -32.2048
+            ],
+            [
+              28.8824,
+              -32.2798
+            ],
+            [
+              28.8317,
+              -32.3055
+            ],
+            [
+              28.7784,
+              -32.3494
+            ],
+            [
+              28.657,
+              -32.4718
+            ],
+            [
+              28.6159,
+              -32.4926
+            ],
+            [
+              28.5117,
+              -32.6032
+            ],
+            [
+              28.4315,
+              -32.6332
+            ],
+            [
+              28.3745,
+              -32.6904
+            ],
+            [
+              28.3079,
+              -32.7255
+            ],
+            [
+              28.269,
+              -32.7589
+            ],
+            [
+              28.1786,
+              -32.7863
+            ],
+            [
+              28.1176,
+              -32.8301
+            ],
+            [
+              28.1077,
+              -32.8735
+            ],
+            [
+              28.0755,
+              -32.9078
+            ],
+            [
+              28.0345,
+              -32.9428
+            ],
+            [
+              27.9691,
+              -32.9737
+            ],
+            [
+              27.9226,
+              -33.0116
+            ],
+            [
+              27.9197,
+              -33.0296
+            ],
+            [
+              27.7821,
+              -33.1026
+            ],
+            [
+              27.728,
+              -33.1214
+            ],
+            [
+              27.7008,
+              -33.1525
+            ],
+            [
+              27.6086,
+              -33.2182
+            ],
+            [
+              27.5295,
+              -33.2555
+            ],
+            [
+              27.4225,
+              -33.3337
+            ],
+            [
+              27.3537,
+              -33.3649
+            ],
+            [
+              27.2106,
+              -33.4625
+            ],
+            [
+              27.165,
+              -33.4735
+            ],
+            [
+              27.1356,
+              -33.4963
+            ],
+            [
+              27.111,
+              -33.5253
+            ],
+            [
+              27.0679,
+              -33.5329
+            ],
+            [
+              27.0432,
+              -33.5535
+            ],
+            [
+              26.9363,
+              -33.582
+            ],
+            [
+              26.8667,
+              -33.6263
+            ],
+            [
+              26.7517,
+              -33.65
+            ],
+            [
+              26.6259,
+              -33.7191
+            ],
+            [
+              26.5586,
+              -33.7482
+            ],
+            [
+              26.4684,
+              -33.7734
+            ],
+            [
+              26.3802,
+              -33.7594
+            ],
+            [
+              26.3219,
+              -33.7678
+            ],
+            [
+              26.1883,
+              -33.7262
+            ],
+            [
+              26.0788,
+              -33.7068
+            ],
+            [
+              26.0159,
+              -33.7053
+            ],
+            [
+              25.849,
+              -33.7225
             ]
-         ]
-      },
-      "properties":{
-         "code":"ZA",
-         "name":"South Africa",
-         "area":1220813161319.17,
-         "parent":null,
-         "level":"country",
-         "version":"2011 Boundaries"
-      }
-   },
-   "children":{
-
-   },
-   "parent_layers":[
-
-   ],
-   "themes":[
-      {
-         "name":"Higher Education",
-         "id":53,
-         "icon":"account_balance",
-         "order":10,
-         "subthemes":[
-            {
-               "label":"TVET colleges",
-               "id":379,
-               "count":292,
-               "color":"",
-               "order":81,
-               "metadata":{
-                  "source":"",
-                  "description":"Voluptatem dolorem eius voluptatem dolore dolorem numquam numquam. Dolor est ut non. Est porro voluptatem dolore. Numquam quaerat magnam dolor. Quaerat tempora dolore quisquam.",
-                  "licence":null
-               }
-            },
-            {
-               "label":"Universities of technology",
-               "id":380,
-               "count":28,
-               "color":"",
-               "order":82,
-               "metadata":{
-                  "source":"",
-                  "description":"Ut adipisci adipisci neque consectetur porro. Amet etincidunt quaerat dolor sed porro. Neque consectetur neque modi amet modi. Tempora neque aliquam etincidunt. Tempora amet ut dolor. Quaerat aliquam magnam sit dolor. Sed tempora amet dolor est. Non ipsum modi quaerat eius.",
-                  "licence":null
-               }
-            },
-            {
-               "label":"Universities",
-               "id":382,
-               "count":69,
-               "color":"",
-               "order":84,
-               "metadata":{
-                  "source":"",
-                  "description":"Dolore sit etincidunt eius adipisci voluptatem. Quaerat adipisci voluptatem sed non consectetur. Neque modi labore quaerat magnam. Ipsum amet sed etincidunt dolorem sed magnam numquam. Dolor consectetur dolor adipisci sit sit magnam sed. Modi non quaerat dolore modi dolor neque.",
-                  "licence":null
-               }
-            },
-            {
-               "label":"phone test",
-               "id":569,
-               "count":12,
-               "color":"",
-               "order":188,
-               "metadata":{
-                  "source":"",
-                  "description":"",
-                  "licence":null
-               }
-            }
-         ]
-      },
-      {
-         "name":"Labour",
-         "id":7,
-         "icon":"work",
-         "order":14,
-         "subthemes":[
-            {
-               "label":"Additional DEL facilities (unverified)",
-               "id":394,
-               "count":34,
-               "color":"",
-               "order":51,
-               "metadata":{
-                  "source":"",
-                  "description":"Neque amet non quiquia dolorem aliquam. Labore dolor dolor labore. Dolor sit etincidunt sed neque magnam non porro. Quaerat modi voluptatem etincidunt. Eius dolore tempora dolorem etincidunt modi porro dolore. Quaerat dolorem sed quiquia non aliquam. Etincidunt dolor amet ipsum quiquia modi porro. Porro dolorem sit magnam. Neque consectetur neque sit sed sit magnam velit.",
-                  "licence":null
-               }
-            },
-            {
-               "label":"Thusong centres (unverified)",
-               "id":384,
-               "count":140,
-               "color":"",
-               "order":86,
-               "metadata":{
-                  "source":"",
-                  "description":"Neque eius porro tempora etincidunt magnam etincidunt. Velit dolor dolorem etincidunt eius quiquia magnam quisquam. Ut sit dolor dolor. Quaerat sed amet eius est velit amet neque. Ut est dolore labore dolor tempora. Porro etincidunt quisquam etincidunt dolorem dolorem magnam. Est quisquam adipisci modi non tempora. Est amet velit quaerat. Sed ipsum neque labore non. Dolor tempora numquam consectetur velit neque.",
-                  "licence":null
-               }
-            },
-            {
-               "label":"Labour centres",
-               "id":566,
-               "count":124,
-               "color":"",
-               "order":186,
-               "metadata":{
-                  "source":"",
-                  "description":"",
-                  "licence":null
-               }
-            }
-         ]
-      },
-      {
-         "name":"Social",
-         "id":4,
-         "icon":"people",
-         "order":15,
-         "subthemes":[
-            {
-               "label":"Libraries (unverified)",
-               "id":383,
-               "count":1567,
-               "color":"",
-               "order":85,
-               "metadata":{
-                  "source":"",
-                  "description":"Velit ipsum non neque quaerat. Etincidunt ipsum velit modi aliquam. Porro non sit consectetur dolorem tempora ut. Ipsum quaerat ut velit quaerat etincidunt. Sit porro aliquam magnam voluptatem quisquam neque. Quisquam adipisci dolor dolor. Amet eius voluptatem ut. Quiquia etincidunt est dolore numquam sed est. Dolorem magnam magnam dolorem non ut.",
-                  "licence":null
-               }
-            },
-            {
-               "label":"NYDA centres",
-               "id":406,
-               "count":38,
-               "color":"",
-               "order":88,
-               "metadata":{
-                  "source":"",
-                  "description":"Dolor modi amet consectetur. Aliquam est tempora ipsum sed dolore. Consectetur magnam numquam numquam dolorem amet. Voluptatem numquam velit consectetur neque. Tempora aliquam non ut. Quisquam numquam numquam tempora.",
-                  "licence":null
-               }
-            },
-            {
-               "label":"eKasiLabs",
-               "id":408,
-               "count":10,
-               "color":"",
-               "order":90,
-               "metadata":{
-                  "source":"",
-                  "description":"Tempora consectetur quaerat ipsum consectetur tempora. Adipisci labore quaerat labore dolor sit. Sit amet porro labore dolorem. Modi eius dolor sit dolor non ipsum. Voluptatem modi amet adipisci amet adipisci ut amet. Quaerat sit ut dolorem quiquia eius neque. Eius neque dolore consectetur sed eius quisquam.",
-                  "licence":null
-               }
-            },
-            {
-               "label":"Youth Cafés",
-               "id":567,
-               "count":12,
-               "color":"",
-               "order":187,
-               "metadata":{
-                  "source":"",
-                  "description":"Est quisquam aliquam velit amet amet amet. Sit porro labore est neque sed non. Neque consectetur quiquia sit non aliquam sit est. Magnam porro aliquam quisquam. Amet neque aliquam velit modi numquam.",
-                  "licence":null
-               }
-            }
-         ]
-      },
-      {
-         "name":"Health",
-         "id":43,
-         "icon":"local_hospital",
-         "order":19,
-         "subthemes":[
-            {
-               "label":"Public health facilities",
-               "id":375,
-               "count":4650,
-               "color":"",
-               "order":77,
-               "metadata":{
-                  "source":"Info4Africa",
-                  "description":"Quaerat tempora porro voluptatem labore numquam etincidunt. Numquam non modi porro amet porro. Ut ut magnam sit. Eius adipisci etincidunt quiquia. Ipsum ipsum amet labore. Ipsum magnam quaerat dolorem numquam voluptatem quisquam tempora. Numquam sit sed aliquam amet sit tempora amet.",
-                  "licence":null
-               }
-            }
-         ]
-      },
-      {
-         "name":"Transport",
-         "id":44,
-         "icon":"directions_transit",
-         "order":20,
-         "subthemes":[
-            {
-               "label":"MyCiti Bus Stops",
-               "id":301,
-               "count":504,
-               "color":"",
-               "order":46,
-               "metadata":{
-                  "source":null,
-                  "description":null,
-                  "licence":null
-               }
-            },
-            {
-               "label":"Municipal Traffic Departments",
-               "id":306,
-               "count":40,
-               "color":"",
-               "order":73,
-               "metadata":{
-                  "source":null,
-                  "description":null,
-                  "licence":null
-               }
-            }
-         ]
-      },
-      {
-         "name":"Police",
-         "id":45,
-         "icon":"security",
-         "order":21,
-         "subthemes":[
-            {
-               "label":"Police Stations",
-               "id":311,
-               "count":1152,
-               "color":"",
-               "order":56,
-               "metadata":{
-                  "source":"SAPS",
-                  "description":"Dolor magnam tempora non porro neque. Non aliquam sed ut eius. Voluptatem etincidunt tempora tempora non dolore sit. Dolor voluptatem ipsum quisquam non. Etincidunt dolore quiquia eius. Dolore quisquam sit velit neque modi.",
-                  "licence":null
-               }
-            }
-         ]
-      },
-      {
-         "name":"Post Offices",
-         "id":46,
-         "icon":"markunread_mailbox",
-         "order":23,
-         "subthemes":[
-            {
-               "label":"Post Offices",
-               "id":313,
-               "count":1502,
-               "color":"",
-               "order":57,
-               "metadata":{
-                  "source":"GIS, South African Social Security Agency (SASSA)",
-                  "description":"Gazetted SASSA pay points and Post Office Service points (obtained from SAPO)",
-                  "licence":null
-               }
-            }
-         ]
-      },
-      {
-         "name":"Basic Education",
-         "id":52,
-         "icon":"school",
-         "order":32,
-         "subthemes":[
-            {
-               "label":"Public Schools",
-               "id":325,
-               "count":23089,
-               "color":"",
-               "order":9,
-               "metadata":{
-                  "source":"Dept of Basic Education, 2020",
-                  "description":"Est etincidunt adipisci ipsum porro modi sed est. Etincidunt consectetur modi amet numquam. Sit eius magnam aliquam neque tempora ut magnam. Quiquia porro modi sed voluptatem sit numquam. Amet ut ipsum ut sit. Dolorem neque ut tempora dolor neque etincidunt sed. Labore eius modi est.",
-                  "licence":null
-               }
-            },
-            {
-               "label":"Independent Schools",
-               "id":326,
-               "count":1952,
-               "color":"",
-               "order":11,
-               "metadata":{
-                  "source":"Dept of Basic Education, 2020",
-                  "description":"Dolore modi numquam magnam sit ipsum numquam quisquam. Labore eius aliquam tempora amet etincidunt ipsum. Velit sed adipisci quisquam numquam etincidunt. Consectetur velit numquam etincidunt etincidunt. Voluptatem labore dolorem eius non amet sed.",
-                  "licence":null
-               }
-            }
-         ]
-      }
-   ]
+          ],
+          [
+            [
+              28.6411,
+              -30.7729
+            ],
+            [
+              28.6412,
+              -30.7731
+            ],
+            [
+              28.641,
+              -30.7726
+            ],
+            [
+              28.6411,
+              -30.7729
+            ]
+          ]
+        ]
+      ]
+    },
+    "properties": {
+      "code": "ZA",
+      "name": "South Africa",
+      "area": 1220813161319.17,
+      "parent": null,
+      "level": "country",
+      "version": "2011 Boundaries"
+    }
+  },
+  "children": {},
+  "parent_layers": [],
+  "themes": [
+    {
+      "name": "Higher Education",
+      "id": 53,
+      "icon": "account_balance",
+      "order": 10,
+      "subthemes": [
+        {
+          "label": "TVET colleges",
+          "id": 379,
+          "count": 292,
+          "color": "",
+          "order": 81,
+          "metadata": {
+            "source": "",
+            "description": "Voluptatem dolorem eius voluptatem dolore dolorem numquam numquam. Dolor est ut non. Est porro voluptatem dolore. Numquam quaerat magnam dolor. Quaerat tempora dolore quisquam.",
+            "licence": null
+          }
+        },
+        {
+          "label": "Universities of technology",
+          "id": 380,
+          "count": 28,
+          "color": "",
+          "order": 82,
+          "metadata": {
+            "source": "",
+            "description": "Ut adipisci adipisci neque consectetur porro. Amet etincidunt quaerat dolor sed porro. Neque consectetur neque modi amet modi. Tempora neque aliquam etincidunt. Tempora amet ut dolor. Quaerat aliquam magnam sit dolor. Sed tempora amet dolor est. Non ipsum modi quaerat eius.",
+            "licence": null
+          }
+        },
+        {
+          "label": "Universities",
+          "id": 382,
+          "count": 69,
+          "color": "",
+          "order": 84,
+          "metadata": {
+            "source": "",
+            "description": "Dolore sit etincidunt eius adipisci voluptatem. Quaerat adipisci voluptatem sed non consectetur. Neque modi labore quaerat magnam. Ipsum amet sed etincidunt dolorem sed magnam numquam. Dolor consectetur dolor adipisci sit sit magnam sed. Modi non quaerat dolore modi dolor neque.",
+            "licence": null
+          }
+        },
+        {
+          "label": "phone test",
+          "id": 569,
+          "count": 12,
+          "color": "",
+          "order": 188,
+          "metadata": {
+            "source": "",
+            "description": "",
+            "licence": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "Labour",
+      "id": 7,
+      "icon": "work",
+      "order": 14,
+      "subthemes": [
+        {
+          "label": "Additional DEL facilities (unverified)",
+          "id": 394,
+          "count": 34,
+          "color": "",
+          "order": 51,
+          "metadata": {
+            "source": "",
+            "description": "Neque amet non quiquia dolorem aliquam. Labore dolor dolor labore. Dolor sit etincidunt sed neque magnam non porro. Quaerat modi voluptatem etincidunt. Eius dolore tempora dolorem etincidunt modi porro dolore. Quaerat dolorem sed quiquia non aliquam. Etincidunt dolor amet ipsum quiquia modi porro. Porro dolorem sit magnam. Neque consectetur neque sit sed sit magnam velit.",
+            "licence": null
+          }
+        },
+        {
+          "label": "Thusong centres (unverified)",
+          "id": 384,
+          "count": 140,
+          "color": "",
+          "order": 86,
+          "metadata": {
+            "source": "",
+            "description": "Neque eius porro tempora etincidunt magnam etincidunt. Velit dolor dolorem etincidunt eius quiquia magnam quisquam. Ut sit dolor dolor. Quaerat sed amet eius est velit amet neque. Ut est dolore labore dolor tempora. Porro etincidunt quisquam etincidunt dolorem dolorem magnam. Est quisquam adipisci modi non tempora. Est amet velit quaerat. Sed ipsum neque labore non. Dolor tempora numquam consectetur velit neque.",
+            "licence": null
+          }
+        },
+        {
+          "label": "Labour centres",
+          "id": 566,
+          "count": 124,
+          "color": "",
+          "order": 186,
+          "metadata": {
+            "source": "",
+            "description": "",
+            "licence": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "Social",
+      "id": 4,
+      "icon": "people",
+      "order": 15,
+      "subthemes": [
+        {
+          "label": "Libraries (unverified)",
+          "id": 383,
+          "count": 1567,
+          "color": "",
+          "order": 85,
+          "metadata": {
+            "source": "",
+            "description": "Velit ipsum non neque quaerat. Etincidunt ipsum velit modi aliquam. Porro non sit consectetur dolorem tempora ut. Ipsum quaerat ut velit quaerat etincidunt. Sit porro aliquam magnam voluptatem quisquam neque. Quisquam adipisci dolor dolor. Amet eius voluptatem ut. Quiquia etincidunt est dolore numquam sed est. Dolorem magnam magnam dolorem non ut.",
+            "licence": null
+          }
+        },
+        {
+          "label": "NYDA centres",
+          "id": 406,
+          "count": 38,
+          "color": "",
+          "order": 88,
+          "metadata": {
+            "source": "",
+            "description": "Dolor modi amet consectetur. Aliquam est tempora ipsum sed dolore. Consectetur magnam numquam numquam dolorem amet. Voluptatem numquam velit consectetur neque. Tempora aliquam non ut. Quisquam numquam numquam tempora.",
+            "licence": null
+          }
+        },
+        {
+          "label": "eKasiLabs",
+          "id": 408,
+          "count": 10,
+          "color": "",
+          "order": 90,
+          "metadata": {
+            "source": "",
+            "description": "Tempora consectetur quaerat ipsum consectetur tempora. Adipisci labore quaerat labore dolor sit. Sit amet porro labore dolorem. Modi eius dolor sit dolor non ipsum. Voluptatem modi amet adipisci amet adipisci ut amet. Quaerat sit ut dolorem quiquia eius neque. Eius neque dolore consectetur sed eius quisquam.",
+            "licence": null
+          }
+        },
+        {
+          "label": "Youth Cafés",
+          "id": 567,
+          "count": 12,
+          "color": "",
+          "order": 187,
+          "metadata": {
+            "source": "",
+            "description": "Est quisquam aliquam velit amet amet amet. Sit porro labore est neque sed non. Neque consectetur quiquia sit non aliquam sit est. Magnam porro aliquam quisquam. Amet neque aliquam velit modi numquam.",
+            "licence": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "Health",
+      "id": 43,
+      "icon": "local_hospital",
+      "order": 19,
+      "subthemes": [
+        {
+          "label": "Public health facilities",
+          "id": 375,
+          "count": 4650,
+          "color": "",
+          "order": 77,
+          "metadata": {
+            "source": "Info4Africa",
+            "description": "Quaerat tempora porro voluptatem labore numquam etincidunt. Numquam non modi porro amet porro. Ut ut magnam sit. Eius adipisci etincidunt quiquia. Ipsum ipsum amet labore. Ipsum magnam quaerat dolorem numquam voluptatem quisquam tempora. Numquam sit sed aliquam amet sit tempora amet.",
+            "licence": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "Transport",
+      "id": 44,
+      "icon": "directions_transit",
+      "order": 20,
+      "subthemes": [
+        {
+          "label": "MyCiti Bus Stops",
+          "id": 301,
+          "count": 504,
+          "color": "",
+          "order": 46,
+          "metadata": {
+            "source": null,
+            "description": null,
+            "licence": null
+          }
+        },
+        {
+          "label": "Municipal Traffic Departments",
+          "id": 306,
+          "count": 40,
+          "color": "",
+          "order": 73,
+          "metadata": {
+            "source": null,
+            "description": null,
+            "licence": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "Police",
+      "id": 45,
+      "icon": "security",
+      "order": 21,
+      "subthemes": [
+        {
+          "label": "Police Stations",
+          "id": 311,
+          "count": 1152,
+          "color": "",
+          "order": 56,
+          "metadata": {
+            "source": "SAPS",
+            "description": "Dolor magnam tempora non porro neque. Non aliquam sed ut eius. Voluptatem etincidunt tempora tempora non dolore sit. Dolor voluptatem ipsum quisquam non. Etincidunt dolore quiquia eius. Dolore quisquam sit velit neque modi.",
+            "licence": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "Post Offices",
+      "id": 46,
+      "icon": "markunread_mailbox",
+      "order": 23,
+      "subthemes": [
+        {
+          "label": "Post Offices",
+          "id": 313,
+          "count": 1502,
+          "color": "",
+          "order": 57,
+          "metadata": {
+            "source": "GIS, South African Social Security Agency (SASSA)",
+            "description": "Gazetted SASSA pay points and Post Office Service points (obtained from SAPO)",
+            "licence": null
+          }
+        }
+      ]
+    },
+    {
+      "name": "Basic Education",
+      "id": 52,
+      "icon": "school",
+      "order": 32,
+      "subthemes": [
+        {
+          "label": "Public Schools",
+          "id": 325,
+          "count": 23089,
+          "color": "",
+          "order": 9,
+          "metadata": {
+            "source": "Dept of Basic Education, 2020",
+            "description": "Est etincidunt adipisci ipsum porro modi sed est. Etincidunt consectetur modi amet numquam. Sit eius magnam aliquam neque tempora ut magnam. Quiquia porro modi sed voluptatem sit numquam. Amet ut ipsum ut sit. Dolorem neque ut tempora dolor neque etincidunt sed. Labore eius modi est.",
+            "licence": null
+          }
+        },
+        {
+          "label": "Independent Schools",
+          "id": 326,
+          "count": 1952,
+          "color": "",
+          "order": 11,
+          "metadata": {
+            "source": "Dept of Basic Education, 2020",
+            "description": "Dolore modi numquam magnam sit ipsum numquam quisquam. Labore eius aliquam tempora amet etincidunt ipsum. Velit sed adipisci quisquam numquam etincidunt. Consectetur velit numquam etincidunt etincidunt. Voluptatem labore dolorem eius non amet sed.",
+            "licence": null
+          }
+        }
+      ]
+    }
+  ]
 }

--- a/__tests__/gui/rich_data/all_details.json
+++ b/__tests__/gui/rich_data/all_details.json
@@ -3033,6 +3033,10 @@
       "Test Category 3": {
         "description": "",
         "subcategories": {
+          "Subcategory with no indicators": {
+            "description": "",
+            "indicators": {}
+          },
           "Subcategory with indicators": {
             "description": "",
             "indicators": {
@@ -3181,10 +3185,6 @@
                 }
               }
             }
-          },
-          "Subcategory with no indicators": {
-            "description": "",
-            "indicators": {}
           }
         }
       },
@@ -3195,10 +3195,6 @@
       "Category with no indicators": {
         "description": "",
         "subcategories": {
-          "Subcategory with indicators": {
-            "description": "",
-            "indicators": {}
-          },
           "Subcategory with no indicators": {
             "description": "",
             "indicators": {}

--- a/__tests__/gui/rich_data/rich_data.js
+++ b/__tests__/gui/rich_data/rich_data.js
@@ -58,3 +58,16 @@ When('I close the Rich Data', () => {
 Then('I check if the indicator with only zero counts is hidden', () => {
     cy.get('.profile-indicator__title:contains("Indicator with only zero counts")').should('not.exist');
 })
+
+Then(/^I confirm that the category "([^"]*)" is invisible$/, function (categoryName) {
+    cy.get(`.category-header h2:contains(${categoryName})`).should('not.be.visible');
+    cy.get(`.rich-data-nav__item:contains(${categoryName})`).should('not.exist');
+});
+
+Then(/^I confirm that the subcategory "([^"]*)" is invisible$/, function (categoryName) {
+    cy.get(`.sub-category-header h3:contains(${categoryName})`).should('not.be.visible');
+});
+
+Then(/^I confirm that the subcategory "([^"]*)" is visible$/, function (categoryName) {
+    cy.get(`.sub-category-header h3:contains(${categoryName})`).should('be.visible');
+});

--- a/src/js/profile/category.js
+++ b/src/js/profile/category.js
@@ -110,13 +110,13 @@ export class Category extends Component {
     }
 
     loadSubcategories = (wrapper, detail) => {
-        let index = 0;
+        let isFirst = true;
         for (const [subcategory, detail] of Object.entries(detail.subcategories)) {
-            let isFirst = index === 0;
             let sc = new Subcategory(this, this.formattingConfig, wrapper, subcategory, detail, isFirst, this.geography, this.profileConfig);
             sc.isVisible = sc.indicators.length > 0;
             if (sc.isVisible) {
                 this.subCategories.push(sc);
+                isFirst = false;    //set to false only when there is a visible item
             }
 
             this.bubbleEvents(sc, [
@@ -124,7 +124,6 @@ export class Category extends Component {
                 'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
                 'point_tray.subindicator_filter.filter'
             ]);
-            index++;
         }
     }
 }

--- a/src/js/profile/category.js
+++ b/src/js/profile/category.js
@@ -25,10 +25,39 @@ export class Category extends Component {
         this.formattingConfig = formattingConfig;
         this.geography = geography;
         this.profileConfig = profileConfig;
+        this._subCategories = [];
+        this._isVisible = true;
+        this._uiElements = [];
 
         this.prepareDomElements();
         this.prepareEvents();
         this.addCategory(category, detail, isFirst);
+    }
+
+    get subCategories() {
+        return this._subCategories;
+    }
+
+    get isVisible() {
+        return this._isVisible;
+    }
+
+    set isVisible(value) {
+        if (value) {
+            this.uiElements.forEach((ele) => {
+                $(ele).show();
+            })
+        } else {
+            this.uiElements.forEach((ele) => {
+                $(ele).hide();
+            })
+        }
+
+        this._isVisible = value;
+    }
+
+    get uiElements() {
+        return this._uiElements;
     }
 
     prepareDomElements = () => {
@@ -68,6 +97,8 @@ export class Category extends Component {
 
         this.loadSubcategories(newCategorySection, detail);
 
+        this.uiElements.push(newCategorySection);
+
         profileWrapper.append(newCategorySection);
     }
 
@@ -80,11 +111,14 @@ export class Category extends Component {
 
     loadSubcategories = (wrapper, detail) => {
         let index = 0;
-        let lastIndex = Object.entries(detail.subcategories).length - 1;
         for (const [subcategory, detail] of Object.entries(detail.subcategories)) {
-            let hasChildren = checkIfSubCategoryHasChildren(subcategory, detail);
             let isFirst = index === 0;
             let sc = new Subcategory(this, this.formattingConfig, wrapper, subcategory, detail, isFirst, this.geography, this.profileConfig);
+            sc.isVisible = sc.indicators.length > 0;
+            if (sc.isVisible) {
+                this.subCategories.push(sc);
+            }
+
             this.bubbleEvents(sc, [
                 'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
                 'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',

--- a/src/js/profile/profile_loader.js
+++ b/src/js/profile/profile_loader.js
@@ -70,8 +70,11 @@ export default class ProfileLoader extends Component {
         this.createNavItem('top', 'Summary');
         for (const [category, detail] of Object.entries(categories)) {
             const id = this.getNewId();
-            this.createNavItem(id, category);
-            let c = new Category(this, this.formattingConfig, category, detail, profileWrapper, id, removePrevCategories, isFirst, profile.geography, this.config)
+            let c = new Category(this, this.formattingConfig, category, detail, profileWrapper, id, removePrevCategories, isFirst, profile.geography, this.config);
+            c.isVisible = c.subCategories.length > 0;
+            if (c.isVisible) {
+                this.createNavItem(id, category);
+            }
             isFirst = false;
             this.bubbleEvents(c, [
                 'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',

--- a/src/js/profile/profile_loader.js
+++ b/src/js/profile/profile_loader.js
@@ -74,8 +74,8 @@ export default class ProfileLoader extends Component {
             c.isVisible = c.subCategories.length > 0;
             if (c.isVisible) {
                 this.createNavItem(id, category);
+                isFirst = false;    //set to false only when there is a visible item
             }
-            isFirst = false;
             this.bubbleEvents(c, [
                 'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
                 'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',

--- a/src/js/profile/subcategory.js
+++ b/src/js/profile/subcategory.js
@@ -26,6 +26,8 @@ export class Subcategory extends Component {
         this._formattingConfig = formattingConfig;
         this._geography = geography;
         this._profileConfig = profileConfig;
+        this._isVisible = true;
+        this._uiElements = [];
 
         this.addSubCategoryHeaders(wrapper, subcategory, detail, isFirst);
         this.addIndicators(wrapper, detail);
@@ -51,6 +53,28 @@ export class Subcategory extends Component {
         return this._geography;
     }
 
+    get isVisible() {
+        return this._isVisible;
+    }
+
+    set isVisible(value) {
+        if (value) {
+            this.uiElements.forEach((ele) => {
+                $(ele).show();
+            })
+        } else {
+            this.uiElements.forEach((ele) => {
+                $(ele).hide();
+            })
+        }
+
+        this._isVisible = value;
+    }
+
+    get uiElements() {
+        return this._uiElements;
+    }
+
     addSubCategoryHeaders = (wrapper, subcategory, detail, isFirst) => {
         let scHeader = scHeaderClone.cloneNode(true);
 
@@ -71,6 +95,8 @@ export class Subcategory extends Component {
         } else {
             $(descriptionClass, scHeader).removeClass('hidden');
         }
+
+        this.uiElements.push(scHeader);
 
         wrapper.append(scHeader);
     }

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -41,10 +41,10 @@ export function getJSON(url, skipCache = true) {
         req.open('GET', url);
 
         req.onload = () => {
-            if (req.status == 200) {
+            if (req.status === 200) {
                 const json = JSON.parse(req.response);
                 resolve(json);
-            } else if (req.status == 401 || request.status == 403) {
+            } else if (req.status === 401 || request.status === 403) {
                 alert("Not logged in")
             } else {
                 reject(Error(req.statusText));


### PR DESCRIPTION
## Description
hiding empty categories & sub-categories

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-263

## How is it tested automatically?
* added test steps into `__tests__/gui/rich_data.feature`

## How should a reviewer test it locally
* find a category or a subcategory that does not have any indicators.
* hint : when you go down to lowest level e.g. ward/main place you can often find categories or subcategories without any data
* confirm that categories & subcategories without indicators are not displayed 
* confirm that the categories without indicators are not listed in the left hand-side nav menu

## Screenshots
before : 
![image](https://user-images.githubusercontent.com/53019884/182375897-74406232-843d-494d-91d4-53b50925c70f.png)

after : 
![image](https://user-images.githubusercontent.com/53019884/182375996-37aa7efe-091f-4efa-8db8-fea6f6324a17.png)


## Changelog

### Added

### Updated
* `src/js/profile/profile_loader.js`, `src/js/profile/category.js`, `src/js/profile/subcategory.js` to hide empty categories & subcategories

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
