### PR TITLE
Sticky indicator filters for rich data view and mapchip

### DIFF
--- a/src/js/controller.js
+++ b/src/js/controller.js
@@ -15,6 +15,7 @@ export default class Controller extends Component {
             // Set if a choropleth is currently active
             // TODO this state should possibly be stored in the mapcontrol
             subindicator: null,
+            indicatorFilters: {},
             selectedSubindicator: ''
         }
 
@@ -129,7 +130,9 @@ export default class Controller extends Component {
             data: payload.indicatorData,
             indicatorId: payload.indicatorId,
             config: payload.config,
-            metadata: payload.metadata
+            metadata: payload.metadata,
+            indicatorId: payload.indicatorId,
+            filter: this.state.indicatorFilters[payload.indicatorId] || {},
         }
 
         this.state.subindicator = subindicator;
@@ -148,6 +151,13 @@ export default class Controller extends Component {
         this.state.subindicator = subindicator;
 
         this.triggerEvent("mapchip.choropleth.filtered", payload);
+    }
+
+    setPersistantIndicatorFilters(payload) {
+      let indicatorFilters = this.state.indicatorFilters;
+      const subindicator = this.state.subindicator;
+      indicatorFilters[subindicator.indicatorId] = payload.selectedFilter;
+      this.state.indicatorFilters = indicatorFilters
     }
 
     onSelectingSubindicator(payload) {

--- a/src/js/elements/mapchip/components/filter_label.js
+++ b/src/js/elements/mapchip/components/filter_label.js
@@ -96,17 +96,12 @@ export class FilterLabel extends Component {
         this._filterHeaderLabelContainer.removeClass("notification-badges");
     }
 
-    compareFilters(defaultFilters, oldFilters) {
-        let flattenFilterObject = {};
-        defaultFilters.forEach((item, idx) => {
-            flattenFilterObject[item.name] = item.value;
-        });
-
-        const showBadge = this.isEqualsJson(flattenFilterObject, oldFilters);
+    compareFilters(previouslySelectedFilters, oldFilters) {
+        const showBadge = this.isEqualsJson(previouslySelectedFilters, oldFilters);
         if (!showBadge) {
             this.showNotificationBadge();
             this.showSnackbar();
-            if (defaultFilters.length === 0) {
+            if (previouslySelectedFilters.length === 0) {
                 this.parent.appliedFilters = {};
             }
         }

--- a/src/js/elements/mapchip/mapchip.js
+++ b/src/js/elements/mapchip/mapchip.js
@@ -282,8 +282,8 @@ export class MapChip extends Component {
     }
 
     setFilterLabel(dataFilterModel, groups) {
-        const defaultFilters = dataFilterModel.configFilters?.defaults || [];
-        this.filterLabel.compareFilters(defaultFilters, this.appliedFilters);
+        const previouslySelectedFilters = dataFilterModel.previouslySelectedFilters || {};
+        this.filterLabel.compareFilters(previouslySelectedFilters, this.appliedFilters);
         this.filterLabel.setFilterLabelTotalCount(groups);
         this.filterLabel.setFilterLabelSelectedCount({});
         this.filterLabel.setFilterLabelContainerVisibility(!this.isContentVisible);

--- a/src/js/elements/mapchip/mapchip.js
+++ b/src/js/elements/mapchip/mapchip.js
@@ -282,11 +282,21 @@ export class MapChip extends Component {
     }
 
     setFilterLabel(dataFilterModel, groups) {
-        const previouslySelectedFilters = dataFilterModel.previouslySelectedFilters || {};
-        this.filterLabel.compareFilters(previouslySelectedFilters, this.appliedFilters);
+        const selectedFilters = dataFilterModel.previouslySelectedFilters;
+        const defaultFilters = dataFilterModel?.configFilters?.defaults;
+        if (defaultFilters){
+          defaultFilters.forEach(item => {
+            if (selectedFilters[item.name] === undefined){
+              selectedFilters[item.name] = item.value
+            }
+          });
+        }
+
+        this.filterLabel.compareFilters(this.appliedFilters, selectedFilters);
         this.filterLabel.setFilterLabelTotalCount(groups);
         this.filterLabel.setFilterLabelSelectedCount({});
         this.filterLabel.setFilterLabelContainerVisibility(!this.isContentVisible);
+        this.appliedFilters = selectedFilters
     }
 
     setDescriptionIcon(description) {

--- a/src/js/elements/subindicator_filter/filter_controller.js
+++ b/src/js/elements/subindicator_filter/filter_controller.js
@@ -239,6 +239,18 @@ export class FilterController extends Component {
         filterRow.setSecondaryIndexUsingValue(group.value);
     }
 
+    addPreviouslySelectedFilters(group) {
+        let isDefault = true;
+        let isExtra = false;
+        let isRequired = true;
+
+        let filterRow = this.addEmptyFilter(isDefault, isExtra, isRequired);
+        // filterRow.indicatorDropdown.disable();
+
+        filterRow.setPrimaryIndexUsingValue(group.group);
+        filterRow.setSecondaryIndexUsingValue(group.value);
+    }
+
     setAddFilterButton() { // TODO write an unselected filters getter in the data model
         if (this.model.dataFilterModel.availableFilters.length > 0)
             this.addFilterButton.enable();
@@ -302,6 +314,7 @@ export class FilterController extends Component {
 
         this.checkAndAddNonAggregatableGroups();
         this.checkAndAddDefaultFilterGroups();
+        this.checkAndAddPreviouslySelectedFilters();
         this.setFilterVisibility();
         this.addInitialFilterRow(dataFilterModel);
     }
@@ -313,6 +326,10 @@ export class FilterController extends Component {
                 fr.updateIndicatorDropdowns(fr.model, lastIndex);
             }
         })
+    }
+
+    updateDefaultFilterValues(group) {
+      console.log(group);
     }
 
     checkAndAddNonAggregatableGroups() {
@@ -340,7 +357,18 @@ export class FilterController extends Component {
 
     checkAndAddPreviouslySelectedFilters() {
         const self = this;
-        let previouslySelectedFilters = this.model.dataFilterModel.previouslySelectedFilters;
+        let previouslySelectedFilters = this.model.dataFilterModel.previouslySelectedFilterGroups;
+        let defaultGroups = this.model.dataFilterModel.defaultFilterGroups;
+        previouslySelectedFilters.forEach(group => {
+            if (group.group != this.model.dataFilterModel.primaryGroup) {
+              if (defaultGroups.some(x => x.group === group.group)){
+                self.updateDefaultFilterValues(group);
+              } else {
+                self.addPreviouslySelectedFilters(group);
+              }
+
+            }
+        })
     }
 
     toggleContentVisibility() {

--- a/src/js/models/data_filter_model.js
+++ b/src/js/models/data_filter_model.js
@@ -110,6 +110,21 @@ export class DataFilterModel extends Observable {
         return defaultFilterGroups;
     }
 
+    get previouslySelectedFilterGroups() {
+        let previouslySelectedFilterGroups = [];
+        if (typeof this.previouslySelectedFilters !== 'undefined') {
+            Object.entries(this.previouslySelectedFilters).forEach(
+              ([key, val]) => {
+                    previouslySelectedFilterGroups.push({
+                        group: key,
+                        value: val
+                    });
+                }
+            );
+        }
+        return previouslySelectedFilterGroups;
+    }
+
     get selectedFilters() {
         return this._selectedFilters;
     }

--- a/src/js/profile/blocks/indicator.js
+++ b/src/js/profile/blocks/indicator.js
@@ -11,6 +11,11 @@ export class Indicator extends ContentBlock {
         this.addIndicatorChart();
     }
 
+    get previouslySelectedFilters() {
+      let indicatorFilters = this.parent.indicatorFilters;
+      return indicatorFilters[this.indicator.id] || {};
+    }
+
     get hasData() {
         return this.indicator.data.some(function (e) {
             return e.count > 0
@@ -30,7 +35,7 @@ export class Indicator extends ContentBlock {
         this.bubbleEvents(c, [
             'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
             'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
-            'point_tray.subindicator_filter.filter'
+            'point_tray.subindicator_filter.filter', 'profile.chart.updateSelectedIndicatorFilters'
         ]);
     }
 

--- a/src/js/profile/category.js
+++ b/src/js/profile/category.js
@@ -35,6 +35,10 @@ export class Category extends Component {
         this.addCategory(category, detail, isFirst);
     }
 
+    get indicatorFilters() {
+      return this.parent.indicatorFilters;
+    }
+
     get subCategories() {
         return this._subCategories;
     }
@@ -125,7 +129,7 @@ export class Category extends Component {
             this.bubbleEvents(sc, [
                 'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
                 'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
-                'point_tray.subindicator_filter.filter'
+                'point_tray.subindicator_filter.filter', 'profile.chart.updateSelectedIndicatorFilters',
             ]);
         }
     }

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -80,6 +80,10 @@ export class Chart extends Component {
         this.addChart(data);
     }
 
+    get previouslySelectedFilters() {
+      return this.parent.previouslySelectedFilters;
+    }
+
     get chartType() {
         const type = this.data.chart_type;
         if (type === chartTypes.LineChart) {
@@ -431,7 +435,7 @@ export class Chart extends Component {
     };
 
     handleChartFilter = (indicators, groups) => {
-        let dataFilterModel = new DataFilterModel(groups, this.data.chartConfiguration.filter, [], indicators.metadata.primary_group, {});
+        let dataFilterModel = new DataFilterModel(groups, this.data.chartConfiguration.filter, this.previouslySelectedFilters, indicators.metadata.primary_group, {});
         if (this._filterController.filterCallback === null) {
             this._filterController.filterCallback = this.applyFilter;
         }
@@ -459,6 +463,11 @@ export class Chart extends Component {
         this.vegaView.run();
         this.appendDataToTable();
         this.setDownloadUrl();
+        this.triggerEvent('profile.chart.updateSelectedIndicatorFilters', {
+          indicatorId: this.data.id,
+          selectedFilter: selectedFilter
+        });
+
     };
 
     exportAsCsv = () => {

--- a/src/js/profile/profile_loader.js
+++ b/src/js/profile/profile_loader.js
@@ -17,12 +17,18 @@ let profileWrapper = null;
 export default class ProfileLoader extends Component {
     constructor(parent, formattingConfig, _api, _profileId, _config) {
         super(parent);
-
+        this.state = {
+          indicatorFilters: {}
+        }
         this.api = _api;
         this.profileId = _profileId;
         this.formattingConfig = formattingConfig;
         this.config = _config;
         this.profileHeader = null;
+    }
+
+    get indicatorFilters() {
+      return this.state.indicatorFilters;
     }
 
     loadProfile = (dataBundle, activeVersion) => {
@@ -82,7 +88,7 @@ export default class ProfileLoader extends Component {
             this.bubbleEvents(c, [
                 'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
                 'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
-                'point_tray.subindicator_filter.filter'
+                'point_tray.subindicator_filter.filter', 'profile.chart.updateSelectedIndicatorFilters',
             ]);
 
             removePrevCategories = false;
@@ -150,5 +156,10 @@ export default class ProfileLoader extends Component {
 
     updateActiveVersion = (activeVersion) => {
         this.triggerEvent('version.updated', activeVersion);
+    }
+
+    updateSelectedIndicatorFilters = (payload) => {
+      let filters = this.state.indicatorFilters;
+      filters[payload.indicatorId] = payload.selectedFilter;
     }
 }

--- a/src/js/profile/subcategory.js
+++ b/src/js/profile/subcategory.js
@@ -21,7 +21,6 @@ const indicatorClass = '.styles .profile-indicator';
 export class Subcategory extends Component {
     constructor(parent, formattingConfig, wrapper, subcategory, detail, isFirst, geography, profileConfig) {
         super(parent);
-
         scHeaderClone = $(subcategoryHeaderClass)[0].cloneNode(true);
         this._indicators = [];
         this._formattingConfig = formattingConfig;
@@ -40,6 +39,10 @@ export class Subcategory extends Component {
         this.parent.on('version.updated', (activeVersion) => {
             this.triggerEvent('version.updated', activeVersion);
         });
+    }
+
+    get indicatorFilters() {
+      return this.parent.indicatorFilters;
     }
 
     get indicators() {
@@ -107,7 +110,7 @@ export class Subcategory extends Component {
         this.bubbleEvents(block, [
             'profile.chart.saveAsPng', 'profile.chart.valueTypeChanged',
             'profile.chart.download_csv', 'profile.chart.download_excel', 'profile.chart.download_json', 'profile.chart.download_kml',
-            'point_tray.subindicator_filter.filter'
+            'point_tray.subindicator_filter.filter', 'profile.chart.updateSelectedIndicatorFilters',
         ]);
 
         return block;

--- a/src/js/setup/choropleth.js
+++ b/src/js/setup/choropleth.js
@@ -9,6 +9,7 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
 
     mapchip.on('mapchip.choropleth.filtered', payload => {
         controller.onChoroplethFiltered(payload);
+        controller.setPersistantIndicatorFilters(payload);
     })
 
     mapchip.on('mapchip.choropleth.selectSubindicator', payload => {
@@ -57,7 +58,7 @@ export function configureChoroplethEvents(controller, objs = {mapcontrol: null, 
             indicatorTitle: args.payload.indicatorTitle,
             selectedSubindicator: args.payload.selectedSubindicator,
             childData: args.payload.data,
-            filter: args.payload.filter,
+            filter: args.state.subindicator.filter,
             config: args.payload.config,
             method: args.state.subindicator.choropleth_method,
             currentGeo: args.state.profile.geometries.boundary.properties.name

--- a/src/js/setup/profile.js
+++ b/src/js/setup/profile.js
@@ -25,5 +25,6 @@ export function configureProfileEvents(controller, objs = {profileLoader: null})
         profileLoader.profileHeader.facilityController.isLoading = true;
         profileLoader.profileHeader.facilityController.getAndAddFacilities(controller.versionController.activeVersion);
     });
-}
 
+    profileLoader.on('profile.chart.updateSelectedIndicatorFilters', payload => profileLoader.updateSelectedIndicatorFilters(payload));
+}


### PR DESCRIPTION
## Description
Sticky indicator options.
* Options selected in mapchip or rich data view should stay there unless user refresh or manually change the selection of filters.

## Related Issue
* https://wazimap.atlassian.net/browse/WNCM-598

## How is it tested automatically?

## How should a reviewer test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
