### PR TITLE
fixed the bug that hides new filter button

### DIFF
--- a/__tests__/gui/sharing.feature
+++ b/__tests__/gui/sharing.feature
@@ -6,30 +6,33 @@ Feature: Sharing url
 
     When I expand Data Mapper
     And I click on "Demographics" in Data Mapper
-    And I click on "Migration" in Data Mapper
-    And I click on "Region of birth" in Data Mapper
-    And I click on "Male" in Data Mapper
+    And I click on "Language" in Data Mapper
+    And I click on "Language most spoken at home" in Data Mapper
+    And I click on "15-19" in Data Mapper
     And I expand the filter dialog
 
-    And I select "30-35" from subIndicator dropdown in filter dialog on row "0"
-    When I select "language" from indicator dropdown in filter dialog on row "1"
+    When I select "gender" from indicator dropdown in filter dialog on row "0"
+    And I select "Male" from subIndicator dropdown in filter dialog on row "0"
+    And I add new filter
+    And I select "language" from indicator dropdown in filter dialog on row "1"
     And I select "English" from subIndicator dropdown in filter dialog on row "1"
     Then I visit current url
     Then I wait until map is ready
 
     When I expand Data Mapper
     And I click on "Demographics" in Data Mapper
-    And I click on "Migration" in Data Mapper
-    And I click on "Region of birth" in Data Mapper
-    And I click on "Male" in Data Mapper
+    And I click on "Language" in Data Mapper
+    And I click on "Language most spoken at home" in Data Mapper
+    And I click on "15-19" in Data Mapper
     And I expand the filter dialog
-    Then I confirm that the choropleth is filtered by "age:30-35" at index 0
+    Then I confirm that the choropleth is filtered by "gender:Male" at index 0
     Then I confirm that the choropleth is filtered by "language:English" at index 1
+    Then I confirm that the add new filter button exists
 
     When I expand My View Window
     And I click on "INDICATOR OPTIONS" in My View
-    Then I confirm that there is an indicator filter for "Data mapper:Region of birth:age:30-35" at index 0
-    Then I confirm that there is an indicator filter for "Data mapper:Region of birth:language:English" at index 1
+    Then I confirm that there is an indicator filter for "Data mapper:Language most spoken at home:gender:Male" at index 0
+    Then I confirm that there is an indicator filter for "Data mapper:Language most spoken at home:language:English" at index 1
     Then I collapse My View Window
     Then I remove filter from mapchip
     And I expand Rich Data Panel
@@ -41,20 +44,20 @@ Feature: Sharing url
 
     When I expand Data Mapper
     And I click on "Demographics" in Data Mapper
-    And I click on "Migration" in Data Mapper
-    And I click on "Region of birth" in Data Mapper
-    And I click on "Male" in Data Mapper
+    And I click on "Language" in Data Mapper
+    And I click on "Language most spoken at home" in Data Mapper
+    And I click on "15-19" in Data Mapper
     And I expand the filter dialog
-    Then I confirm that the choropleth is filtered by "age:30-35" at index 0
+    Then I confirm that the choropleth is filtered by "gender:Male" at index 0
     And I expand Rich Data Panel
     Then I confirm that the chart is filtered by "language:Afrikaans" at index 0
     And I collapse Rich Data Panel
 
     When I expand My View Window
     And I click on "INDICATOR OPTIONS" in My View
-    Then I confirm that there is an indicator filter for "Data mapper:Region of birth:age:30-35" at index 0
-    Then I confirm that there is an indicator filter for "Rich data view:Language most spoken at home:language:Afrikaans" at index 1
-    And I remove the indicator filter at index 0
+    Then I confirm that there is an indicator filter for "Data mapper:Language most spoken at home:gender:Male" at index 1
+    Then I confirm that there is an indicator filter for "Rich data view:Language most spoken at home:language:Afrikaans" at index 0
+    And I remove the indicator filter at index 1
     Then I visit current url
     Then I wait until map is ready
 

--- a/__tests__/gui/sharing/profile_indicator_summary.json
+++ b/__tests__/gui/sharing/profile_indicator_summary.json
@@ -35,7 +35,7 @@
                   ],
                   "dataset": 241,
                   "name": "age",
-                  "can_aggregate": false,
+                  "can_aggregate": true,
                   "can_filter": true
                 },
                 {
@@ -66,19 +66,6 @@
                   ],
                   "dataset": 241,
                   "name": "language",
-                  "can_aggregate": true,
-                  "can_filter": true
-                },
-                {
-                  "subindicators": [
-                    "Black African",
-                    "Coloured",
-                    "White",
-                    "Other",
-                    "Indian or Asian"
-                  ],
-                  "dataset": 241,
-                  "name": "race",
                   "can_aggregate": true,
                   "can_filter": true
                 }
@@ -169,19 +156,6 @@
                   ],
                   "dataset": 241,
                   "name": "language",
-                  "can_aggregate": true,
-                  "can_filter": true
-                },
-                {
-                  "subindicators": [
-                    "Black African",
-                    "Coloured",
-                    "White",
-                    "Other",
-                    "Indian or Asian"
-                  ],
-                  "dataset": 241,
-                  "name": "race",
                   "can_aggregate": true,
                   "can_filter": true
                 }

--- a/__tests__/gui/sharing/sharing.js
+++ b/__tests__/gui/sharing/sharing.js
@@ -74,9 +74,9 @@ When(/^I select "([^"]*)" from subIndicator dropdown in chart filter/, function 
     selectChartDropdownOption(word, 1);
 });
 
-When("I remove filter from mapchip", function (){
-  cy.get(`${mapBottomItems} .map-options .map-options__filter-row:visible:eq(1)`).should('have.length', 1);
-  cy.get(`${mapBottomItems} .map-options .map-options__filter-row:visible:eq(1) .mapping-options__remove-filter:visible`).click();
+When("I remove filter from mapchip", function () {
+    cy.get(`${mapBottomItems} .map-options .map-options__filter-row:visible:eq(1)`).should('have.length', 1);
+    cy.get(`${mapBottomItems} .map-options .map-options__filter-row:visible:eq(1) .mapping-options__remove-filter:visible`).click();
 });
 
 Then(/^I confirm that the choropleth is filtered by "([^"]*)" at index (\d+)$/, function (filter, index) {
@@ -96,9 +96,9 @@ Then(/^I confirm that the choropleth is filtered by "([^"]*)" at index (\d+)$/, 
 });
 
 Then("I visit current url", () => {
-  cy.url().then(($url) => {
-    cy.visit($url);
-  });
+    cy.url().then(($url) => {
+        cy.visit($url);
+    });
 });
 
 When('I expand My View Window', () => {
@@ -151,12 +151,12 @@ When('I expand Rich Data Panel', () => {
 });
 
 Then(/^I confirm that the chart is not filtered$/, function () {
-  cy.get('.rich-data-content .profile-indicator__filter-row:visible:eq(0)').should('have.length', 1);
-  cy.get('.rich-data-content .profile-indicator__filter-row:visible:eq(0) .profile-indicator__filter')
-      .eq(0)
-      .find(' .dropdown-menu__selected-item .truncate')
-      .should('have.text', 'Select an attribute');
-  cy.get('.rich-data-content .profile-indicator__filter-row:visible:eq(0) .profile-indicator__filter').eq(1).should('have.class', 'disabled');
+    cy.get('.rich-data-content .profile-indicator__filter-row:visible:eq(0)').should('have.length', 1);
+    cy.get('.rich-data-content .profile-indicator__filter-row:visible:eq(0) .profile-indicator__filter')
+        .eq(0)
+        .find(' .dropdown-menu__selected-item .truncate')
+        .should('have.text', 'Select an attribute');
+    cy.get('.rich-data-content .profile-indicator__filter-row:visible:eq(0) .profile-indicator__filter').eq(1).should('have.class', 'disabled');
 });
 
 Then(/^I confirm that the chart is filtered by "([^"]*)" at index (\d+)$/, function (filter, index) {
@@ -180,11 +180,11 @@ When('I collapse Rich Data Panel', () => {
 })
 
 When("I go back in browser history", () => {
-  cy.go("back");
+    cy.go("back");
 });
 
 When("I go forward in browser history", () => {
-  cy.go("forward");
+    cy.go("forward");
 });
 
 When('I collapse Data Mapper', () => {
@@ -223,12 +223,12 @@ When('I navigate to WC', () => {
     })
 
     cy.intercept('/api/v1/profile/8/geography/WC/indicator/**/child_data/', (request) => {
-      let tempObj = JSON.parse(JSON.stringify(profile_indicator_data_WC));
-      request.reply({
-          statusCode: 200,
-          body: tempObj,
-          forceNetworkError: false // default
-      });
+        let tempObj = JSON.parse(JSON.stringify(profile_indicator_data_WC));
+        request.reply({
+            statusCode: 200,
+            body: tempObj,
+            forceNetworkError: false // default
+        });
     })
 
     cy.visit('/#geo:WC');
@@ -239,5 +239,13 @@ Then('I wait until map is ready for Western Cape', () => {
 })
 
 When('I go back to root geography', () => {
-  cy.get('.map-location .location-tag .location-tag__name:contains("South Africa Test")', {timeout: 20000}).click({force: true});
+    cy.get('.map-location .location-tag .location-tag__name:contains("South Africa Test")', {timeout: 20000}).click({force: true});
+})
+
+Then('I add new filter', () => {
+    cy.get(`${mapBottomItems} .map-options .mapping-options__add-filter`).click();
+})
+
+Then('I confirm that the add new filter button exists', () => {
+    cy.get(`${mapBottomItems} .map-options .mapping-options__add-filter`).should('be.visible');
 })

--- a/src/js/elements/subindicator_filter/filter_controller.js
+++ b/src/js/elements/subindicator_filter/filter_controller.js
@@ -175,8 +175,9 @@ export class FilterController extends Component {
     shouldFiltersBeVisible() {
         const nonAggregatableGroups = this.model.dataFilterModel.nonAggregatableGroups;
         const defaultGroups = this.model.dataFilterModel.defaultFilterGroups;
+        const previouslySelectedFilterGroups = this.model.dataFilterModel.previouslySelectedFilterGroups;
 
-        if (nonAggregatableGroups.length <= 0 && defaultGroups.length <= 0 && this.model.dataFilterModel.availableFilters.length <= 0) {
+        if (nonAggregatableGroups.length <= 0 && defaultGroups.length <= 0 && previouslySelectedFilterGroups.length <= 0 && this.model.dataFilterModel.availableFilters.length <= 0) {
             return false;
         } else {
             return true;


### PR DESCRIPTION
## Description
bug : 
add new filter button was not visible when 
* there are no default filters
* there are no non-aggregatable columns
* all the available filters are set as indicator-specific option

added a condition to make sure the add new filter is still visible 

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-675

## How is it tested automatically?
updated `__tests__/gui/sharing.feature`

## How should a reviewer test it locally
watch the video in the Jira card

## Screenshots


## Changelog

### Added

### Updated
* `src/js/elements/subindicator_filter/filter_controller.js` to make sure the button is visible

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
