### PR TITLE
Fixing the automated tests failing when query strings are used instead of fragment

### DIFF
--- a/__tests__/gui/common_cy_functions/general.js
+++ b/__tests__/gui/common_cy_functions/general.js
@@ -5,6 +5,30 @@ export const mapBottomItems = '.map-bottom-items--v2';
 export const allDetailsEndpoint = 'all_details';
 const recursiveResult = {PANEL_ALREADY_EXPANDED: false, ALL_PANELS_CLOSED: true};
 
+const geoCoordinates = {
+  "EC": {
+    lat: -32.033241,
+    lng: 26.838765,
+  },
+  "WC": {
+    lat: -33.571055,
+    lng: 19.868258,
+  },
+  "FS": {
+    lat: -28.886856,
+    lng: 26.202557,
+  },
+  "NC": {
+    lat: -29.719176,
+    lng: 21.283331,
+  },
+  "CPT": {
+    lat: -33.978895,
+    lng: 18.529666,
+  }
+}
+
+
 export function setupInterceptions(profiles, all_details, profile, themes, points, themes_count = [],
                                    profile_indicator_summary = {}, indicator_data = {}, categories_data = []) {
 
@@ -89,6 +113,22 @@ export function setupInterceptionsForSpecificGeo(geoCode, all_details) {
             forceNetworkError: false // default
         })
     }).as('all_details')
+}
+
+export function visitToGeo(geoCode) {
+  const coords = geoCoordinates[geoCode];
+  let L;
+  cy.window().then((win) => {
+      L = win.L;
+      let map = win.map;
+      const latlng = L.latLng(coords.lat, coords.lng);
+
+      map.flyTo(latlng, 14);
+      hoverOverTheMapCenter('.leaflet-interactive')
+          .then(() => {
+              cy.get('.leaflet-interactive').click();
+          })
+  });
 }
 
 export function extractRequestedIndicatorData(url, indicatorData) {

--- a/src/js/map/maps.js
+++ b/src/js/map/maps.js
@@ -7,7 +7,6 @@ import {createRoot} from "react-dom/client";
 import Watermark from "../ui_components/watermark";
 import React from "react";
 
-
 export class MapControl extends Component {
     constructor(parent, config, zoomToPosition = () => true) {
         super(parent);
@@ -94,6 +93,8 @@ export class MapControl extends Component {
 
         if (mapOptions.leafletOptions.preferCanvas)
             this.configureForwarder(map);
+
+        window.map = map;
 
         return map;
     };


### PR DESCRIPTION
## Description

A meaningful description of proposed change in your own words.

## Related Issue


## How is it tested automatically?

> Is the particular functionality/structure of the backend API this relies on tested?
> What unit, integration, GUI, end-to-end tests were added to test the functionality implemented/fixed in this PR?
> What other tests does it rely on so that the new tests are sufficient?

## How should a reviewer test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
