### PR TITLE
Fix bug in filtering indicator data

### DIFF
--- a/src/js/tabular_comparison/result.js
+++ b/src/js/tabular_comparison/result.js
@@ -137,7 +137,7 @@ const Result = (props) => {
         if (obj.filters.length > 0){
           obj.filters.map(
             filterObj => {
-              if (filterObj.group.length > 0 && filterObj.value.length > 0){
+              if (filterObj.group != null && filterObj.value != null){
                 indicatorData = indicatorData.filter(
                   f => f[filterObj.group] === filterObj.value
                 )


### PR DESCRIPTION
## Description
Fixed bug in tabular comparison filters.
We were checking length for value and here value was int type hence check was failing.

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-842


## How is it tested automatically?


## How should a reviewer test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
