### PR TITLE
Fixed issue in rendering chart when drilldown is active and dropdown selection for int values

### DIFF
--- a/src/js/elements/subindicator_filter/filter_controller.js
+++ b/src/js/elements/subindicator_filter/filter_controller.js
@@ -364,7 +364,6 @@ export class FilterController extends Component {
             .filter(x => x.model.currentSubindicatorValue === "All values" && !x.model.isUnavailable)[0];
 
         const isNullOrHidden = rowToUpdate == null || $(rowToUpdate.container).css('display') === '' || $(rowToUpdate.container).hasClass('hidden');
-        
         if (this.model.dataFilterModel.availableFilters.length > 0 && isNullOrHidden) {
             this.addFilterButton.enable();
         } else {

--- a/src/js/profile/chart.js
+++ b/src/js/profile/chart.js
@@ -140,7 +140,7 @@ export class Chart extends Component {
     }
 
     get isDrilldownSelected() {
-        return this.hasGroupedBarChart && Object.keys(this.selectedFilter).indexOf(this.data.chartConfiguration?.drilldown) >= 0;
+        return this.hasGroupedBarChart && this.selectedFilter !== null && Object.keys(this.selectedFilter).indexOf(this.data.chartConfiguration?.drilldown) >= 0;
     }
 
     updateConfig(chartColorRange) {

--- a/src/js/ui_components/filter_dropdown/dropdown.js
+++ b/src/js/ui_components/filter_dropdown/dropdown.js
@@ -11,7 +11,7 @@ import {
 } from './styledElements';
 import Tooltip from '@mui/material/Tooltip';
 
-import {isArray, isEqual} from "lodash";
+import {isArray, isEqual, isInteger} from "lodash";
 
 
 const DrillDownSvg = () => (
@@ -56,12 +56,13 @@ export const FilterDropdown = ({
   const handleSelectChange = (event) => {
     dropdownElement.model.manualTrigger = true;
     dropdownElement.model.currentValue = isMultiselect ? event.target.value : [event.target.value];
-
   };
 
   const getCurrentlySelectedValue = useCallback(
     (selected) => {
-      if (selected === '' || selected?.[0] === undefined) {
+      const isInvalidValue = isInteger(selected) ? selected.toString()?.[0] === undefined : selected?.[0] === undefined;
+
+      if (selected === undefined || isInvalidValue) {
         return <em>{label}</em>;
       }
 

--- a/src/js/ui_components/filter_row.js
+++ b/src/js/ui_components/filter_row.js
@@ -2,7 +2,7 @@ import {Dropdown, DropdownModel} from "./dropdown";
 import {Component, Observable} from "../utils";
 import {SidePanels} from "../elements/side_panels";
 import {LockFilterButtonWrapper} from "./lock_filter_button/lock_filter_button_wrapper";
-import {isArray, isEqual} from "lodash";
+import {isArray, isEqual, isString} from "lodash";
 
 /**
  *
@@ -222,22 +222,30 @@ export class FilterRow extends Component {
         return this._lockFilterButton;
     }
 
+    formatValue(value) {
+      if (isArray(value)){
+        return value;
+      }
+      return isString(value) ? value.split(",") : [value];
+    }
+
+
     setPrimaryIndexUsingValue(value) {
-        this.indicatorDropdown.model.currentItem = isArray(value) ? value : value.split(",");
+        this.indicatorDropdown.model.currentItem = this.formatValue(value);
     }
 
     setSecondaryIndexUsingValue(value) {
-        this.subIndicatorDropdown.model.currentItem = isArray(value) ? value : value.split(",");
+        this.subIndicatorDropdown.model.currentItem = this.formatValue(value);
     }
 
     setPrimaryIndex(index) {
         let value = this.model.indicatorValues[index];
-        this.indicatorDropdown.model.currentValue = isArray(value) ? value : value.split(",");
+        this.indicatorDropdown.model.currentValue = this.formatValue(value);
     }
 
     setSecondaryIndex(index) {
         let value = [this.model.subindicatorValues[index]];
-        this.subIndicatorDropdown.model.currentValue = isArray(value) ? value : value.split(",");
+        this.subIndicatorDropdown.model.currentValue = this.formatValue(value);
     }
 
     setPrimaryValueUnavailable(value) {


### PR DESCRIPTION
## Description

Fixed 3 issues:
* Chart threw error when selected filters coming as null
* Non agg / default initial value dropdown breaks when values are int
* showing label breaks because value are int.

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-848

## How is it tested automatically?

## How should a reviewer test it locally
* Enable drilldown for year  for 
     * https://production.wazimap-ng.openup.org.za/admin/profile/profileindicator/2646/change/?_changelist_filters=profile__name%3DCommunity%2BExplorer%2BSandbox%26q%3Dfte
     * https://production.wazimap-ng.openup.org.za/admin/profile/profileindicator/2647/change/?_changelist_filters=profile__name%3DCommunity%2BExplorer%2BSandbox%26q%3Dfte

* Go to western cape > capetown for prod community explorer
* Go to Right Data view
* Go to Labour Marketrs category
* Go to FTE emplyees by industry and check if grouped bar chart is enabled

## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
