### PR TITLE
Do not disable already selected indicator categories

### DIFF
--- a/src/js/tabular_comparison/category-auto-complete.js
+++ b/src/js/tabular_comparison/category-auto-complete.js
@@ -12,11 +12,6 @@ const CategoryAutoComplete = (props) => {
                         .filter((x) => x.name === props.selectedIndicator.indicatorDetail.metadata.primary_group)[0].subindicators
             }
             getOptionLabel={(option) => option}
-            getOptionDisabled={(option) => {
-                let alreadySelected = props.indicatorObjs.filter(x => x.indicator === props.selectedIndicator.indicator && x.category === option)[0];
-
-                return alreadySelected != null && alreadySelected.category !== props.categoryValue;
-            }}
             size={'small'}
             value={props.categoryValue}
             onChange={(event, selectedValue) => props.handleCategorySelection(event, selectedValue)}


### PR DESCRIPTION
## Description
Do not disable category options if already selected for same indicator in tabular comparison

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-868

## How is it tested automatically?


## How should a reviewer test it locally


## Screenshots


## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally
- [x] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out
- [x] commit messages are meaningful

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
