### PR TITLE
added cc license text

### DIFF
--- a/src/custom-css/general.scss
+++ b/src/custom-css/general.scss
@@ -17,6 +17,13 @@
   bottom: 10px;
 }
 
+.cc-license-wrapper {
+  position: absolute;
+  left: 10px;
+  bottom: -5px;
+  font-size: 10px;
+}
+
 .right-panel-toggles {
   position: fixed;
   right: 0;

--- a/src/js/configurations/geography_sa.js
+++ b/src/js/configurations/geography_sa.js
@@ -61,6 +61,12 @@ export class Config {
         return true;
     }
 
+    get ccLicenseEnabled() {
+        if (this.config["cc_license_enabled"] != undefined)
+            return this.config["cc_license_enabled"];
+        return false;
+    }
+
     get siteWideFiltersEnabled() {
         if (this.config["site_wide_filters_enabled"] != undefined)
             return this.config["site_wide_filters_enabled"];

--- a/src/js/elements/data_mapper/menu.js
+++ b/src/js/elements/data_mapper/menu.js
@@ -15,6 +15,7 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ChevronRightIcon from '@mui/icons-material/ChevronRight';
 import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
+import CcLicense from "../../ui_components/cc_license";
 
 
 let parentContainer = null;
@@ -95,7 +96,7 @@ export function loadMenu(dataMapperMenu, data) {
  * This class is a stub for a menu component
  */
 export class DataMapperMenu extends Component {
-    constructor(parent, api, watermarkEnabled, controller) {
+    constructor(parent, api, watermarkEnabled, ccLicenseEnabled, controller) {
         super(parent);
 
         this._isLoading = false;
@@ -106,6 +107,9 @@ export class DataMapperMenu extends Component {
 
         if (watermarkEnabled) {
             this.addWatermark();
+        }
+        if (ccLicenseEnabled) {
+            this.addCcLicense();
         }
         this.addDataMapperMenuRoot();
     }
@@ -157,6 +161,21 @@ export class DataMapperMenu extends Component {
 
         let watermarkRoot = createRoot(watermarkWrapper);
         watermarkRoot.render(<Watermark/>);
+    }
+
+    addCcLicense() {
+        if ($('.data-mapper .cc-license-wrapper').length > 0) {
+            return;
+        }
+
+        let licenseWrapper = document.createElement('div');
+        $(licenseWrapper)
+            .addClass('cc-license-wrapper');
+        $('.data-mapper-content')
+            .append(licenseWrapper);
+
+        let licenseRoot = createRoot(licenseWrapper);
+        licenseRoot.render(<CcLicense/>);
     }
 
     addDataMapperMenuRoot() {

--- a/src/js/elements/point_tray/tray.js
+++ b/src/js/elements/point_tray/tray.js
@@ -3,6 +3,7 @@ import {createRoot} from "react-dom/client";
 import Watermark from "../../ui_components/watermark";
 import React from "react";
 import PointMapperTreeview from "./point_mapper_treeview";
+import CcLicense from "../../ui_components/cc_license";
 
 const categoryWrapperClsName = '.point-mapper__h1_content';
 const treeLineClsName = '.point-data__h2_line-v';
@@ -13,7 +14,7 @@ const stylesClsName = '.styles';
 const loadingClsName = '.point-mapper-content__loading';
 
 export class PointDataTray extends Component {
-    constructor(parent, api, profileId, watermarkEnabled) {
+    constructor(parent, api, profileId, watermarkEnabled, ccLicenseEnabled) {
         super(parent);
         this.api = api;
         this.profileId = profileId;
@@ -23,6 +24,9 @@ export class PointDataTray extends Component {
 
         if (watermarkEnabled) {
             this.addWatermark();
+        }
+        if (ccLicenseEnabled) {
+            this.addCcLicense();
         }
         this.addTreeviewRoot();
     }
@@ -67,7 +71,7 @@ export class PointDataTray extends Component {
     }
 
     categoryToggled(category) {
-        if (category.isLoading){
+        if (category.isLoading) {
             return;
         }
 
@@ -130,6 +134,21 @@ export class PointDataTray extends Component {
 
         let watermarkRoot = createRoot(watermarkWrapper);
         watermarkRoot.render(<Watermark/>);
+    }
+
+    addCcLicense() {
+        if ($('.point-mapper .cc-license-wrapper').length > 0) {
+            return;
+        }
+
+        let licenseWrapper = document.createElement('div');
+        $(licenseWrapper)
+            .addClass('cc-license-wrapper');
+        $('.point-mapper-content')
+            .append(licenseWrapper);
+
+        let licenseRoot = createRoot(licenseWrapper);
+        licenseRoot.render(<CcLicense/>);
     }
 
     unSelectAll() {

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -75,7 +75,7 @@ class Application extends Component {
         const mapcontrol = new MapControl(this, config, () => controller.shouldMapZoom);
         mapcontrol.popup = new Popup(this, formattingConfig, mapcontrol.map);
         const pointData = new PointData(this, api, mapcontrol.map, profileId, config);
-        const pointDataTray = new PointDataTray(this, api, profileId, config.watermarkEnabled);
+        const pointDataTray = new PointDataTray(this, api, profileId, config.watermarkEnabled, config.ccLicenseEnabled);
         const mapchip = new MapChip(this, config.choropleth, config.siteWideFiltersEnabled, config.restrictValues, config.defaultFilters);
         const search = new Search(this, api, profileId, 2);
         const profileLoader = new ProfileLoader(this, formattingConfig, api, profileId, config.config, config.watermarkEnabled, config.siteWideFiltersEnabled, config.restrictValues, config.defaultFilters, config.chartColorRange);
@@ -88,7 +88,7 @@ class Application extends Component {
         const styleConfig = new StyleConfig(config.style);
         const tabNotice = new TabNotice(this, config.config.feedback);
         const translations = new Translations(this, config.config.translations);
-        const dataMapperMenu = new DataMapperMenu(this, api, config.watermarkEnabled, controller);
+        const dataMapperMenu = new DataMapperMenu(this, api, config.watermarkEnabled, config.ccLicenseEnabled, controller);
         const richDataLinkRendrer = new RichDataLinkRendrer(this);
         const myView = new MyView(this, controller, config.siteWideFiltersEnabled, api, profileId);
         const currentView = new CurrentView(this);

--- a/src/js/map/maps.js
+++ b/src/js/map/maps.js
@@ -6,6 +6,7 @@ import {MapLocker} from './maplocker';
 import {createRoot} from "react-dom/client";
 import Watermark from "../ui_components/watermark";
 import React from "react";
+import CcLicense from "../ui_components/cc_license";
 
 export class MapControl extends Component {
     constructor(parent, config, zoomToPosition = () => true) {
@@ -43,6 +44,9 @@ export class MapControl extends Component {
         if (config.watermarkEnabled) {
             this.addWatermark();
         }
+        if (config.ccLicenseEnabled) {
+            this.addCcLicense();
+        }
 
         this.choropleth = new Choropleth(this, this.layerCache, this.layerStyler, config.map.choropleth);
     };
@@ -55,6 +59,25 @@ export class MapControl extends Component {
 
         let watermarkRoot = createRoot(watermarkWrapper);
         watermarkRoot.render(<Watermark/>);
+    }
+
+    addCcLicense(){
+        if ($('.main .map-cc-license-wrapper').length > 0) {
+            return;
+        }
+        let mapWrapper = document.createElement('div');
+        $(mapWrapper).addClass('map-cc-license-wrapper');
+
+        let licenseWrapper = document.createElement('div');
+        $(licenseWrapper).addClass('cc-license-wrapper');
+
+        $(mapWrapper).append(licenseWrapper);
+
+        $('.main')
+            .append(mapWrapper);
+
+        let licenseRoot = createRoot(licenseWrapper);
+        licenseRoot.render(<CcLicense/>);
     }
 
     registerEvents() {

--- a/src/js/profile/profile_loader.js
+++ b/src/js/profile/profile_loader.js
@@ -65,7 +65,7 @@ export default class ProfileLoader extends Component {
     }
 
     set hiddenIndicators(value) {
-      this._hiddenIndicators = value;
+        this._hiddenIndicators = value;
     }
 
     loadProfile = (dataBundle, activeVersion) => {
@@ -139,7 +139,7 @@ export default class ProfileLoader extends Component {
                 isFirst = false;    //set to false only when there is a visible item
             }
             c.isVisible = c.subCategories.filter(
-              subcategory => subcategory.isVisible
+                subcategory => subcategory.isVisible
             ).length > 0;
 
             this.bubbleEvents(c, [

--- a/src/js/ui_components/cc_license.js
+++ b/src/js/ui_components/cc_license.js
@@ -1,0 +1,21 @@
+import React from "react";
+import {styled} from "@mui/system";
+import Box from "@mui/material/Box";
+
+const CcLicense = (props) => {
+    const LicenseContainer = styled(Box)(({theme}) => ({
+        width: 'auto',
+        padding: '10px',
+        display: 'flex',
+        paddingLeft: 0
+    }));
+
+    return (
+        <LicenseContainer>
+            @ 2023. This work is openly licensed via <a href={'https://creativecommons.org/licenses/by-nc-nd/4.0'}
+                                                        target={'_blank'}>CC BY-NC-ND 4.0</a>
+        </LicenseContainer>
+    );
+}
+
+export default CcLicense;

--- a/src/js/ui_components/cc_license.js
+++ b/src/js/ui_components/cc_license.js
@@ -12,8 +12,8 @@ const CcLicense = (props) => {
 
     return (
         <LicenseContainer>
-            @ 2023. This work is openly licensed via <a href={'https://creativecommons.org/licenses/by-nc-nd/4.0'}
-                                                        target={'_blank'}>CC BY-NC-ND 4.0</a>
+            <span>@ 2023. This work is openly licensed via <a href={'https://creativecommons.org/licenses/by-nc-nd/4.0'}
+                                                        target={'_blank'}>CC BY-NC-ND 4.0</a></span>
         </LicenseContainer>
     );
 }


### PR DESCRIPTION
## Description
displaying cc license text in data mapper, point mapper, on map. we will not display it in rich data for now since the text overflows.

to display cc license, this line needs to be added to the profile configuration : 
`"cc_license_enabled": true`

documentation : https://openup.gitbook.io/wazi-ng-technical/profile-configuation#adding-cc-license

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-883

## How is it tested automatically?


## How should a reviewer test it locally


## Screenshots
* displaying on map
<img width="830" alt="Screenshot 2023-11-02 at 11 38 13" src="https://github.com/OpenUpSA/wazimap-ng-ui/assets/53019884/21dbc0fe-ec14-48ef-ac6b-346b0e95a175">

* displaying in point mapper
<img width="622" alt="Screenshot 2023-11-02 at 11 38 22" src="https://github.com/OpenUpSA/wazimap-ng-ui/assets/53019884/58bc797c-720b-4d32-aa81-f6ef4d03fc7b">

* displaying in data mapper
<img width="568" alt="Screenshot 2023-11-02 at 11 38 29" src="https://github.com/OpenUpSA/wazimap-ng-ui/assets/53019884/2dbeb6e2-1cba-4205-9a70-168cb2ef2c4f">

* not displaying in rich data panel
<img width="675" alt="Screenshot 2023-11-02 at 11 38 36" src="https://github.com/OpenUpSA/wazimap-ng-ui/assets/53019884/24f32ef4-f997-4fbb-8707-2d623f46f521">



## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally
- [ ] 👩‍🎨 does the design match the [Demo](https://wazimap-ng-v1.webflow.io/demo)

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out
- [ ] commit messages are meaningful

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
