### PR TITLE
Visibly disable download all button while download in progress

### DIFF
--- a/src/custom-css/general.scss
+++ b/src/custom-css/general.scss
@@ -97,7 +97,7 @@
   margin-bottom: 10px;
 }
 
-.mapping-options__add-filter.disabled, .profile-indicator__new-filter.disabled {
+.mapping-options__add-filter.disabled, .profile-indicator__new-filter.disabled, .location__facilities_download-all.disabled {
   opacity: 0.4;
 }
 

--- a/src/js/profile/facilities/facility_controller.js
+++ b/src/js/profile/facilities/facility_controller.js
@@ -1,266 +1,317 @@
-import {Facility} from "./facility";
+import { Facility } from "./facility";
 import XLSX from "xlsx";
-import {Component, extractSheetsData} from "../../utils";
+import { Component, extractSheetsData } from "../../utils";
 import * as Sentry from "@sentry/browser";
 
 export class FacilityControllerModel extends Component {
-    static EVENTS = {
-        facilitiesCreated: 'FacilityControllerModel.facilitiesCreated'
-    }
+  static EVENTS = {
+    facilitiesCreated: "FacilityControllerModel.facilitiesCreated",
+  };
 
-    constructor(parent, controllerParent) {
-        super(parent);
+  constructor(parent, controllerParent) {
+    super(parent);
 
-        this._controllerParent = controllerParent;
-        this._themes = null;
-    }
+    this._controllerParent = controllerParent;
+    this._themes = null;
+  }
 
-    get profileId() {
-        return this._controllerParent.profileId;
-    }
+  get profileId() {
+    return this._controllerParent.profileId;
+  }
 
-    get geography() {
-        return this._controllerParent.geography;
-    }
+  get geography() {
+    return this._controllerParent.geography;
+  }
 
-    get geometries() {
-        return this._controllerParent.geometries;
-    }
+  get geometries() {
+    return this._controllerParent.geometries;
+  }
 
-    get api() {
-        return this._controllerParent.api;
-    }
+  get api() {
+    return this._controllerParent.api;
+  }
 
-    get isDownloadsDisabled() {
-        return this._controllerParent.isDownloadsDisabled;
-    }
+  get isDownloadsDisabled() {
+    return this._controllerParent.isDownloadsDisabled;
+  }
 
-    get themes() {
-        return this._themes;
-    }
+  get themes() {
+    return this._themes;
+  }
 
-    set themes(value) {
-        this._themes = value;
-    }
+  set themes(value) {
+    this._themes = value;
+  }
 }
 
 export class FacilityController extends Component {
-    constructor(parent) {
-        super(parent);
+  constructor(parent) {
+    super(parent);
 
-        this._model = new FacilityControllerModel(this, parent);
-        this._isLoading = false;
-        this._isFailed = false;
-        this._isExpanded = false;
-        this.facilityItems = [];
-        this.prepareDomElements();
-        this.prepareEvents();
+    this._model = new FacilityControllerModel(this, parent);
+    this._isLoading = false;
+    this._isFailed = false;
+    this._isExpanded = false;
+    this.facilityItems = [];
+    this.prepareDomElements();
+    this.prepareEvents();
+  }
+
+  get model() {
+    return this._model;
+  }
+
+  get isLoading() {
+    return this._isLoading;
+  }
+
+  set isLoading(value) {
+    if (value) {
+      this.showLoadingState();
+    } else {
+      this.hideLoadingState();
     }
 
-    get model() {
-        return this._model;
+    this._isLoading = value;
+  }
+
+  get isFailed() {
+    return this._isFailed;
+  }
+
+  set isFailed(value) {
+    if (value) {
+      $(
+        ".rich-data-content .location__facilities .location__facilities_header"
+      ).addClass("hidden");
+      $(
+        ".rich-data-content .location__facilities .location__facilities_trigger"
+      ).addClass("hidden");
+      $(
+        ".rich-data-content .location__facilities .location__facilities_error"
+      ).removeClass("hidden");
+    } else {
+      $(
+        ".rich-data-content .location__facilities .location__facilities_error"
+      ).addClass("hidden");
     }
 
-    get isLoading() {
-        return this._isLoading;
+    this._isFailed = value;
+  }
+
+  get isExpanded() {
+    return this._isExpanded;
+  }
+
+  set isExpanded(value) {
+    if (value) {
+      this.expandButton.addClass("hidden");
+      this.collapseButton.removeClass("hidden");
+      this.facilityContent.removeClass("is--hidden").addClass("is--shown");
+    } else {
+      this.expandButton.removeClass("hidden");
+      this.collapseButton.addClass("hidden");
+      this.facilityContent.addClass("is--hidden").removeClass("is--shown");
     }
 
-    set isLoading(value) {
-        if (value) {
-            this.showLoadingState();
-        } else {
-            this.hideLoadingState();
-        }
+    this._isExpanded = value;
+  }
 
-        this._isLoading = value;
+  prepareDomElements() {
+    this.facilityContent = $(
+      ".rich-data-content .location__facilities .location__facilities_content"
+    );
+    this.facilityWrapper = $(
+      ".rich-data-content .location__facilities .location__facilities_content-wrapper"
+    );
+    this.facilityTemplate =
+      typeof $(".location-facility")[0] === "undefined"
+        ? null
+        : $(".location-facility")[0].cloneNode(true);
+    this.facilityRowClone =
+      this.facilityTemplate === null
+        ? null
+        : $(this.facilityTemplate)
+            .find(".location-facility__list_item")[0]
+            .cloneNode(true);
+
+    this.expandButton = $(".location__facilities_expand");
+    this.collapseButton = $(".location__facilities_contract");
+
+    this.prepareFailMessage();
+
+    this.isExpanded = false;
+  }
+
+  prepareEvents() {
+    this.expandButton.on("click", () => {
+      this.isExpanded = true;
+    });
+    this.collapseButton.on("click", () => {
+      this.isExpanded = false;
+    });
+  }
+
+  prepareFailMessage() {
+    if (
+      $(".rich-data-content .location__facilities .location__facilities_error")
+        .length > 0
+    ) {
+      return;
     }
 
-    get isFailed() {
-        return this._isFailed;
-    }
+    let failMsg = document.createElement("div");
+    $(failMsg).addClass("location__facilities_error").addClass("hidden");
+    $(failMsg).html(
+      "Failed to load summary of available point data. Please reload or try again later."
+    );
 
-    set isFailed(value) {
-        if (value) {
-            $('.rich-data-content .location__facilities .location__facilities_header').addClass('hidden');
-            $('.rich-data-content .location__facilities .location__facilities_trigger').addClass('hidden');
-            $('.rich-data-content .location__facilities .location__facilities_error').removeClass('hidden');
-        } else {
-            $('.rich-data-content .location__facilities .location__facilities_error').addClass('hidden');
-        }
+    $(failMsg).css("display", "block");
+    $(failMsg).css("color", "#666");
+    $(failMsg).css("width", "100%");
+    $(failMsg).css("background-color", "#f0f0f0");
+    $(failMsg).css("padding", "4px 6px");
+    $(failMsg).css("font-size", "0.9em");
+    $(failMsg).css("border-radius", "2px");
+    $(failMsg).css("margin-right", "6px");
+    $(failMsg).css("margin-left", "6px");
 
-        this._isFailed = value;
-    }
+    $(".rich-data-content .location__facilities").append(failMsg);
+  }
 
-    get isExpanded() {
-        return this._isExpanded;
-    }
-
-    set isExpanded(value) {
-        if (value) {
-            this.expandButton.addClass('hidden');
-            this.collapseButton.removeClass('hidden');
-            this.facilityContent.removeClass('is--hidden').addClass('is--shown');
-        } else {
-            this.expandButton.removeClass('hidden');
-            this.collapseButton.addClass('hidden');
-            this.facilityContent.addClass('is--hidden').removeClass('is--shown');
-        }
-
-        this._isExpanded = value;
-    }
-
-    prepareDomElements() {
-        this.facilityContent = $('.rich-data-content .location__facilities .location__facilities_content');
-        this.facilityWrapper = $('.rich-data-content .location__facilities .location__facilities_content-wrapper');
-        this.facilityTemplate = typeof $('.location-facility')[0] === 'undefined' ? null : $('.location-facility')[0].cloneNode(true);
-        this.facilityRowClone = this.facilityTemplate === null ? null : $(this.facilityTemplate).find('.location-facility__list_item')[0].cloneNode(true);
-
-        this.expandButton = $('.location__facilities_expand');
-        this.collapseButton = $('.location__facilities_contract');
-
-        this.prepareFailMessage();
-
-        this.isExpanded = false;
-    }
-
-    prepareEvents() {
-        this.expandButton.on('click', () => {
-            this.isExpanded = true;
+  getAndAddFacilities(activeVersion) {
+    if (this.model.api !== null) {
+      this.model.api
+        .getThemesCount(
+          this.model.profileId,
+          this.model.geography.code,
+          activeVersion.model.name
+        )
+        .then((data) => {
+          this.model.themes = data;
+          this.triggerEvent("profile.facilities.loaded", {
+            parent: this.parent.parent,
+            data: data,
+          });
+          this.addFacilities();
         })
-        this.collapseButton.on('click', () => {
-            this.isExpanded = false;
-        })
+        .catch((err) => {
+          console.error({ err });
+          this.isLoading = false;
+          this.isFailed = true;
+          Sentry.captureException(err);
+        });
+    }
+  }
+
+  addFacilities() {
+    $(".location-facility", this.facilityWrapper).remove();
+    let self = this;
+
+    let categoryArr = [];
+    let themes = [];
+    let totalCount = 0;
+
+    this.model.themes.forEach((theme) => {
+      let themeCount = 0;
+      theme.subthemes.forEach((st) => {
+        totalCount += st.count;
+        themeCount += st.count;
+
+        categoryArr.push({
+          theme_id: theme.id,
+          count: st.count,
+          label: st.label,
+          category_id: st.id,
+        });
+      });
+
+      themes.push({
+        theme_id: theme.id,
+        name: theme.name,
+        icon: theme.icon,
+        count: themeCount,
+      });
+    });
+
+    if (themes.length > 0) {
+      themes.forEach((theme) => {
+        const f = new Facility(
+          this,
+          this.facilityTemplate,
+          this.facilityRowClone,
+          theme,
+          categoryArr
+        );
+        $(".location-facility__description", f.facility).addClass("hidden");
+
+        this.facilityWrapper.prepend(f.facility);
+      });
+
+      $(".location__facilities_header").removeClass("hidden");
+      $(".location__facilities_trigger").removeClass("hidden");
+      $(".location__facilities_categories-value strong").text(
+        categoryArr.length
+      );
+      $(".location__facilities_facilities-value strong").text(totalCount + " ");
+
+      self.model.triggerEvent(FacilityControllerModel.EVENTS.facilitiesCreated);
+      self.isLoading = false;
+      self.isFailed = false;
+      $(".location__facilities").removeClass("hidden");
+    } else {
+      $(".location__facilities").addClass("hidden");
     }
 
-    prepareFailMessage() {
-        if ($('.rich-data-content .location__facilities .location__facilities_error').length > 0) {
-            return;
-        }
+    $(".location__facilities_loading").addClass("hidden");
+  }
 
-        let failMsg = document.createElement('div');
-        $(failMsg).addClass('location__facilities_error').addClass('hidden');
-        $(failMsg).html('Failed to load summary of available point data. Please reload or try again later.');
+  downloadAllFacilities(e) {
+    const downloadAllFacilitiesButton = $(e.currentTarget);
+    const buttonLabel = downloadAllFacilitiesButton.children().first();
+    const originalButtonLabelHtml = buttonLabel.html();
+    downloadAllFacilitiesButton.toggleClass('disabled');
+    buttonLabel.html("Download started...");
+    this.model.api
+      .loadAllPoints(this.model.profileId, this.model.geography.code)
+      .then((data) => {
+        const wb = XLSX.utils.book_new();
+        const fileName = "Facilities-" + this.model.geography.code + ".xlsx";
+        let sheets = extractSheetsData(data);
+        sheets.forEach((s) => {
+          const sheetData = XLSX.utils.json_to_sheet(s.sheetData);
+          const sheetName = s.sheetName;
 
-        $(failMsg).css('display', 'block');
-        $(failMsg).css('color', '#666');
-        $(failMsg).css('width', '100%');
-        $(failMsg).css('background-color', '#f0f0f0');
-        $(failMsg).css('padding', '4px 6px');
-        $(failMsg).css('font-size', '0.9em');
-        $(failMsg).css('border-radius', '2px');
-        $(failMsg).css('margin-right', '6px');
-        $(failMsg).css('margin-left', '6px');
-
-        $('.rich-data-content .location__facilities').append(failMsg);
-    }
-
-    getAndAddFacilities(activeVersion) {
-        if (this.model.api !== null) {
-            this.model.api.getThemesCount(this.model.profileId, this.model.geography.code, activeVersion.model.name)
-                .then((data) => {
-                    this.model.themes = data;
-                    this.triggerEvent('profile.facilities.loaded', {parent: this.parent.parent, data: data});
-                    this.addFacilities();
-                })
-                .catch((err) => {
-                    console.error({err})
-                    this.isLoading = false;
-                    this.isFailed = true;
-                    Sentry.captureException(err);
-                })
-        }
-    }
-
-    addFacilities() {
-        $('.location-facility', this.facilityWrapper).remove();
-        let self = this;
-
-        let categoryArr = [];
-        let themes = [];
-        let totalCount = 0;
-
-        this.model.themes.forEach((theme) => {
-            let themeCount = 0;
-            theme.subthemes.forEach((st) => {
-                totalCount += st.count;
-                themeCount += st.count;
-
-                categoryArr.push({
-                    theme_id: theme.id,
-                    count: st.count,
-                    label: st.label,
-                    category_id: st.id
-                });
-            });
-
-            themes.push({
-                theme_id: theme.id,
-                name: theme.name,
-                icon: theme.icon,
-                count: themeCount
-            });
+          XLSX.utils.book_append_sheet(wb, sheetData, sheetName);
         });
 
-        if (themes.length > 0) {
-            themes.forEach((theme) => {
-                const f = new Facility(this, this.facilityTemplate, this.facilityRowClone, theme, categoryArr);
-                $('.location-facility__description', f.facility).addClass('hidden')
+        XLSX.writeFile(wb, fileName);
+      })
+      .finally(() => {
+        buttonLabel.html(originalButtonLabelHtml);
+        downloadAllFacilitiesButton.toggleClass('disabled');
+      });
+  }
 
-                this.facilityWrapper.prepend(f.facility);
-            })
+  hideLoadingState() {
+    $(".location__facilities_loading").addClass("hidden");
+    $(".location__facilities_title--loading").addClass("hidden");
+    $(".location__facilities_title").removeClass("hidden");
 
-            $('.location__facilities_header').removeClass('hidden');
-            $('.location__facilities_trigger').removeClass('hidden');
-            $('.location__facilities_categories-value strong').text(categoryArr.length);
-            $('.location__facilities_facilities-value strong').text(totalCount + ' ');
+    $(".location-facilities__trigger--loading").addClass("hidden");
+    this.expandButton.removeClass("hidden");
 
-            self.model.triggerEvent(FacilityControllerModel.EVENTS.facilitiesCreated);
-            self.isLoading = false;
-            self.isFailed = false;
-            $('.location__facilities').removeClass('hidden');
-        } else {
-            $('.location__facilities').addClass('hidden');
-        }
+    $(".location__facilities_download-all").removeClass("disabled");
+  }
 
-        $('.location__facilities_loading').addClass('hidden');
-    }
+  showLoadingState() {
+    $(".location__facilities_title--loading").removeClass("hidden");
+    $(".location__facilities_title").addClass("hidden");
 
-    downloadAllFacilities() {
-        this.model.api.loadAllPoints(this.model.profileId, this.model.geography.code)
-            .then((data) => {
-                const wb = XLSX.utils.book_new();
-                const fileName = 'Facilities-' + this.model.geography.code + '.xlsx';
-                let sheets = extractSheetsData(data);
-                sheets.forEach((s) => {
-                    const sheetData = XLSX.utils.json_to_sheet(s.sheetData);
-                    const sheetName = s.sheetName;
+    $(".location-facilities__trigger--loading").removeClass("hidden");
+    this.isExpanded = false;
+    this.expandButton.addClass("hidden");
 
-                    XLSX.utils.book_append_sheet(wb, sheetData, sheetName);
-                })
-
-                XLSX.writeFile(wb, fileName);
-            });
-    }
-
-    hideLoadingState() {
-        $('.location__facilities_loading').addClass('hidden');
-        $('.location__facilities_title--loading').addClass('hidden');
-        $('.location__facilities_title').removeClass('hidden');
-
-        $('.location-facilities__trigger--loading').addClass('hidden');
-        this.expandButton.removeClass('hidden');
-
-        $('.location__facilities_download-all').removeClass('disabled');
-    }
-
-    showLoadingState() {
-        $('.location__facilities_title--loading').removeClass('hidden');
-        $('.location__facilities_title').addClass('hidden');
-
-        $('.location-facilities__trigger--loading').removeClass('hidden');
-        this.isExpanded = false;
-        this.expandButton.addClass('hidden');
-
-        $('.location__facilities_download-all').addClass('disabled');
-    }
+    $(".location__facilities_download-all").addClass("disabled");
+  }
 }

--- a/src/js/profile/profile_header.js
+++ b/src/js/profile/profile_header.js
@@ -1,94 +1,114 @@
-import {Component} from "../utils";
-import {FacilityController} from "./facilities/facility_controller";
+import { Component } from "../utils";
+import { FacilityController } from "./facilities/facility_controller";
 
 let breadcrumbsContainer = null;
 let breadcrumbTemplate = null;
 
 let parents = null;
 
-const FACILITY_DOWNLOADS = 'facility-downloads';
+const FACILITY_DOWNLOADS = "facility-downloads";
 
-const breadcrumbClass = '.breadcrumb';
-const locationDescriptionClass = '.location__description';
+const breadcrumbClass = ".breadcrumb";
+const locationDescriptionClass = ".location__description";
 
-const downloadAllFacilities = '.location__facilities_download-all';
+const downloadAllFacilities = ".location__facilities_download-all";
 
 export class Profile_header extends Component {
-    constructor(parent, _parents, geometries, _api, _profileId, _geography, _config, activeVersion) {
-        super(parent);
+  constructor(
+    parent,
+    _parents,
+    geometries,
+    _api,
+    _profileId,
+    _geography,
+    _config,
+    activeVersion
+  ) {
+    super(parent);
 
-        this.api = _api;
-        this.profileId = _profileId;
-        this.config = _config;
-        this.isDownloadsDisabled = false;
+    this.api = _api;
+    this.profileId = _profileId;
+    this.config = _config;
+    this.isDownloadsDisabled = false;
 
-        parents = _parents;
-        this._geometries = geometries
-        this.geography = _geography;
+    parents = _parents;
+    this._geometries = geometries;
+    this.geography = _geography;
 
-        breadcrumbsContainer = $('.location__breadcrumbs');
-        breadcrumbTemplate = $('.styles').find(breadcrumbClass)[0];
+    breadcrumbsContainer = $(".location__breadcrumbs");
+    breadcrumbTemplate = $(".styles").find(breadcrumbClass)[0];
 
-        $('.rich-data__print').off('click').on('click', () => {
-            window.print();
+    $(".rich-data__print")
+      .off("click")
+      .on("click", () => {
+        window.print();
+      });
+
+    this.checkIfDownloadsDisabled();
+    this.setPointSource();
+    this.addBreadCrumbs();
+    this.setLocationDescription();
+
+    this.facilityController = new FacilityController(this);
+    this.facilityController.on("profile.facilities.loaded", (payload) =>
+      payload.parent.triggerEvent("profile.facilities.loaded", payload.data)
+    );
+    this.facilityController.getAndAddFacilities(activeVersion);
+    $(downloadAllFacilities)
+      .off("click")
+      .on("click", (e) => this.facilityController.downloadAllFacilities(e));
+  }
+
+  get geometries() {
+    return this._geometries;
+  }
+
+  checkIfDownloadsDisabled = () => {
+    if ("richdata" in this.config && "hide" in this.config["richdata"]) {
+      this.isDownloadsDisabled =
+        this.config["richdata"]["hide"].includes(FACILITY_DOWNLOADS);
+    }
+  };
+
+  addBreadCrumbs = () => {
+    let self = this;
+    $(breadcrumbClass, breadcrumbsContainer).remove();
+
+    if (parents !== null && parents.length > 0) {
+      parents.forEach((parent) => {
+        let breadcrumb = breadcrumbTemplate.cloneNode(true);
+        $(".truncate", breadcrumb).text(parent.name);
+        $(breadcrumb).on("click", () => {
+          self.triggerEvent("profile.breadcrumbs.selected", parent);
+          $(breadcrumb).off("click");
         });
 
-        this.checkIfDownloadsDisabled();
-        this.setPointSource();
-        this.addBreadCrumbs();
-        this.setLocationDescription();
-
-        this.facilityController = new FacilityController(this);
-        this.facilityController.on('profile.facilities.loaded', payload => payload.parent.triggerEvent('profile.facilities.loaded', payload.data));
-        this.facilityController.getAndAddFacilities(activeVersion);
-        $(downloadAllFacilities).off('click').on('click', () => this.facilityController.downloadAllFacilities());
+        breadcrumbsContainer.append(breadcrumb);
+      });
+      $(breadcrumbsContainer).removeClass("hidden");
+    } else {
+      $(breadcrumbsContainer).addClass("hidden");
     }
+  };
 
-    get geometries() {
-        return this._geometries;
+  setPointSource = () => {
+    //todo:change this when the API is ready
+    $(".location__sources_loading").addClass("hidden");
+    $(".location__sources").addClass("hidden");
+    $(".location__sources_no-data").removeClass("hidden");
+  };
+
+  setLocationDescription = () => {
+    if (parents !== null && parents.length > 0) {
+      $(locationDescriptionClass)
+        .find(".location-type")
+        .text(this.geography.level);
+      $(locationDescriptionClass)
+        .find(".parent-geography")
+        .text(parents[parents.length - 1].name);
+      $(locationDescriptionClass).removeClass("hidden");
+    } else {
+      $(locationDescriptionClass).addClass("hidden");
     }
-
-    checkIfDownloadsDisabled = () => {
-        if ('richdata' in this.config && 'hide' in this.config['richdata']) {
-            this.isDownloadsDisabled = this.config['richdata']['hide'].includes(FACILITY_DOWNLOADS);
-        }
-    }
-
-    addBreadCrumbs = () => {
-        let self = this;
-        $(breadcrumbClass, breadcrumbsContainer).remove();
-
-        if (parents !== null && parents.length > 0) {
-            parents.forEach(parent => {
-                let breadcrumb = breadcrumbTemplate.cloneNode(true);
-                $(".truncate", breadcrumb).text(parent.name);
-                $(breadcrumb).on('click', () => {
-                    self.triggerEvent('profile.breadcrumbs.selected', parent);
-                    $(breadcrumb).off("click")
-                })
-
-                breadcrumbsContainer.append(breadcrumb);
-            })
-            $(breadcrumbsContainer).removeClass('hidden');
-        } else {
-            $(breadcrumbsContainer).addClass('hidden');
-        }
-    }
-
-    setPointSource = () => {
-        //todo:change this when the API is ready
-        $('.location__sources_loading').addClass('hidden');
-        $('.location__sources').addClass('hidden');
-        $('.location__sources_no-data').removeClass('hidden');
-    }
-
-    setLocationDescription = () => {
-        if (parents !== null && parents.length > 0) {
-            $(locationDescriptionClass).find('.location-type').text(this.geography.level);
-            $(locationDescriptionClass).find('.parent-geography').text(parents[parents.length - 1].name);
-            $(locationDescriptionClass).removeClass('hidden');
-        } else {
-            $(locationDescriptionClass).addClass('hidden');
-        }
-    }
+  };
 }


### PR DESCRIPTION
## Description

The "Download all" action can take some time to complete even with the proposed caching. At the moment the button does stop multiple clicks but there is no indication to the user that the download is in progress. So these changes change the button text to "Download started" and visibly show it as disabled. It then restores the HTML/Text and enables the button once the download has completed.

## How should a reviewer test it locally

Open the "Rich Data" tab and click the "Download all facilities" button.

## Screenshots

![image](https://github.com/OpenUpSA/wazimap-ng-ui/assets/4352/f64e79d2-f7b3-46c1-a801-74c2a1590d18)
![image](https://github.com/OpenUpSA/wazimap-ng-ui/assets/4352/2bf0d488-1c28-4433-961d-deedf20d8dde)
