### PR TITLE
Ensures filters are reset on indicator change

### DIFF
--- a/src/js/tabular_comparison/indicator.js
+++ b/src/js/tabular_comparison/indicator.js
@@ -83,9 +83,7 @@ const Indicator = (props) => {
     }, [selectedIndicator])
 
     useEffect(() => {
-      if (selectedFilters.length > 0){
-        props.handleFilterSelection(selectedFilters);
-      }
+      props.handleFilterSelection(selectedFilters);
     }, [
       selectedFilters
     ])


### PR DESCRIPTION
## Description

Changing indicators in tabular comparison did not properly reset filters. Therefore a previous default filter could be carried over to the new indicator. This made some indicators seem like they had 0% data but the user would not notice an irrelevant filter was being applied.